### PR TITLE
is_valid and error handeling

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -8,7 +8,7 @@ from ctypes import pointer, c_size_t, c_char_p, c_void_p
 
 from shapely.coords import CoordinateSequence
 from shapely.ftools import wraps
-from shapely.geos import lgeos, ReadingError
+from shapely.geos import lgeos, ReadingError, GeometryValueError
 from shapely.geos import WKBWriter, WKTWriter
 from shapely.impl import DefaultImplementation, delegated
 
@@ -592,7 +592,10 @@ class BaseGeometry(object):
     def is_valid(self):
         """True if the geometry is valid (definition depends on sub-class),
         else False"""
-        return bool(self.impl['is_valid'](self))
+        try:
+            return bool(self.impl['is_valid'](self))
+        except GeometryValueError as e:
+            return False
 
     # Binary predicates
     # -----------------

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -9,7 +9,7 @@ if sys.version_info[0] < 3:
 from ctypes import c_double, cast, POINTER
 
 from shapely.coords import required
-from shapely.geos import lgeos, TopologicalError
+from shapely.geos import lgeos, TopologicalError, DimensionError, ShapeError
 from shapely.geometry.base import (
     BaseGeometry, geom_factory, JOIN_STYLE, geos_geom_from_py
 )
@@ -197,12 +197,12 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         assert len(array['shape']) == 2
         m = array['shape'][0]
         if m < 2:
