### PR TITLE
Update MANIFEST.in to exclude *.c files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,8 @@ prune DLLs_AMD64
 prune DLLs_x86
 exclude *.txt
 exclude MANIFEST.in
-include CHANGES.txt CREDITS.txt LICENSE.txt README.rst VERSION.txt
+include CHANGES.txt CREDITS.txt LICENSE.txt README.rst
+include pyproject.toml
 recursive-include _vendor *.py
 recursive-include tests *.py *.txt
 recursive-include shapely/examples *.py
@@ -13,4 +14,5 @@ recursive-include shapely/speedups *.pyx
 recursive-include shapely/vectorized *.pyx
 recursive-include shapely *.pxi
 recursive-include shapely/DLLs *.dll *.rst *.txt
+recursive-exclude shapely *.c
 include docs/*.rst


### PR DESCRIPTION
This is similar to #1249 and somewhat fixes #1263 for shapely-1.8

It seems that cythonized C files were packaged in the source distribution, which is not what we want to have.