### PR TITLE
Fix setup.py to install with pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ if (hasattr(platform, 'python_implementation')
     and platform.python_implementation() == 'PyPy'):
     # python_implementation is only available since 2.6
     ext_modules = []
-
+    libraries = []
 elif sys.platform == 'win32':
     libraries = ['geos']
 else:


### PR DESCRIPTION
I just had the same issue as [#40](https://github.com/Toblerity/Shapely/issues/40) with pypy 1.9 on OSX 10.8. This is a simple one line fix to get Shapely to install with pypy.
