### PR TITLE
Remove getCoordinateDimension calls

### DIFF
--- a/shapely/_geos.pxi
+++ b/shapely/_geos.pxi
@@ -26,7 +26,6 @@ cdef extern from "geos_c.h":
     GEOSGeometry *GEOSGeom_createLinearRing_r(GEOSContextHandle_t, GEOSCoordSequence *) nogil
     GEOSGeometry *GEOSGeom_clone_r(GEOSContextHandle_t, GEOSGeometry *) nogil
     GEOSCoordSequence *GEOSCoordSeq_clone_r(GEOSContextHandle_t, GEOSCoordSequence *) nogil
-    int GEOSGeom_getCoordinateDimension_r(GEOSContextHandle_t, GEOSGeometry *) nogil
 
     void GEOSGeom_destroy_r(GEOSContextHandle_t, GEOSGeometry *) nogil
 
@@ -41,6 +40,7 @@ cdef extern from "geos_c.h":
     char GEOSPreparedTouches_r(GEOSContextHandle_t, const GEOSPreparedGeometry*, const GEOSGeometry*) nogil
     char GEOSPreparedWithin_r(GEOSContextHandle_t, const GEOSPreparedGeometry*, const GEOSGeometry*) nogil
 
+    char GEOSHasZ_r(GEOSContextHandle_t, GEOSGeometry *) nogil
     char GEOSisRing_r(GEOSContextHandle_t, GEOSGeometry *) nogil
     char GEOSisClosed_r(GEOSContextHandle_t, GEOSGeometry *) nogil
 

--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -357,9 +357,6 @@ def prototype(lgeos, geos_version):
     lgeos.GEOSGeom_getDimensions.restype = c_int
     lgeos.GEOSGeom_getDimensions.argtypes = [c_void_p]
 
-    lgeos.GEOSGeom_getCoordinateDimension.restype = c_int
-    lgeos.GEOSGeom_getCoordinateDimension.argtypes = [c_void_p]
-
     '''
     Misc functions
     '''

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -129,7 +129,9 @@ def geos_geom_from_py(ob, create_func=None):
         cs = lgeos.GEOSGeom_getCoordSeq(ob._geom)
         cs = lgeos.GEOSCoordSeq_clone(cs)
         geom = create_func(cs)
-    N = lgeos.GEOSGeom_getCoordinateDimension(geom)
+
+    N = ob._ndim
+
     return geom, N
 
 def exceptNull(func):

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -130,7 +130,12 @@ def geos_multilinestring_from_py(ob):
         for l in range(L):
             geom, ndims = linestring.geos_linestring_from_py(array['data'][l])
             subs[i] = cast(geom, c_void_p)
-        N = lgeos.GEOSGeom_getCoordinateDimension(subs[0])
+
+        if lgeos.GEOSHasZ(subs[0]):
+            N = 3
+        else:
+            N = 2
+
     except (NotImplementedError, AttributeError):
         obs = getattr(ob, 'geoms', ob)
         L = len(obs)

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -36,7 +36,11 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     # If a LinearRing is passed in, clone the coord seq and return a LineString
     if isinstance(ob, LineString):
         g = cast_geom(ob._geom)
-        n = GEOSGeom_getCoordinateDimension_r(handle, g)
+        if GEOSHasZ_r(handle, g):
+            n = 3
+        else:
+            n = 2
+
         if type(ob) == LineString:
             return <unsigned long>GEOSGeom_clone_r(handle, g), n
         else:
@@ -171,7 +175,11 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
     # If a LineString is passed in, clone the coord seq and return a LinearRing
     if isinstance(ob, LineString):
         g = cast_geom(ob._geom)
-        n = GEOSGeom_getCoordinateDimension_r(handle, g)
+        if GEOSHasZ_r(handle, g):
+            n = 3
+        else:
+            n = 2
+
         if type(ob) == LinearRing:
             return <unsigned long>GEOSGeom_clone_r(handle, g), n
         else:

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -67,6 +67,16 @@ class LineStringTestCase(unittest.TestCase):
                          lgeos.GEOSGeomType(copy._geom).decode('ascii'))
 
 
+    def test_from_linestring_z(self):
+        coords = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+        line = LineString(coords)
+        copy = LineString(line)
+        self.assertEqual(len(copy.coords), 2)
+        self.assertEqual(copy.coords[:], coords)
+        self.assertEqual('LineString',
+                         lgeos.GEOSGeomType(copy._geom).decode('ascii'))
+
+
     def test_from_linearring(self):
         coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]
         ring = LinearRing(coords)

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,11 +1,12 @@
 from . import unittest, numpy
+from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
 
 
 class MultiLineStringTestCase(unittest.TestCase):
 
-    def test_multipoint(self):
+    def test_multilinestring(self):
 
         # From coordinate tuples
         geom = MultiLineString((((1.0, 2.0), (3.0, 4.0)),))
@@ -35,6 +36,22 @@ class MultiLineStringTestCase(unittest.TestCase):
         self.assertEqual(geom.__geo_interface__,
                          {'type': 'MultiLineString',
                           'coordinates': (((0.0, 0.0), (1.0, 2.0)),)})
+
+
+    def test_from_multilinestring_z(self):
+        coords1 = [(0.0, 1.0, 2.0), (3.0, 4.0, 5.0)]
+        coords2 = [(6.0, 7.0, 8.0), (9.0, 10.0, 11.0)]
+
+        # From coordinate tuples
+        ml = MultiLineString([coords1, coords2])
+        copy = MultiLineString(ml)
+        self.assertIsInstance(copy, MultiLineString)
+        self.assertEqual('MultiLineString',
+                         lgeos.GEOSGeomType(copy._geom).decode('ascii'))
+        self.assertEqual(len(copy.geoms), 2)
+        self.assertEqual(dump_coords(copy.geoms[0]), coords1)
+        self.assertEqual(dump_coords(copy.geoms[1]), coords2)
+
 
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy(self):


### PR DESCRIPTION
Use HasZ instead of getCoordinateDimension to support GEOS 3.2.
