### PR TITLE
Ensure geos_* funcs imported properly

### DIFF
--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -10,7 +10,7 @@ from ctypes import c_double, c_void_p, cast, POINTER
 
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry
-from shapely.geometry.linestring import LineString, geos_linestring_from_py
+from shapely.geometry import linestring
 from shapely.geometry.proxy import CachingGeometryProxy
 
 __all__ = ['MultiLineString', 'asMultiLineString']
@@ -52,7 +52,7 @@ class MultiLineString(BaseMultipartGeometry):
             self._geom, self._ndim = geos_multilinestring_from_py(lines)
 
     def shape_factory(self, *args):
-        return LineString(*args)
+        return linestring.LineString(*args)
 
     @property
     def __geo_interface__(self):
@@ -123,7 +123,7 @@ def geos_multilinestring_from_py(ob):
         subs = (c_void_p * L)()
 
         for l in range(L):
-            geom, ndims = geos_linestring_from_py(array['data'][l])
+            geom, ndims = linestring.geos_linestring_from_py(array['data'][l])
             subs[i] = cast(geom, c_void_p)
         N = lgeos.GEOSGeom_getDimensions(subs[0])
     except (NotImplementedError, AttributeError):
@@ -142,7 +142,7 @@ def geos_multilinestring_from_py(ob):
         
         # add to coordinate sequence
         for l in range(L):
-            geom, ndims = geos_linestring_from_py(obs[l])
+            geom, ndims = linestring.geos_linestring_from_py(obs[l])
             subs[l] = cast(geom, c_void_p)
             
     return (lgeos.GEOSGeom_createCollection(5, subs, L), N)

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -12,7 +12,7 @@ from ctypes import ArgumentError
 from shapely.coords import required
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, exceptNull
-from shapely.geometry.point import Point, geos_point_from_py
+from shapely.geometry import point
 from shapely.geometry.proxy import CachingGeometryProxy
 
 __all__ = ['MultiPoint', 'asMultiPoint']
@@ -58,7 +58,7 @@ class MultiPoint(BaseMultipartGeometry):
             self._geom, self._ndim = geos_multipoint_from_py(points)
 
     def shape_factory(self, *args):
-        return Point(*args)
+        return point.Point(*args)
 
     @property
     def __geo_interface__(self):
@@ -180,7 +180,7 @@ def geos_multipoint_from_py(ob):
         subs = (c_void_p * m)()
 
         for i in range(m):
-            geom, ndims = geos_point_from_py(cp[n*i:n*i+2])
+            geom, ndims = point.geos_point_from_py(cp[n*i:n*i+2])
             subs[i] = cast(geom, c_void_p)
 
     except AttributeError:
@@ -198,7 +198,7 @@ def geos_multipoint_from_py(ob):
         # add to coordinate sequence
         for i in range(m):
             coords = ob[i]
-            geom, ndims = geos_point_from_py(coords)
+            geom, ndims = point.geos_point_from_py(coords)
             subs[i] = cast(geom, c_void_p)
             
     return lgeos.GEOSGeom_createCollection(4, subs, m), n

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -10,7 +10,7 @@ from ctypes import c_void_p, cast
 
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry
-from shapely.geometry.polygon import Polygon, geos_polygon_from_py
+from shapely.geometry import polygon
 from shapely.geometry.proxy import CachingGeometryProxy
 
 __all__ = ['MultiPolygon', 'asMultiPolygon']
@@ -64,7 +64,7 @@ class MultiPolygon(BaseMultipartGeometry):
             self._geom, self._ndim = geos_multipolygon_from_py(polygons)
 
     def shape_factory(self, *args):
-        return Polygon(*args)
+        return polygon.Polygon(*args)
 
     @property
     def __geo_interface__(self):
@@ -145,7 +145,7 @@ def geos_multipolygon_from_py(ob):
 
     subs = (c_void_p * L)()
     for l in range(L):
-        geom, ndims = geos_polygon_from_py(ob[l][0], ob[l][1:])
+        geom, ndims = polygon.geos_polygon_from_py(ob[l][0], ob[l][1:])
         subs[l] = cast(geom, c_void_p)
             
     return (lgeos.GEOSGeom_createCollection(6, subs, L), N)
@@ -172,7 +172,7 @@ def geos_multipolygon_from_polygons(ob):
         holes = getattr(obs[l], 'interiors', None)
         if holes is None:
             holes =  obs[l][1]
-        geom, ndims = geos_polygon_from_py(shell, holes)
+        geom, ndims = polygon.geos_polygon_from_py(shell, holes)
         subs[l] = cast(geom, c_void_p)
             
     return (lgeos.GEOSGeom_createCollection(6, subs, L), N)


### PR DESCRIPTION
Enable `multilinestring` to take advantage of speedups, if enabled. Just changes the way `geos_linestring_from_py` is imported in `multilinestring`. Before this, `multilinestring` imported the pure python version of `geos_linestring_from_py` and never saw the switched out function when speedups are enabled. I'm not quite sure the best way to test this.

Use linestring.geos_linestring_from_py in multilinestring instead of importing
as 'from shapely.geometry.linestring import geos_linestring_from_py' as the
speedups won't apply.

Apply the same pattern to MultiPoint and MultiPolygon even though they're
unaffected.
