### PR TITLE
Support SRID on geometry, and with WKT/B Reader/Writers

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -358,6 +358,15 @@ class BaseGeometry(object):
         """Name of the geometry's type, such as 'Point'"""
         return self.geometryType()
 
+    @property
+    def srid(self):
+        """Spatial reference ID"""
+        return lgeos.GEOSGetSRID(self._geom)
+
+    @srid.setter
+    def srid(self, value):
+        lgeos.GEOSSetSRID(self._geom, int(value))
+
     # Real-valued properties and methods
     # ----------------------------------
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -214,6 +214,11 @@ class WKTReader(object):
 
     def read(self, text):
         """Returns geometry from WKT"""
+        if hasattr(text, 'upper') and text.upper().startswith('SRID='):
+            srid = int(text[(text.index('=') + 1):text.index(';')])
+            text = text[(text.index(';') + 1):]
+        else:
+            srid = 0
         if sys.version_info[0] >= 3:
             text = text.encode('ascii')
         geom = self._lgeos.GEOSWKTReader_read(self._reader, c_char_p(text))
@@ -222,7 +227,10 @@ class WKTReader(object):
                                "while reading input.")
         # avoid circular import dependency
         from shapely.geometry.base import geom_factory
-        return geom_factory(geom)
+        geom = geom_factory(geom)
+        if srid:
+            geom.srid = srid
+        return geom
 
 
 class WKTWriter(object):
@@ -231,7 +239,18 @@ class WKTWriter(object):
     _writer = None
 
     # Establish default output settings
-    defaults = {}
+    defaults = {'include_srid': True}
+
+    _include_srid = True
+
+    @property
+    def include_srid(self):
+        """Include SRID, True (default) or False"""
+        return getattr(self, '_include_srid')
+
+    @include_srid.setter
+    def include_srid(self, value):
+        setattr(self, '_include_srid', value)
 
     if geos_version >= (3, 3, 0):
 
@@ -327,13 +346,18 @@ class WKTWriter(object):
         """Returns WKT string for geometry"""
         if geom is None or geom._geom is None:
             raise ValueError("Null geometry supports no operations")
+        srid = geom.srid
+        if self.include_srid and srid:
+            pre = 'SRID=' + str(srid) + ';'
+        else:
+            pre = ''
         result = self._lgeos.GEOSWKTWriter_write(self._writer, geom._geom)
-        text = string_at(result)
+        wkt = string_at(result)
         lgeos.GEOSFree(result)
         if sys.version_info[0] >= 3:
-            return text.decode('ascii')
+            return pre + wkt.decode('ascii')
         else:
-            return text
+            return pre + wkt
 
 
 class WKBReader(object):
@@ -384,7 +408,7 @@ class WKBWriter(object):
     _writer = None
 
     # Establish default output setting
-    defaults = {'output_dimension': 3}
+    defaults = {'output_dimension': 3, 'include_srid': True}
 
     @property
     def output_dimension(self):
@@ -407,7 +431,7 @@ class WKBWriter(object):
 
     @property
     def include_srid(self):
-        """Include SRID, True or False (default)"""
+        """Include SRID, True (default) or False"""
         return bool(self._lgeos.GEOSWKBWriter_getIncludeSRID(self._writer))
 
     @include_srid.setter


### PR DESCRIPTION
A few notes:
- If SRID=0, it is not written to either WKT or WKB, regardless of 'include_srid' setting
- SRID ranges are not checked, as PostGIS does. E.g., the valid range is between 0 and I think 999998
- SRID support for the WKT Reader/Writer is 100% Python, since [it isn't in GEOS](http://trac.osgeo.org/geos/ticket/355)
- SRID support for the WKB Reader/Writer is 100% GEOS C API

Currently, I set 'include_srid'=True as default for both writers, which may not be popular. However, I don't expect any surprises since this would only be written with geometries that somehow have set the SRID attribute data, which before now was to load WKB where it is set.

Here's a short demo of the current capabilities:

``` python
from shapely.wkt import loads as load_wkt
from shapely.wkb import loads as load_wkb
p1 = load_wkt('POINT(0 0)')
p2 = load_wkt('SRID=4326;POINT(0 0)')
print(p1.srid)  # 0
print(p2.srid)  # 4326
print(p1.wkb_hex)  # 010100000000000000000000000000000000000000
print(p2.wkb_hex)  # 0101000020E610000000000000000000000000000000000000
print(p1.wkt)  # POINT (0 0)
print(p2.wkt)  # SRID=4326;POINT (0 0)
# Change values
p1.srid = -10000000
p2.srid = 0
print(p1.wkt)  # SRID=-10000000;POINT (0 0)
print(p2.wkt)  # POINT (0 0)
print(load_wkb(p1.wkb).wkt)  # SRID=-10000000;POINT (0 0)
print(load_wkb(p2.wkb).wkt)  # POINT (0 0)
print(load_wkb(p1.wkb_hex, hex=True).wkt)  # SRID=-10000000;POINT (0 0)
print(load_wkb(p2.wkb_hex, hex=True).wkt)  # POINT (0 0)
```
