### PR TITLE
Fixed bug in speedups where GEOSGeom_clone was called twice.

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -36,7 +36,6 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     if isinstance(ob, LineString):
         g = cast_geom(ob._geom)
         n = GEOSGeom_getCoordinateDimension_r(handle, g)
-        g = GEOSGeom_clone_r(handle, g)
         return <unsigned long>GEOSGeom_clone_r(handle, g), n
 
     try:


### PR DESCRIPTION
This commit fixes a bug in _speedups.pyx, whereby GEOSGeom_clone was called twice, resulting in the ctypes version being faster than the cython version.
