### PR TITLE
encoding for credits.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ with open('README.rst', 'r') as fp:
     readme_text = fp.read()
 readme_text = readme_text.replace(".. include:: CREDITS.txt", "")
 
-with open('CREDITS.txt', 'r') as fp:
+with open('CREDITS.txt', 'r', encoding='utf-8') as fp:
     credits = fp.read()
 
 with open('CHANGES.txt', 'r') as fp:


### PR DESCRIPTION
Hello

building shapely with Python 3.4, i get the following error:

```
Traceback (most recent call last):
  File "setup.py", line 78, in <module>
    credits = fp.read()
  File "/project/avd/python/python3/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 870: ordinal not in range(128)
```

I have seen this other places with Python 3.4, where the encoding for a string is not set to utf-8

I have looked in setup.py and it appears to be CREDITS.txt which is the problem

This PR attempts to fix this issue and enable installation for Python 3.4
