### PR TITLE
Added unary_union() function.

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -282,3 +282,7 @@ def prototype(lgeos, geosVersion):
             lgeos.GEOSInterpolateNormalized.argtypes = [ctypes.c_void_p, 
                                                         ctypes.c_double]
 
+    # TODO: Find out what version of geos_c came with geos 3.3.0
+    if geosVersion >= (1, 6, 3):
+        lgeos.GEOSUnaryUnion.restype = ctypes.c_void_p
+        lgeos.GEOSUnaryUnion.argtypes = [ctypes.c_void_p]

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -7,7 +7,8 @@ from shapely.geos import lgeos
 from shapely.geometry.base import geom_factory, BaseGeometry
 from shapely.geometry import asShape, asLineString, asMultiLineString
 
-__all__= ['operator', 'polygonize', 'linemerge', 'cascaded_union']
+__all__= ['operator', 'polygonize', 'linemerge', 'cascaded_union',
+          'unary_union']
 
 
 class CollectionOperator(object):
@@ -73,11 +74,25 @@ class CollectionOperator(object):
         collection = lgeos.GEOSGeom_createCollection(6, subs, L)
         return geom_factory(lgeos.GEOSUnionCascaded(collection))
 
+    def unary_union(self, geoms):
+        """Returns the union of a sequence of geometries
+
+        This method replaces :meth:`cascaded_union` as the
+        prefered method for dissolving many polygons.
+
+        """
+        L = len(geoms)
+        subs = (c_void_p * L)()
+        for i, g in enumerate(geoms):
+            subs[i] = g._geom
+        collection = lgeos.GEOSGeom_createCollection(6, subs, L)
+        return geom_factory(lgeos.GEOSUnaryUnion(collection))
 
 operator = CollectionOperator()
 polygonize = operator.polygonize
 linemerge = operator.linemerge
 cascaded_union = operator.cascaded_union
+unary_union = operator.unary_union
 
 class ValidateOp(object):
     def __call__(self, this):


### PR DESCRIPTION
This is the start of the branch that would bring unary_union to Shapely.  Some outstanding tasks:
- Determine the minimum version number for geos_c when GEOSUnaryUnion was introduced.  All I know is that it was introducted for GEOS 3.3.0, but I don't know the geos_c version number that corresponds to that release.
- Update docs and examples and tests
- Discuss deprecation policy for cascaded_union().  A decision here would guide some of the changes to the documentation.
