### PR TITLE
Added constructor for GeometryCollection objects

### DIFF
--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -1,8 +1,13 @@
 """Multi-part collections of geometries
 """
 
+from ctypes import c_void_p
+
+from shapely.geos import lgeos
+from shapely.geometry.base import BaseGeometry
 from shapely.geometry.base import BaseMultipartGeometry
 from shapely.geometry.base import HeterogeneousGeometrySequence
+from shapely.geometry.base import geos_geom_from_py
 
 
 class GeometryCollection(BaseMultipartGeometry):
@@ -15,8 +20,26 @@ class GeometryCollection(BaseMultipartGeometry):
         A sequence of Shapely geometry instances
     """
 
-    def __init__(self):
+    def __init__(self, geoms=None):
+        """
+        Parameters
+        ----------
+        geoms : list
+            A list of shapely geometry instances, which may be heterogenous.
+        
+        Example
+        -------
+        Create a GeometryCollection with a Point and a LineString
+        
+          >>> p = Point(51, -1)
+          >>> l = LineString([(52, -1), (49, 2)])
+          >>> gc = GeometryCollection([p, l])
+        """
         BaseMultipartGeometry.__init__(self)
+        if not geoms:
+            pass
+        else:
+            self._geom, self._ndim = geos_geometrycollection_from_py(geoms)
 
     @property
     def __geo_interface__(self):
@@ -31,6 +54,19 @@ class GeometryCollection(BaseMultipartGeometry):
             return []
         return HeterogeneousGeometrySequence(self)
 
+def geos_geometrycollection_from_py(ob):
+    """Creates a GEOS GeometryCollection from a list of geometries"""
+    L = len(ob)
+    N = 2
+    subs = (c_void_p * L)()
+    for l in range(L):
+        assert(isinstance(ob[l], BaseGeometry))
+        if ob[l].has_z:
+            N = 3
+        geom, n = geos_geom_from_py(ob[l])
+        subs[l] = geom
+    
+    return (lgeos.GEOSGeom_createCollection(7, subs, L), N)
 
 # Test runner
 def _test():

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -66,11 +66,9 @@ class AffineTestCase(unittest.TestCase):
         test_geom(load_wkt(
             'MULTIPOLYGON(((900 4300, -1100 -400, 900 -800, 900 4300)), '
             '((1200 4300, 2300 4400, 1900 1000, 1200 4300)))'))
-        # GeometryCollection fails, since it does not have a good constructor
-        gc = load_wkt('GEOMETRYCOLLECTION(POINT(20 70),'
+        test_geom(load_wkt('GEOMETRYCOLLECTION(POINT(20 70),'
                       ' POLYGON((60 70, 13 35, 60 -30, 60 70)),'
-                      ' LINESTRING(60 70, 50 100, 80 100))')
-        self.assertRaises(TypeError, test_geom, gc)  # TODO: fix this
+                      ' LINESTRING(60 70, 50 100, 80 100))'))
 
     def test_affine_2d(self):
         g = load_wkt('LINESTRING(2.4 4.1, 2.4 3, 3 3)')


### PR DESCRIPTION
This commit allows GeometryCollection objects to be created from a list of existing shapely geometries.

Example usage:

```
p = Point(51, -1)
l = LineString([(52, -1), (49, 2)])
gc = GeometryCollection([p, l])
```

An empty GeometryCollection can still be created by instantiating without any arguments, or with an empty list:

```
>>> gc = GeometryCollection()
>>> gc.to_wkt()
'GEOMETRYCOLLECTION EMPTY'
```

This allows the `affine_transform` function to work with GeometryCollection objects (the test for this has been updated).

```
>>> from shapely.affinity import translate
>>> from shapely.wkt import dumps
>>> gc2 = translate(gc, 5, 0)
>>> dumps(gc, trim=True)
'GEOMETRYCOLLECTION (POINT (51 -1), LINESTRING (52 -1, 49 2))'
>>> dumps(gc2, trim=True)
'GEOMETRYCOLLECTION (POINT (56 -1), LINESTRING (57 -1, 54 2))'
```
