### PR TITLE
Updated manual: shapely.ops.snap added in 1.5.0, not 1.4.5

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2037,7 +2037,7 @@ one geometry to the vertices in a second geometry with a given tolerance.
    The `tolerance` argument specifies the minimum distance between vertices for
    them to be snapped.
 
-   `New in version 1.4.5`
+   `New in version 1.5.0`
 
 .. code-block:: pycon
 


### PR DESCRIPTION
Minor edit to manual.
