### PR TITLE
Fix README.rst badges to the main-1.8 branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,14 @@ Shapely
 
 |github-actions| |appveyor| |coveralls|
 
-.. |github-actions| image:: https://github.com/Toblerity/Shapely/workflows/Tests%20(Linux)/badge.svg
-   :target: https://github.com/Toblerity/Shapely/actions
+.. |github-actions| image:: https://github.com/Toblerity/Shapely/workflows/Tests%20(Linux)/badge.svg?branch=maint-1.8
+   :target: https://github.com/Toblerity/Shapely/actions?query=branch%3Amaint-1.8
 
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/Toblerity/Shapely?branch=master&svg=true
-   :target: https://ci.appveyor.com/project/frsci/shapely?branch=master
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/Toblerity/Shapely?branch=maint-1.8&svg=true
+   :target: https://ci.appveyor.com/project/frsci/shapely?branch=maint-1.8
 
-.. |coveralls| image:: https://coveralls.io/repos/github/Toblerity/Shapely/badge.svg?branch=master
-   :target: https://coveralls.io/github/Toblerity/Shapely?branch=master
+.. |coveralls| image:: https://coveralls.io/repos/github/Toblerity/Shapely/badge.svg?branch=maint-1.8
+   :target: https://coveralls.io/github/Toblerity/Shapely?branch=maint-1.8
 
 Manipulation and analysis of geometric objects in the Cartesian plane.
 


### PR DESCRIPTION
Similar to #1209 and f3bbb907281ba420bc4aa47a0f078b5b38fb5f88, but for the `maint-1.8` maintenance branch.