### PR TITLE
PERF: speed-up bounds function with GEOSGeom_getXMin et al (GEOS >= 3.7.0)

### DIFF
--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2547,6 +2547,30 @@ static void bounds_func(char** args, npy_intp* dimensions, npy_intp* steps, void
     if (in1 == NULL) { /* no geometry => bbox becomes (nan, nan, nan, nan) */
       *x1 = *y1 = *x2 = *y2 = NPY_NAN;
     } else {
+
+#if GEOS_SINCE_3_7_0
+      if (GEOSisEmpty_r(ctx, in1)) {
+        *x1 = *y1 = *x2 = *y2 = NPY_NAN;
+      }
+      else {
+        if (!GEOSGeom_getXMin_r(ctx, in1, x1)) {
+            errstate = PGERR_GEOS_EXCEPTION;
+            goto finish;
+        }
+        if (!GEOSGeom_getYMin_r(ctx, in1, y1)) {
+            errstate = PGERR_GEOS_EXCEPTION;
+            goto finish;
+        }
+        if (!GEOSGeom_getXMax_r(ctx, in1, x2)) {
+            errstate = PGERR_GEOS_EXCEPTION;
+            goto finish;
+        }
+        if (!GEOSGeom_getYMax_r(ctx, in1, y2)) {
+            errstate = PGERR_GEOS_EXCEPTION;
+            goto finish;
+        }
+      }
+#else
       /* construct the envelope */
       envelope = GEOSEnvelope_r(ctx, in1);
       if (envelope == NULL) {
@@ -2602,6 +2626,7 @@ static void bounds_func(char** args, npy_intp* dimensions, npy_intp* steps, void
       }
       GEOSGeom_destroy_r(ctx, envelope);
       envelope = NULL;
+#endif
     }
   }
 


### PR DESCRIPTION
Instead of going through `GEOSEnvelope` and getting the coordinates of that rectangular geometry object. This is simpler code, and quite a bit faster (it avoids the construction/destruction of the polygon object).

See https://github.com/libgeos/geos/pull/554 for context