### PR TITLE
Fix typo in 'shapely.ops' docu

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -187,7 +187,7 @@ def transform(func, geom):
 
       project = partial(
           pyproj.transform,
-          pyproj.Proj(init='espg:4326'),
+          pyproj.Proj(init='epsg:4326'),
           pyproj.Proj(init='epsg:26913'))
 
       g2 = transform(project, g1)


### PR DESCRIPTION
'epsg:4326' and not 'espg:4326'
