### PR TITLE
BaseGeometry.__array_interface__ use AttributeError instead of NotImplementedError as well (for numpy compat)

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -309,7 +309,7 @@ class BaseGeometry:
     @property
     def __array_interface__(self):
         """Provide the Numpy array protocol."""
-        raise NotImplementedError
+        raise AttributeError("Not implemented")
 
     # Coordinate access
     # -----------------

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -69,6 +69,16 @@ class EmptinessTestCase(unittest.TestCase):
         self.assertTrue(LinearRing(empty_generator()).is_empty)
 
 
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geoms = [BaseGeometry(), EmptyGeometry()]
+    arr = np.empty(2, object)
+    arr[:] = geoms
+
+
 def test_shape_empty():
     empty_mp = MultiPolygon()
     empty_json = mapping(empty_mp)


### PR DESCRIPTION
Follow-up on https://github.com/Toblerity/Shapely/pull/1174

@mwtoews you didn't to this in the original PR, because BaseGeometry is only an abstract base class. But actually, we do use it currently for "generic empty" object (in geopandas we are using `BaseGeometry()` for that, and Shapely now has a `EmptyGeometry()` that also basically returns a base geometry). Those for those corner cases, that can still give this warning from numpy, so I think it's best to just use AttributeError here as well.