### PR TITLE
Fix speedups for Points in LineString constructor

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -7,6 +7,7 @@
 
 import ctypes
 from shapely.geos import lgeos
+from shapely.geometry import Point
 
 include "../_geos.pxi"
     
@@ -81,8 +82,15 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if m < 2:
             raise ValueError(
                 "LineStrings must have at least 2 coordinate tuples")
+
+        def _coords(o):
+            if isinstance(o, Point):
+                return o.coords[0]
+            else:
+                return o
+
         try:
-            n = len(ob[0])
+            n = len(_coords(ob[0]))
         except TypeError:
             raise ValueError(
                 "Input %s is the wrong shape for a LineString" % str(ob))
@@ -100,7 +108,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
         # add to coordinate sequence
         for i in xrange(m):
-            coords = ob[i]
+            coords = _coords(ob[i])
             dx = coords[0]
             dy = coords[1]
             dz = 0

--- a/shapely/tests/test_speedups.py
+++ b/shapely/tests/test_speedups.py
@@ -1,9 +1,10 @@
 from . import unittest
 
 from shapely import speedups
-from shapely.geometry import LineString, Polygon
+from shapely.geometry import Point, LineString, Polygon
 
 
+@unittest.skipIf(not speedups.available, 'speedups not available')
 class SpeedupsTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -18,17 +19,18 @@ class SpeedupsTestCase(unittest.TestCase):
         speedups.disable()
         self.assertFalse(speedups._orig)
 
-    @unittest.skipIf(not speedups.available, 'speedups not available')
     def test_create_linestring(self):
         ls = LineString([(0, 0), (1, 0), (1, 2)])
         self.assertEqual(ls.length, 3)
 
-    @unittest.skipIf(not speedups.available, 'speedups not available')
+    def test_create_linestring_point(self):
+        ls = LineString([Point(0, 0), (1, 0), Point(1, 2)])
+        self.assertEqual(ls.length, 3)
+
     def test_create_polygon(self):
         p = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
         self.assertEqual(p.length, 8)
 
-    @unittest.skipIf(not speedups.available, 'speedups not available')
     def test_create_polygon_from_linestring(self):
         ls = LineString([(0, 0), (2, 0), (2, 2), (0, 2)])
         p = Polygon(ls)


### PR DESCRIPTION
Fixes #150.
Adds similar code from #102 to speedups. Adds a test.
