### PR TITLE
Speedups for constructing geometries from existing GEOS geometries

### DIFF
--- a/shapely/_geos.pxi
+++ b/shapely/_geos.pxi
@@ -38,6 +38,9 @@ cdef extern from "geos_c.h":
     char GEOSPreparedTouches_r(GEOSContextHandle_t, const GEOSPreparedGeometry*, const GEOSGeometry*) nogil
     char GEOSPreparedWithin_r(GEOSContextHandle_t, const GEOSPreparedGeometry*, const GEOSGeometry*) nogil
 
+    GEOSGeometry *GEOSGeom_clone_r(GEOSContextHandle_t, GEOSGeometry*) nogil
+    GEOSCoordSequence *GEOSCoordSeq_clone_r(GEOSContextHandle_t, GEOSCoordSequence*) nogil
+
 
 cdef GEOSContextHandle_t get_geos_context_handle():
     # Note: This requires that lgeos is defined, so needs to be imported as:


### PR DESCRIPTION
This commit implements Cython speedups for creating new LineString and LinearRing geometries from existing geometry objects. Speedups for MultiLineString, MultiLinearRing, Polygon and MultiPolygon come for free. The code enhances the existing speedups for these geometry types, adding a special case where the input coordinates object is a LineString or LinearRing geometry. This should address issue https://github.com/Toblerity/Shapely/issues/143, I think, although I haven't tested it specifically with geopandas.

I've been using the following code for testing:

```
#!/usr/bin/env python

from __future__ import print_function

import timeit
setup = '''
import shapely.speedups
shapely.speedups.enable()
import shapely.geometry
import random
line1 = shapely.geometry.LineString(shapely.geometry.Point(0,0).buffer(100, 30).exterior)
line2 = shapely.geometry.LineString(shapely.geometry.Point(0,0).buffer(50, 30).exterior)
'''
run = '''
#line3 = shapely.geometry.LineString(line1)
#assert line3.coords[-1] == line1.coords[-1]
#poly1 = shapely.geometry.LinearRing(line1)
#poly1 = shapely.geometry.Polygon(line1, [line2])
#poly2 = shapely.geometry.Polygon(poly1.exterior)
line3 = shapely.geometry.MultiLineString([line1, line2])
'''

print(timeit.timeit(run, setup=setup, number=500))
```

The exact speed increase depends on the number of coordinates in the geometry, with more complex geometries benefiting more.

I've also changed the cast of pointers from `unsigned long` to `uintptr_t`, which is more correct. http://stackoverflow.com/questions/18695402/wrapping-a-pre-initialized-pointer-in-a-cython-class
