### PR TITLE
Implemented GEOSNearestPoints function.

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -358,6 +358,9 @@ def prototype(lgeos, geos_version):
 
     lgeos.GEOSDistance.restype = c_int
     lgeos.GEOSDistance.argtypes = [c_void_p, c_void_p, c_void_p]
+    
+    lgeos.GEOSNearestPoints.restype = c_void_p
+    lgeos.GEOSNearestPoints.argtypes = [c_void_p, c_void_p]
 
     '''
     Reader and Writer APIs


### PR DESCRIPTION
This commit implements the GEOSNearestPoints function, which returns the nearest points between two geometries.

Usage is shown below. Note that the resulting points may not be existing vertex (as in the example below).

```
from shapely.geometry import Point, LineString, Polygon
from shapely.ops import nearest_points

g1 = LineString([(0,0),(0,2)])
g2 = Polygon([(1,1),(2,0),(3,1),(2,2),(1,1)])

p1, p2 = nearest_points(g1, g2)

print p1 # POINT (0 1)
print p2 # POINT (1 1)
```

The distance between the two points is the same as the shortest distance between the two geometries:

```
assert p1.distance(p2) == g1.distance(g2)
```

The shortest line between the two geometries can be created by converting the points to a linestring:

```
shortest_line = LineString([p1, p2])
```
