### PR TITLE
Allow LineStrings to take arrays of Points

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -12,6 +12,7 @@ from shapely.coords import required
 from shapely.geos import lgeos, TopologicalError
 from shapely.geometry.base import BaseGeometry, geom_factory, JOIN_STYLE
 from shapely.geometry.proxy import CachingGeometryProxy
+from shapely.geometry.point import Point
 
 __all__ = ['LineString', 'asLineString']
 
@@ -221,8 +222,15 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if m < 2:
             raise ValueError(
                 "LineStrings must have at least 2 coordinate tuples")
+
+        def _coords(o):
+            if isinstance(o, Point):
+                return o.coords[0]
+            else:
+                return o
+
         try:
-            n = len(ob[0])
+            n = len(_coords(ob[0]))
         except TypeError:
             raise ValueError(
                 "Input %s is the wrong shape for a LineString" % str(ob))
@@ -240,7 +248,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
         # add to coordinate sequence
         for i in range(m):
-            coords = ob[i]
+            coords = _coords(ob[i])
             # Because of a bug in the GEOS C API,
             # always set X before Y
             lgeos.GEOSCoordSeq_setX(cs, i, coords[0])

--- a/shapely/tests/test_linestring.py
+++ b/shapely/tests/test_linestring.py
@@ -1,5 +1,5 @@
 from . import unittest, numpy
-from shapely.geometry import LineString, asLineString
+from shapely.geometry import LineString, asLineString, Point
 
 
 class LineStringTestCase(unittest.TestCase):
@@ -10,6 +10,16 @@ class LineStringTestCase(unittest.TestCase):
         line = LineString(((1.0, 2.0), (3.0, 4.0)))
         self.assertEqual(len(line.coords), 2)
         self.assertEqual(line.coords[:], [(1.0, 2.0), (3.0, 4.0)])
+
+        # From Points
+        line2 = LineString((Point(1.0, 2.0), Point(3.0, 4.0)))
+        self.assertEqual(len(line2.coords), 2)
+        self.assertEqual(line2.coords[:], [(1.0, 2.0), (3.0, 4.0)])
+
+        # From mix of tuples and Points
+        line3 = LineString((Point(1.0, 2.0), (2.0, 3.0), Point(3.0, 4.0)))
+        self.assertEqual(len(line3.coords), 3)
+        self.assertEqual(line3.coords[:], [(1.0, 2.0), (2.0, 3.0), (3.0, 4.0)])
 
         # From lines
         copy = LineString(line)


### PR DESCRIPTION
This allows LineStrings to be created using Point objects, not just arrays and tuples. Currently this would raise `ValueError`:

```
p0 = Point(x,y)
p1 = translate(p0, xoff, yoff)
line = LineString([p0, p1])
```

The commit allows mixing of Points and coordinate tuples as well:
`LineString([Point(1,2), (3,4), Point(5,6)])`

If you're okay with this and the approach, I can make sure it works for the other geometry types too.
