### PR TITLE
Added documentation for shapely.ops.triangulate.

### DIFF
--- a/docs/code/triangulate.py
+++ b/docs/code/triangulate.py
@@ -1,0 +1,24 @@
+from shapely.geometry import MultiPoint
+from shapely.ops import triangulate
+
+from matplotlib import pyplot
+from descartes.patch import PolygonPatch
+from figures import SIZE, BLUE, GRAY
+
+points = MultiPoint([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
+triangles = triangulate(points)
+
+fig = pyplot.figure(1, figsize=SIZE, dpi=90)
+fig.set_frameon(True)
+ax = fig.add_subplot(111)
+
+for triangle in triangles:
+    patch = PolygonPatch(triangle, facecolor=BLUE, edgecolor=BLUE, alpha=0.5, zorder=2)
+    ax.add_patch(patch)
+
+for point in points:
+    pyplot.plot(point.x, point.y, 'o', color=GRAY)
+
+pyplot.xlim(-0.5, 3.5)
+pyplot.ylim(-0.5, 2.5)
+pyplot.show()

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1960,6 +1960,42 @@ efficient than accumulating with :meth:`union`.
 
   Returns a representation of the union of the given geometric objects.
 
+Delaunay triangulation
+----------------------
+
+The :func:`~shapely.ops.triangulate` function in `shapely.ops` calculates a
+Delaunay triangulation from a collection of points.
+
+.. plot:: code/triangulate.py
+
+.. function:: shapely.ops.triangulate(geom, tolerance=0.0, edges=False)
+
+   Returns a Delaunary triangulation of the vertices of the input geometry.
+
+   The source may be any geometry type. All vertices of the geometry will be
+   used as the points of the triangulation.
+
+   The `tolerance` keyword argument sets the snapping tolerance used to improve
+   the robustness of the triangulation computation. A tolerance of 0.0 specifies
+   that no snapping will take place.
+
+   If the `edges` keyword argument is `False` a list of `Polygon` triangles
+   will be returned. Otherwise a list of `LineString` edges is returned.
+
+   `New in version  1.4.0`
+
+.. code-block:: pycon
+
+  >>> from shapely.ops import triangulate
+  >>> points = MultiPoint([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
+  >>> triangles = triangulate(points)
+  >>> pprint([triangle.wkt for triangle in triangles])
+  ['POLYGON ((0 2, 0 0, 1 1, 0 2))',
+   'POLYGON ((0 2, 1 1, 2 2, 0 2))',
+   'POLYGON ((2 2, 1 1, 3 1, 2 2))',
+   'POLYGON ((3 1, 1 1, 1 0, 3 1))',
+   'POLYGON ((1 0, 1 1, 0 0, 1 0))']
+
 Nearest points
 --------------
 


### PR DESCRIPTION
This commit adds documentation for the Delaunay triangulation method added for 1.4.0.

The example by @jwass using triangulation to create uniform random points is nice, but doesn't fit with the style of the manual. Perhaps a candidate for the examples directory? https://gist.github.com/jwass/ea225c99676adb2a2be9
