### PR TITLE
Carefully promote data to float64 only if Numpy present.

### DIFF
--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -21,13 +21,13 @@ def required(ob):
     """Return an object that meets Shapely requirements for self-owned
     C-continguous data, copying if necessary, or just return the original
     object."""
-    if (hasattr(ob, '__array_interface__')
-            and ob.__array_interface__.get('strides')):
-        if has_numpy:
-            return numpy.require(ob, numpy.float64, ["C", "OWNDATA"])
-        else:
+    if hasattr(ob, '__array_interface__'):
+        if ob.__array_interface__.get('strides') and not has_numpy:
             # raise an error if strided. See issue #52.
             raise ValueError("C-contiguous data is required")
+        else:
+            # numpy.require will just return (ob) if it is already float64 and well-behaved.
+            return numpy.require(ob, numpy.float64, ["C", "OWNDATA"])
     else:
         return ob
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,0 +1,40 @@
+from . import unittest, numpy
+from shapely import geometry
+
+
+class CoordsTestCase(unittest.TestCase):
+    """
+    Shapely assumes contiguous C-order float64 data for internal ops.
+    Data should be converted to contiguous float64 if numpy exists.
+    c9a0707 broke this a little bit.
+    """
+
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_data_promotion(self):
+        coords = numpy.array([[ 12, 34 ], [ 56, 78 ]], dtype=numpy.float32)
+        processed_coords = numpy.array(
+            geometry.LineString(coords).coords
+        )
+
+        self.assertEqual(
+            coords.tolist(),
+            processed_coords.tolist()
+        )
+
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_data_destriding(self):
+        coords = numpy.array([[ 12, 34 ], [ 56, 78 ]], dtype=numpy.float32)
+
+        # Easy way to introduce striding: reverse list order
+        processed_coords = numpy.array(
+            geometry.LineString(coords[::-1]).coords
+        )
+
+        self.assertEqual(
+            coords[::-1].tolist(),
+            processed_coords.tolist()
+        )
+
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(CoordsTestCase)


### PR DESCRIPTION
G'day,

The test introduced by c9a0707 (raising an error for strided data if numpy isn't present) results in unstrided data being treated as float64 even if it's not. This patch updates the conditional a little, and introduces a unit test.
- Morris
  PS: Thankyou for this excellent, excellent project.