-            raise ValueError(
+            raise TopologicalError(
                 "LineStrings must have at least 2 coordinate tuples")
         try:
             n = array['shape'][1]
         except IndexError:
-            raise ValueError(
+            raise ShapeError(
                 "Input %s is the wrong shape for a LineString" % str(ob))
         assert n == 2 or n == 3
 
@@ -217,7 +217,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if update_geom is not None:
             cs = lgeos.GEOSGeom_getCoordSeq(update_geom)
             if n != update_ndim:
-                raise ValueError(
+                raise DimensionError(
                     "Wrong coordinate dimensions; this geometry has "
                     "dimensions: %d" % update_ndim)
         else:
@@ -232,7 +232,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
                 try:
                     dz = c_double(cp[n*i+2])
                 except IndexError:
-                    raise ValueError("Inconsistent coordinate dimensionality")
+                    raise DimensionError("Inconsistent coordinate dimensionality")
 
             # Because of a bug in the GEOS C API,
             # always set X before Y
@@ -250,7 +250,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
             m = len(ob)
 
         if m < 2:
-            raise ValueError(
+            raise TopologicalError(
                 "LineStrings must have at least 2 coordinate tuples")
 
         def _coords(o):
@@ -262,7 +262,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         try:
             n = len(_coords(ob[0]))
         except TypeError:
-            raise ValueError(
+            raise ShapeError(
                 "Input %s is the wrong shape for a LineString" % str(ob))
         assert n == 2 or n == 3
 
@@ -270,7 +270,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if update_geom is not None:
             cs = lgeos.GEOSGeom_getCoordSeq(update_geom)
             if n != update_ndim:
-                raise ValueError(
+                raise DimensionError(
                     "Wrong coordinate dimensions; this geometry has "
                     "dimensions: %d" % update_ndim)
         else:
@@ -287,7 +287,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
                 try:
                     lgeos.GEOSCoordSeq_setZ(cs, i, coords[2])
                 except IndexError:
-                    raise ValueError("Inconsistent coordinate dimensionality")
+                    raise DimensionError("Inconsistent coordinate dimensionality")
 
     if update_geom is not None:
         return None

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -241,7 +241,7 @@ def geos_point_from_py(ob, update_geom=None, update_ndim=0):
     if update_geom:
         cs = lgeos.GEOSGeom_getCoordSeq(update_geom)
         if n != update_ndim:
-            raise ValueError(
+            raise DimensionError(
                 "Wrong coordinate dimensions; this geometry has dimensions: "
                 "%d" % update_ndim)
     else:

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -12,7 +12,7 @@ import weakref
 
 from shapely.algorithms.cga import signed_area
 from shapely.coords import required
-from shapely.geos import lgeos
+from shapely.geos import lgeos, DimensionError, TopologicalError
 from shapely.geometry.base import BaseGeometry, geos_geom_from_py
 from shapely.geometry.linestring import LineString, LineStringAdapter
 from shapely.geometry.proxy import PolygonProxy
@@ -379,7 +379,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         m = array['shape'][0]
         n = array['shape'][1]
         if m < 3:
-            raise ValueError(
+            raise TopologicalError(
                 "A LinearRing must have at least 3 coordinate tuples")
         assert n == 2 or n == 3
 
@@ -400,7 +400,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         if update_geom is not None:
             cs = lgeos.GEOSGeom_getCoordSeq(update_geom)
             if n != update_ndim:
-                raise ValueError(
+                raise DimensionError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
                 % update_ndim)
         else:
@@ -434,7 +434,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
 
         n = len(ob[0])
         if m < 3:
-            raise ValueError(
+            raise TopologicalError(
                 "A LinearRing must have at least 3 coordinate tuples")
         assert (n == 2 or n == 3)
 
@@ -448,7 +448,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         if update_geom is not None:
             cs = lgeos.GEOSGeom_getCoordSeq(update_geom)
             if n != update_ndim:
-                raise ValueError(
+                raise DimensionError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
                 % update_ndim)
         else:
@@ -465,7 +465,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
                 try:
                     lgeos.GEOSCoordSeq_setZ(cs, i, coords[2])
                 except IndexError:
-                    raise ValueError("Inconsistent coordinate dimensionality")
+                    raise DimensionError("Inconsistent coordinate dimensionality")
 
         # Add closing coordinates to sequence?
         if M > m:
@@ -502,7 +502,7 @@ def geos_polygon_from_py(shell, holes=None):
             if not L >= 1:
                 raise ValueError("number of holes must be non zero")
             if not N in (2, 3):
-                raise ValueError("insufficiant coordinate dimension")
+                raise DimensionError("insufficiant coordinate dimension")
 
             # Array of pointers to ring geometries
             geos_holes = (c_void_p * L)()

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -166,11 +166,17 @@ class ReadingError(Exception):
     pass
 
 
-class DimensionError(Exception):
+class GeometryValueError(ValueError):
+    #Base error for invalid geometries
     pass
 
+class ShapeError(GeometryValueError):
+    pass
 
-class TopologicalError(Exception):
+class DimensionError(GeometryValueError):
+    pass
+
+class TopologicalError(GeometryValueError):
     pass
 
 

--- a/tests/test_invalid_geometries.py
+++ b/tests/test_invalid_geometries.py
@@ -2,7 +2,8 @@
 '''
 
 from . import unittest
-from shapely.geometry import Polygon
+from shapely.geos import TopologicalError, DimensionError
+from shapely.geometry import Polygon, LineString, asPolygon, asLineString
 from shapely.topology import TopologicalError
 
 
@@ -23,6 +24,33 @@ class InvalidGeometriesTestCase(unittest.TestCase):
                           polygon.intersection, polygon_invalid)
         return
 
+    def test_polygon_inconsistent_dimensionality(self):
+        invalid_arr = [(0, 0, 0), (1, 1), (2, 2)]
+        with self.assertRaises(DimensionError):
+            Polygon(invalid_arr)
+        p = asPolygon(invalid_arr)
+        self.assertFalse(p.is_valid)
+
+    def test_polygon_missing_coordinates(self):
+        invalid_arr = [(0, 0), (1, 1)]
+        with self.assertRaises(TopologicalError):
+            Polygon(invalid_arr)
+        p = asPolygon(invalid_arr)
+        self.assertFalse(p.is_valid)
+
+    def test_linestring_inconsistent_dimensionality(self):
+        invalid_arr = [(0, 0, 0), (1, 1)]
+        with self.assertRaises(DimensionError):
+            LineString(invalid_arr)
+        l = asLineString(invalid_arr)
+        self.assertFalse(l.is_valid)
+
+    def test_linestring_missing_coordinates(self):
+        invalid_arr = [(0, 0)]
+        with self.assertRaises(TopologicalError):
+            LineString(invalid_arr)
+        l = asLineString(invalid_arr)
+        self.assertFalse(l.is_valid)
 
 def test_suite():
     loader = unittest.TestLoader()


### PR DESCRIPTION
I ran into some unexpected problems using shapely with malformed geojson geometries. Instead of returning `false`, the `is_valid` function raised exceptions if e.g. a polygon consisted of two points. My suggestion is to more consistently use shapely's own exceptions for common errors, and having `is_valid` catch these. By having these exceptions inherit from `ValueError`, code that relied on catching the old errors should be unaffected. Generally speaking, consolidating the thrown errors should have additional benefits.
