### PR TITLE
Implementing GEOSSnap function.

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2023,6 +2023,31 @@ the nearest points in a pair of geometries.
 
 Note that the nearest points may not be existing vertices in the geometries.
 
+Snapping
+--------
+
+The :func:`~shapely.ops.snap` function in `shapely.ops` snaps the vertices in
+one geometry to the vertices in a second geometry with a given tolerance.
+
+.. function:: shapely.ops.snap(geom1, geom2, tolerance)
+
+   Snaps vertices in `geom1` to vertices in the `geom2`. A copy of the snapped
+   geometry is returned. The input geometries are not modified.
+
+   The `tolerance` argument specifies the minimum distance between vertices for
+   them to be snapped.
+
+   `New in version 1.4.5`
+
+.. code-block:: pycon
+
+  >>> from shapely.ops import snap
+  >>> square = Polygon([(1,1), (2, 1), (2, 2), (1, 2), (1, 1)])
+  >>> line = LineString([(0,0), (0.8, 0.8), (1.8, 0.95), (2.6, 0.5)])
+  >>> result = snap(line, square, 0.5)
+  >>> result.wkt
+  'LINESTRING (0 0, 1 1, 2 1, 2.6 0.5)'
+
 Prepared Geometry Operations
 ----------------------------
 

--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -466,6 +466,10 @@ def prototype(lgeos, geos_version):
         lgeos.GEOSFree.restype = None
         lgeos.GEOSFree.argtypes = [c_void_p]
 
+    if geos_version >= (3, 3, 0):
+        lgeos.GEOSSnap.restype = c_void_p
+        lgeos.GEOSSnap.argtypes = [c_void_p, c_void_p, c_double]
+
     if geos_version >= (3, 4, 0):
         lgeos.GEOSNearestPoints.restype = c_void_p
         lgeos.GEOSNearestPoints.argtypes = [c_void_p, c_void_p]

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -721,6 +721,7 @@ class LGEOS330(LGEOS320):
         self.methods['unary_union'] = self.GEOSUnaryUnion
         self.methods['is_closed'] = self.GEOSisClosed
         self.methods['cascaded_union'] = self.methods['unary_union']
+        self.methods['snap'] = self.GEOSSnap
 
 
 class LGEOS340(LGEOS330):

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -275,3 +275,29 @@ def nearest_points(g1, g2):
     p1 = Point(x1.value, y1.value)
     p2 = Point(x2.value, y2.value)
     return (p1, p2)
+
+def snap(g1, g2, tolerance):
+    """Snap one geometry to another with a given tolerance
+
+    Vertices of the first geometry are snapped to vertices of the second
+    geometry. The resulting snapped geometry is returned. The input geometries
+    are not modified.
+
+    Parameters
+    ----------
+    g1 : geometry
+        The first geometry
+    g2 : geometry
+        The second geometry
+    tolerence : float
+        The snapping tolerance
+
+    Example
+    -------
+    >>> square = Polygon([(1,1), (2, 1), (2, 2), (1, 2), (1, 1)])
+    >>> line = LineString([(0,0), (0.8, 0.8), (1.8, 0.95), (2.6, 0.5)])
+    >>> result = snap(line, square, 0.5)
+    >>> result.wkt
+    'LINESTRING (0 0, 1 1, 2 1, 2.6 0.5)'
+    """
+    return(geom_factory(lgeos.methods['snap'](g1._geom, g2._geom, tolerance)))

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -1,0 +1,32 @@
+from . import unittest
+
+from shapely.geometry import LineString, Polygon
+from shapely.geos import geos_version
+from shapely.ops import snap
+
+@unittest.skipIf(geos_version < (3, 3, 0), 'GEOS 3.3.0 required')
+class Snap(unittest.TestCase):
+    def test_snap(self):
+        
+        # input geometries
+        square = Polygon([(1,1), (2, 1), (2, 2), (1, 2), (1, 1)])
+        line = LineString([(0,0), (0.8, 0.8), (1.8, 0.95), (2.6, 0.5)])
+                
+        square_coords = square.exterior.coords[:]
+        line_coords = line.coords[:]
+
+        result = snap(line, square, 0.5)
+
+        # test result is correct
+        self.assertTrue(isinstance(result, LineString))
+        self.assertEqual(result.coords[:], [(0.0, 0.0), (1.0, 1.0), (2.0, 1.0), (2.6, 0.5)])
+        
+        # test inputs have not been modified
+        self.assertEqual(square.exterior.coords[:], square_coords)
+        self.assertEqual(line.coords[:], line_coords)
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(Snap)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds support for the GEOSSnap function added in GEOS 3.3.0:

http://trac.osgeo.org/geos/browser/tags/3.4.2/NEWS#L175

Usage is given below. Documentation is included, and the manual has been updated (more work than the actual implementation, which is 6 lines...)

```
>>> square = Polygon([(1,1), (2, 1), (2, 2), (1, 2), (1, 1)])
>>> line = LineString([(0,0), (0.8, 0.8), (1.8, 0.95), (2.6, 0.5)])
>>> result = snap(line, square, 0.5)
>>> result.wkt
'LINESTRING (0 0, 1 1, 2 1, 2.6 0.5)'
```
