### PR TITLE
BUG: fix Polygon() constructor from a LineString

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -238,6 +238,9 @@ class Polygon(BaseGeometry):
                 # conversion of coords to 2D array failed, this might be due
                 # to inconsistent coordinate dimensionality
                 raise ValueError("Inconsistent coordinate dimensionality")
+        else:
+            if not isinstance(shell, LinearRing):
+                shell = LinearRing(shell)
 
         geom = shapely.polygons(shell, holes=holes)
         if not isinstance(geom, Polygon):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -238,9 +238,8 @@ class Polygon(BaseGeometry):
                 # conversion of coords to 2D array failed, this might be due
                 # to inconsistent coordinate dimensionality
                 raise ValueError("Inconsistent coordinate dimensionality")
-        else:
-            if not isinstance(shell, LinearRing):
-                shell = LinearRing(shell)
+        elif not isinstance(shell, LinearRing):
+            shell = LinearRing(shell)
 
         geom = shapely.polygons(shell, holes=holes)
         if not isinstance(geom, Polygon):

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -173,6 +173,18 @@ def test_polygon_from_linearring():
         assert polygon.interiors[i].coords[:] == holes[i].coords[:]
 
 
+def test_polygon_from_linestring():
+    coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]
+    line = LineString(coords)
+    polygon = Polygon(line)
+    assert polygon.exterior.coords[:] == coords
+
+    # from unclosed linestring
+    line = LineString(coords[:-1])
+    polygon = Polygon(line)
+    assert polygon.exterior.coords[:] == coords
+
+
 def test_polygon_from_polygon():
     coords = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)]
     polygon = Polygon(coords, [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])


### PR DESCRIPTION
Constructing a Polygon from a LineString worked before, but no longer on the main branch (noticed this while testing out shapely 2.0 with geopandas). This PR restores that behaviour.

For example with shapely 1.8:

```
In [3]: import shapely

In [4]: import shapely.geometry

In [5]: shapely.geometry.box(0,0,1,1)
Out[5]: <shapely.geometry.polygon.Polygon at 0x7f4ce490cfd0>

In [6]: shapely.geometry.box(0,0,1,1).boundary
Out[6]: <shapely.geometry.linestring.LineString at 0x7f4d36342d90>

In [7]: shapely.geometry.LinearRing(shapely.geometry.box(0,0,1,1).boundary)
Out[7]: <shapely.geometry.polygon.LinearRing at 0x7f4ce4868f10>

In [8]: shapely.geometry.Polygon(shapely.geometry.box(0,0,1,1).boundary)
Out[8]: <shapely.geometry.polygon.Polygon at 0x7f4ce4868490>

In [9]: shapely.__version__
Out[9]: '1.8.0'
```