### PR TITLE
Added Cython speedup for shapely.affinity.affine_transform

### DIFF
--- a/shapely/speedups/__init__.py
+++ b/shapely/speedups/__init__.py
@@ -44,7 +44,11 @@ def enable():
     polygon.geos_linearring_from_py = _speedups.geos_linearring_from_py
     
     _orig['affine_transform'] = shapely.affinity.affine_transform
-    shapely.affinity.affine_transform = _speedups.affine_transform
+    # copy docstring from original function
+    def affine_transform(geom, matrix):
+        return _speedups.affine_transform(geom, matrix)
+    affine_transform.__doc__ = shapely.affinity.affine_transform.__doc__
+    shapely.affinity.affine_transform = affine_transform
 
 def disable():
     if not _orig:

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -438,43 +438,6 @@ cdef GEOSCoordSequence* transform(GEOSCoordSequence* cs,
     return cs_t
 
 cpdef affine_transform(geom, matrix):
-    """Returns a transformed geometry using an affine transformation matrix.
-
-    The coefficient matrix is provided as a list or tuple with 6 or 12 items
-    for 2D or 3D transformations, respectively.
-
-    For 2D affine transformations, the 6 parameter matrix is:
-
-    [a, b, d, e, xoff, yoff]
-
-    which represents the augmented matrix:
-
-    / a  b xoff \ 
-    [x' y' 1] = [x y 1] | d  e yoff |
-    \ 0  0   1  /
-
-    or the equations for the transformed coordinates:
-
-    x' = a * x + b * y + xoff
-    y' = d * x + e * y + yoff
-
-    For 3D affine transformations, the 12 parameter matrix is:
-
-    [a, b, c, d, e, f, g, h, i, xoff, yoff, zoff]
-
-    which represents the augmented matrix:
-
-    / a  b  c xoff \ 
-    [x' y' z' 1] = [x y z 1] | d  e  f yoff |
-    | g  h  i zoff |
-    \ 0  0  0   1  /
-
-    or the equations for the transformed coordinates:
-
-    x' = a * x + b * y + c * z + xoff
-    y' = d * x + e * y + f * z + yoff
-    z' = g * x + h * y + i * z + zoff
-    """
     cdef double a, b, c, d, e, f, g, h, i, xoff, yoff, zoff
     if geom.is_empty:
         return geom


### PR DESCRIPTION
There is a longstanding issue requesting improvement to the performance of the `shapely.affinity.affine_transform` function: https://github.com/Toblerity/Shapely/issues/93

As a baseline, the following code takes **21.7 seconds** to run on my machine:

```
import timeit
setup = 'import shapely.geometry; import shapely.affinity; circle = shapely.geometry.Point([0, 0]).buffer(10, resolution=1000);'
rotate = 'shapely.affinity.rotate(circle, 0.1, origin=[0, 0])'
print timeit.timeit(rotate, setup=setup, number=1000)
```

With the addition of the speedups to the creation of `LineString` and `LinearRing` objects this is reduced down to only **1.4 seconds**.

This pull request goes the next step by Cythonising `affine_transform`, and notably the internal `affine_pts` loop. The result is that the above code takes only **0.16 seconds**.

The code is a little lazy in that it only speeds up the transforms for `Point`, `LineString` and `LinearRing` objects, but gets `Polygon` and `Multi*` geometry speedups for free with the existing code.

Also, it uses the `geom_factory` function from Cython - I'm assuming this is OK?
