### PR TITLE
TST: remove filterwarnings for numpy 1.21

### DIFF
--- a/shapely/tests/geometry/test_collection.py
+++ b/shapely/tests/geometry/test_collection.py
@@ -78,7 +78,6 @@ def test_len_raises(geometrycollection_geojson):
         len(geom)
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = GeometryCollection([LineString([(0, 0), (1, 1)])])
     ar = np.empty(1, object)

--- a/shapely/tests/geometry/test_emptiness.py
+++ b/shapely/tests/geometry/test_emptiness.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from shapely.geometry import (
     GeometryCollection,
@@ -63,7 +62,6 @@ class TestEmptiness:
         assert LinearRing(empty_generator()).is_empty
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geoms = [BaseGeometry(), EmptyGeometry()]
     arr = np.empty(2, object)

--- a/shapely/tests/geometry/test_linestring.py
+++ b/shapely/tests/geometry/test_linestring.py
@@ -85,7 +85,6 @@ def test_from_numpy():
     assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_linestring_coords():
     # Check empty
     line = LineString([])
@@ -94,7 +93,6 @@ def test_numpy_empty_linestring_coords():
     assert la.shape == (0, 2)
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = LineString([(0.0, 0.0), (0.0, 1.0)])
     ar = np.empty(1, object)

--- a/shapely/tests/geometry/test_multilinestring.py
+++ b/shapely/tests/geometry/test_multilinestring.py
@@ -72,7 +72,6 @@ class TestMultiLineString(MultiGeometryTestCase):
             MultiLineString([LineString([(0, 0), (1, 1), (2, 2)]), LineString()]).wkt
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = MultiLineString([[[5.0, 6.0], [7.0, 8.0]]])
     ar = np.empty(1, object)

--- a/shapely/tests/geometry/test_multipoint.py
+++ b/shapely/tests/geometry/test_multipoint.py
@@ -66,7 +66,6 @@ def test_multipoint_array_coercion():
     assert arr.item() == geom
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
     ar = np.empty(1, object)

--- a/shapely/tests/geometry/test_multipolygon.py
+++ b/shapely/tests/geometry/test_multipolygon.py
@@ -107,7 +107,6 @@ def test_fail_list_of_multipolygons():
         MultiPolygon([multi])
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = MultiPolygon(
         [

--- a/shapely/tests/geometry/test_point.py
+++ b/shapely/tests/geometry/test_point.py
@@ -160,7 +160,6 @@ def test_point_array_coercion():
     assert arr.item() == p
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_point_coords():
     pe = Point()
 
@@ -169,7 +168,6 @@ def test_numpy_empty_point_coords():
     assert a.shape == (0, 2)
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = Point(3.0, 4.0)
     ar = np.empty(1, object)

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -102,13 +102,11 @@ def test_numpy_linearring_coords():
     assert_array_equal(ra, expected)
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_linearring_coords():
     ring = LinearRing()
     assert np.asarray(ring.coords).shape == (0, 2)
 
 
-@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_object_array():
     geom = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])
     ar = np.empty(1, object)


### PR DESCRIPTION
Since the geometry objects are now no longer sequence-like objects / objects with an array interface, those objects should now interoperate fine with numpy arrays, and the warning should be no longer be raised.