### PR TITLE
Added Cython speedup for CoordinateSequence.__iter__

### DIFF
--- a/shapely/speedups/__init__.py
+++ b/shapely/speedups/__init__.py
@@ -13,6 +13,12 @@ except ImportError:
     # TODO: This does not appear to do anything useful
     import_error_msg = sys.exc_info()[1]
 
+from ..ftools import wraps
+def method_wrapper(f):
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wraps(f)(wrapper)
+
 __all__ = ['available', 'enable', 'disable']
 _orig = {}
 
@@ -27,6 +33,9 @@ def enable():
     _orig['CoordinateSequence.ctypes'] = coords.CoordinateSequence.ctypes
     coords.CoordinateSequence.ctypes = property(_speedups.coordseq_ctypes)
     
+    _orig['CoordinateSequence.__iter__'] = coords.CoordinateSequence.__iter__
+    coords.CoordinateSequence.__iter__ = method_wrapper(_speedups.coordseq_iter)
+
     _orig['geos_linestring_from_py'] = linestring.geos_linestring_from_py
     linestring.geos_linestring_from_py = _speedups.geos_linestring_from_py
 
@@ -38,6 +47,7 @@ def disable():
         return
 
     coords.CoordinateSequence.ctypes = _orig['CoordinateSequence.ctypes']
+    coords.CoordinateSequence.__iter__ = _orig['CoordinateSequence.__iter__']
     linestring.geos_linestring_from_py = _orig['geos_linestring_from_py']
     polygon.geos_linearring_from_py = _orig['geos_linearring_from_py']
     _orig.clear()

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -319,3 +319,25 @@ def coordseq_ctypes(self):
             data_p[n*i+2] = temp
     return data
 
+def coordseq_iter(self):
+    cdef int i
+    cdef double dx
+    cdef double dy
+    cdef double dz
+    cdef int has_z
+
+    self._update()
+
+    cdef GEOSContextHandle_t handle = cast_handle(lgeos.geos_handle)
+    cdef GEOSCoordSequence *cs
+    cs = cast_seq(self._cseq)
+
+    has_z = self._ndim == 3
+    for i in range(self.__len__()):
+        GEOSCoordSeq_getX_r(handle, cs, i, &dx)
+        GEOSCoordSeq_getY_r(handle, cs, i, &dy)
+        if has_z == 1:
+            GEOSCoordSeq_getZ_r(handle, cs, i, &dz)
+            yield (dx, dy, dz)
+        else:
+            yield (dx, dy)


### PR DESCRIPTION
This commit adds a Cython speedup for the `__iter__` method on `shapely.coords.CoordinateSequence`.

To test I've been using the code from issue https://github.com/Toblerity/Shapely/issues/93.

Without speedups, 500 iterations takes 31 seconds on my machine. With the existing speedups this is reduced to 6 seconds. This commit takes this down to less than 1 second.

It should be compatible with Python 2.4 and upwards, including Python 3.x.
