### PR TITLE
Update manual version from 1.7.0 to 1.8.0

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -5,7 +5,7 @@ The Shapely User Manual
 =======================
 
 :Author: Sean Gillies, <sean.gillies@gmail.com>
-:Version: 1.7.0
+:Version: 1.8.0
 :Date: |today|
 :Copyright:
   This work is licensed under a `Creative Commons Attribution 3.0


### PR DESCRIPTION
Found a typo in the docs that listed the version as 1.7.0.