### PR TITLE
Extended geometry cloning for efficient LineString<->LinearRing conversion

### DIFF
--- a/shapely/_geos.pxi
+++ b/shapely/_geos.pxi
@@ -25,6 +25,7 @@ cdef extern from "geos_c.h":
     GEOSGeometry *GEOSGeom_createLineString_r(GEOSContextHandle_t, GEOSCoordSequence *) nogil
     GEOSGeometry *GEOSGeom_createLinearRing_r(GEOSContextHandle_t, GEOSCoordSequence *) nogil
     GEOSGeometry *GEOSGeom_clone_r(GEOSContextHandle_t, GEOSGeometry *) nogil
+    GEOSCoordSequence *GEOSCoordSeq_clone_r(GEOSContextHandle_t, GEOSCoordSequence *) nogil
     int GEOSGeom_getCoordinateDimension_r(GEOSContextHandle_t, GEOSGeometry *) nogil
 
     void GEOSGeom_destroy_r(GEOSContextHandle_t, GEOSGeometry *) nogil

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -115,12 +115,22 @@ def geom_to_wkb(ob):
     return lgeos.GEOSGeomToWKB_buf(c_void_p(ob._geom), pointer(size))
 
 
-def geos_geom_from_py(ob):
-    """ Helper function for geos_*_from_py functions in each geom type. """
-    geom = lgeos.GEOSGeom_clone(ob._geom)
+def geos_geom_from_py(ob, create_func=None):
+    """Helper function for geos_*_from_py functions in each geom type.
+
+    If a create_func is specified the coodinate sequence is cloned and a new
+    geometry is created with it, otherwise the geometry is cloned directly.
+    This behaviour is useful for converting between LineString and LinearRing
+    objects.
+    """
+    if create_func is None:
+        geom = lgeos.GEOSGeom_clone(ob._geom)
+    else:
+        cs = lgeos.GEOSGeom_getCoordSeq(ob._geom)
+        cs = lgeos.GEOSCoordSeq_clone(cs)
+        geom = create_func(cs)
     N = lgeos.GEOSGeom_getCoordinateDimension(geom)
     return geom, N
-
 
 def exceptNull(func):
     """Decorator which helps avoid GEOS operations on null pointers."""

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -181,8 +181,12 @@ def asLineString(context):
 
 def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     # If a LineString is passed in, clone it and return
+    # If a LinearRing is passed in, clone the coord seq and return a LineString
     if isinstance(ob, LineString):
-        return geos_geom_from_py(ob)
+        if type(ob) == LineString:
+            return geos_geom_from_py(ob)
+        else:
+            return geos_geom_from_py(ob, lgeos.GEOSGeom_createLineString)
 
     # If numpy is present, we use numpy.require to ensure that we have a
     # C-continguous array that owns its data. View data will be copied.

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -345,8 +345,12 @@ def orient(polygon, sign=1.0):
 
 def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
     # If a LinearRing is passed in, clone it and return
-    if isinstance(ob, LinearRing):
-        return geos_geom_from_py(ob)
+    # If a LineString is passed in, clone the coord seq and return a LinearRing
+    if isinstance(ob, LineString):
+        if type(ob) == LinearRing:
+            return geos_geom_from_py(ob)
+        else:
+            return geos_geom_from_py(ob, lgeos.GEOSGeom_createLinearRing)
 
     # If numpy is present, we use numpy.require to ensure that we have a
     # C-continguous array that owns its data. View data will be copied.

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -33,10 +33,16 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     cdef int i, n, m, sm, sn
 
     # If a LineString is passed in, just clone it and return
+    # If a LinearRing is passed in, clone the coord seq and return a LineString
     if isinstance(ob, LineString):
         g = cast_geom(ob._geom)
         n = GEOSGeom_getCoordinateDimension_r(handle, g)
-        return <unsigned long>GEOSGeom_clone_r(handle, g), n
+        if type(ob) == LineString:
+            return <unsigned long>GEOSGeom_clone_r(handle, g), n
+        else:
+            cs = GEOSGeom_getCoordSeq_r(handle, g)
+            cs = GEOSCoordSeq_clone_r(handle, cs)
+            return <unsigned long>GEOSGeom_createLineString_r(handle, cs), n
 
     try:
         # From array protocol
@@ -162,10 +168,16 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
     cdef int i, n, m, M, sm, sn
 
     # If a LinearRing is passed in, just clone it and return
-    if isinstance(ob, LinearRing):
+    # If a LineString is passed in, clone the coord seq and return a LinearRing
+    if isinstance(ob, LineString):
         g = cast_geom(ob._geom)
         n = GEOSGeom_getCoordinateDimension_r(handle, g)
-        return <unsigned long>GEOSGeom_clone_r(handle, g), n
+        if type(ob) == LinearRing:
+            return <unsigned long>GEOSGeom_clone_r(handle, g), n
+        else:
+            cs = GEOSGeom_getCoordSeq_r(handle, g)
+            cs = GEOSCoordSeq_clone_r(handle, cs)
+            return <unsigned long>GEOSGeom_createLinearRing_r(handle, cs), n
 
     try:
         # From array protocol


### PR DESCRIPTION
This commit improves the efficiency of creating a `LineString` from a `LinearRing` or vice versa, in both ctypes and cython. This is built on top of the work done by @jwass.
