### PR TITLE
Use sizeof, not cython.sizeof

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -9,8 +9,6 @@ import ctypes
 from shapely.geos import lgeos
 from shapely.geometry import Point
 
-import cython
-
 include "../_geos.pxi"
     
 
@@ -55,9 +53,11 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Use strides to properly index into cp
         # ob[i, j] == cp[sm*i + sn*j]
+        # Just to avoid a referenced before assignment warning.
+        dx = 0
         if array.get('strides', None):
-            sm = array['strides'][0] / cython.sizeof(dx)
-            sn = array['strides'][1] / cython.sizeof(dx)
+            sm = array['strides'][0] / sizeof(dx)
+            sn = array['strides'][1] / sizeof(dx)
         else:
             sm = n
             sn = 1
@@ -170,9 +170,10 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Use strides to properly index into cp
         # ob[i, j] == cp[sm*i + sn*j]
+        dx = 0  # Just to avoid a referenced before assignment warning.
         if array.get('strides', None):
-            sm = array['strides'][0] / cython.sizeof(dx)
-            sn = array['strides'][1] / cython.sizeof(dx)
+            sm = array['strides'][0] / sizeof(dx)
+            sn = array['strides'][1] / sizeof(dx)
         else:
             sm = n
             sn = 1


### PR DESCRIPTION
Removes importing cython as the Shapely runtime does not require it.
Pointed out by @pelson & @sgillies in #156.
