### PR TITLE
Fix bug in big_endian property of WKBWriter (issue #174)

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -383,6 +383,10 @@ class WKBWriter(object):
     _lgeos = None
     _writer = None
 
+    # EndianType enum in ByteOrderValues.h
+    _ENDIAN_BIG = 0
+    _ENDIAN_LITTLE = 1
+
     # Establish default output setting
     defaults = {'output_dimension': 3}
 
@@ -399,11 +403,13 @@ class WKBWriter(object):
     @property
     def big_endian(self):
         """Byte order is big endian, True (default) or False"""
-        return bool(self._lgeos.GEOSWKBWriter_getByteOrder(self._writer))
+        return (self._lgeos.GEOSWKBWriter_getByteOrder(self._writer) ==
+            self._ENDIAN_BIG)
 
     @big_endian.setter
     def big_endian(self, value):
-        self._lgeos.GEOSWKBWriter_setByteOrder(self._writer, bool(value))
+        self._lgeos.GEOSWKBWriter_setByteOrder(
+            self._writer, self._ENDIAN_BIG if value else self._ENDIAN_LITTLE)
 
     @property
     def include_srid(self):

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -4,9 +4,18 @@ from . import unittest
 import pickle
 from shapely import wkb, wkt
 from shapely.geometry import Point
+import struct
 
 
 class PersistTestCase(unittest.TestCase):
+
+    @staticmethod
+    def _byte(i):
+        """Convert an integer in the range [0, 256) to a byte."""
+        if bytes == str: # Python 2
+            return chr(i)
+        else: # Python 3
+            return int(i)
 
     def test_pickle(self):
 
@@ -18,9 +27,33 @@ class PersistTestCase(unittest.TestCase):
     def test_wkb(self):
 
         p = Point(0.0, 0.0)
-        bytes = wkb.dumps(p)
-        pb = wkb.loads(bytes)
-        self.assertTrue(pb.equals(p))
+        wkb_big_endian = wkb.dumps(p, big_endian=True)
+        wkb_little_endian = wkb.dumps(p, big_endian=False)
+        # Regardless of byte order, loads ought to correctly recover the
+        # geometry
+        self.assertTrue(p.equals(wkb.loads(wkb_big_endian)))
+        self.assertTrue(p.equals(wkb.loads(wkb_little_endian)))
+
+    def test_wkb_dumps_endianness(self):
+
+        p = Point(0.5, 2.0)
+        wkb_big_endian = wkb.dumps(p, big_endian=True)
+        wkb_little_endian = wkb.dumps(p, big_endian=False)
+        self.assertNotEqual(wkb_big_endian, wkb_little_endian)
+        # According to WKB specification in section 3.3 of OpenGIS
+        # Simple Features Specification for SQL, revision 1.1, the
+        # first byte of a WKB representation indicates byte order.
+        # Big-endian is 0, little-endian is 1.
+        self.assertEqual(wkb_big_endian[0], self._byte(0))
+        self.assertEqual(wkb_little_endian[0], self._byte(1))
+        # Check that the doubles (0.5, 2.0) are in correct byte order
+        double_size = struct.calcsize('d')
+        self.assertEqual(
+            wkb_big_endian[(-2 * double_size):],
+            struct.pack('>2d', p.x, p.y))
+        self.assertEqual(
+            wkb_little_endian[(-2 * double_size):],
+            struct.pack('<2d', p.x, p.y))
 
     def test_wkt(self):
         p = Point(0.0, 0.0)


### PR DESCRIPTION
See https://github.com/Toblerity/Shapely/issues/174

WKBWriter did not correctly interpret its `big_endian` property. It
wrote WKB in big-endian byte order when `big_endian=False`, and in
little-endian byte order when `big_endian=True`.

This commit fixes this bug and adds basic test coverage in the
`test_persist.py` module.
