### PR TITLE
Fixed handling of geom._geom is None

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -16,6 +16,7 @@ Patches contributed by:
 * Jonathan Tartley
 * Kristian Thy
 * Mike Toews (https://github.com/mwtoews)
+* Phil Elson (https://github.com/pelson)
 
 Additional help from:
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -386,7 +386,7 @@ class BaseGeometry(object):
     @property
     def is_empty(self):
         """True if the set of points in this geometry is empty, else False"""
-        return bool(self.impl['is_empty'](self)) or (self._geom is None)
+        return (self._geom is None) or bool(self.impl['is_empty'](self))
 
     @property
     def is_ring(self):

--- a/shapely/tests/test_emptiness.py
+++ b/shapely/tests/test_emptiness.py
@@ -14,6 +14,11 @@ class EmptinessTestCase(unittest.TestCase):
         self.failIf(p._is_empty, False)
         p.empty()
         self.failUnless(p._is_empty, True)
+    def test_none_geom(self):
+        p = BaseGeometry()
+        p._geom = None
+        self.failUnless(p.is_empty, True)
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(EmptinessTestCase)


### PR DESCRIPTION
I have some code which produces some geometries which end up having `poly._geom is None` which essentially mean that all operations result in a `ValueError`:

```
>>> import shapely.geometry as sgeom
>>> p = sgeom.Polygon(None) 
>>> p._geom = None
>>> p.is_empty
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "shapely/geometry/base.py", line 389, in is_empty
    return bool(self.impl['is_empty'](self)) or (self._geom is None)
  File "shapely/predicates.py", line 21, in __call__
    self._validate(this)
  File "shapely/topology.py", line 16, in _validate
    raise ValueError("Null geometry supports no operations")
ValueError: Null geometry supports no operations

```

Its fairly hard in my code to track down the precise reasons that such a case is happening, but it seems that the `is_empty` property is trying to catch it, but failing. This patch means that the following now works:

```
>>> import shapely.geometry as sgeom
>>> p = sgeom.Polygon(None) 
>>> p._geom = None
>>> p.is_empty
True
```

I have not tried to be cleverer than that (I just want a published way of finding out if I can do anything with my geometry), so the following still fails (I would expect this to fail):

```

>>> p.area
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "shapely/geometry/base.py", line 254, in area
    return self.impl['area'](self)
  File "shapely/topology.py", line 34, in __call__
    self._validate(this)
  File "shapely/topology.py", line 16, in _validate
    raise ValueError("Null geometry supports no operations")
ValueError: Null geometry supports no operations
```

Thanks,
