### PR TITLE
Fix remaining speedups test failures

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -89,7 +89,11 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
     except AttributeError:
         # Fall back on list
-        m = len(ob)
+        try:
+            m = len(ob)
+        except TypeError:  # Iterators, e.g. Python 3 zip
+            ob = list(ob)
+            m = len(ob)
         if m < 2:
             raise ValueError(
                 "LineStrings must have at least 2 coordinate tuples")
@@ -224,7 +228,11 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
             
     except AttributeError:
         # Fall back on list
-        m = len(ob)
+        try:
+            m = len(ob)
+        except TypeError:  # Iterators, e.g. Python 3 zip
+            ob = list(ob)
+            m = len(ob)
         n = len(ob[0])
         if m < 3:
             raise ValueError(


### PR DESCRIPTION
There 2 commits here. The first fixes #155. The speedups functions use the `strides` property, if present, when iterating over the array. I'm new to Cython so if any experts know a better solution, please let me know. // @pelson.

2dadc2d4f617f6acf17f0e392577809ffaea6a8a actually exposed some more bugs, fixed in the second commit. Force generators to lists - the python versions already handled this case.
