### PR TITLE
Consolidate error class for unsupported GEOS version functionality

### DIFF
--- a/shapely/__init__.py
+++ b/shapely/__init__.py
@@ -2,7 +2,6 @@ from .lib import GEOSException  # NOQA
 from .lib import Geometry  # NOQA
 from .lib import geos_version, geos_version_string  # NOQA
 from .lib import geos_capi_version, geos_capi_version_string  # NOQA
-from .decorators import UnsupportedGEOSOperation  # NOQA
 from ._geometry import *  # NOQA
 from .creation import *  # NOQA
 from .constructive import *  # NOQA

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -4,10 +4,7 @@ from functools import wraps
 import numpy as np
 
 from . import lib
-
-
-class UnsupportedGEOSOperation(ImportError):
-    pass
+from .errors import UnsupportedGEOSVersionError
 
 
 class requires_geos:
@@ -35,7 +32,7 @@ class requires_geos:
 
             @wraps(func)
             def wrapped(*args, **kwargs):
-                raise UnsupportedGEOSOperation(msg)
+                raise UnsupportedGEOSVersionError(msg)
 
         doc = wrapped.__doc__
         if doc:

--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -7,7 +7,7 @@ class ShapelyError(Exception):
 
 
 class UnsupportedGEOSVersionError(ShapelyError):
-    """Raised when the system's GEOS library version is unsupported."""
+    """Raised when the GEOS library version does not support a certain operation."""
 
 
 class ReadingError(ShapelyError):

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -3,7 +3,8 @@ import numpy as np
 from . import box  # NOQA
 from . import Geometry  # NOQA
 from . import GeometryType, lib
-from .decorators import multithreading_enabled, requires_geos, UnsupportedGEOSOperation
+from .decorators import multithreading_enabled, requires_geos
+from .errors import UnsupportedGEOSVersionError
 
 __all__ = [
     "difference",
@@ -65,7 +66,9 @@ def difference(a, b, grid_size=None, **kwargs):
 
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSOperation("grid_size parameter requires GEOS >= 3.9.0")
+            raise UnsupportedGEOSVersionError(
+                "grid_size parameter requires GEOS >= 3.9.0"
+            )
 
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
@@ -119,7 +122,9 @@ def intersection(a, b, grid_size=None, **kwargs):
 
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSOperation("grid_size parameter requires GEOS >= 3.9.0")
+            raise UnsupportedGEOSVersionError(
+                "grid_size parameter requires GEOS >= 3.9.0"
+            )
 
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
@@ -209,7 +214,9 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
 
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSOperation("grid_size parameter requires GEOS >= 3.9.0")
+            raise UnsupportedGEOSVersionError(
+                "grid_size parameter requires GEOS >= 3.9.0"
+            )
 
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
@@ -300,7 +307,9 @@ def union(a, b, grid_size=None, **kwargs):
 
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSOperation("grid_size parameter requires GEOS >= 3.9.0")
+            raise UnsupportedGEOSVersionError(
+                "grid_size parameter requires GEOS >= 3.9.0"
+            )
 
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
@@ -377,7 +386,9 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
 
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSOperation("grid_size parameter requires GEOS >= 3.9.0")
+            raise UnsupportedGEOSVersionError(
+                "grid_size parameter requires GEOS >= 3.9.0"
+            )
 
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -102,7 +102,7 @@ def test_requires_geos_ok(version, mocked_geos_version):
 @pytest.mark.parametrize("version", ["3.7.2", "3.8.0", "3.8.1"])
 def test_requires_geos_not_ok(version, mocked_geos_version):
     wrapped = requires_geos(version)(func)
-    with pytest.raises(shapely.UnsupportedGEOSOperation):
+    with pytest.raises(shapely.errors.UnsupportedGEOSVersionError):
         wrapped()
 
     assert wrapped.__doc__ == expected_docstring.format(version=version, indent=" " * 4)

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -3,7 +3,7 @@ import pytest
 
 import shapely
 from shapely import Geometry
-from shapely.decorators import UnsupportedGEOSOperation
+from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 
 from .common import all_types, multi_polygon, point, polygon
@@ -57,7 +57,7 @@ def test_set_operation_array(a, func):
 @pytest.mark.parametrize("grid_size", [0, 1])
 def test_set_operations_prec_not_supported(func, grid_size):
     with pytest.raises(
-        UnsupportedGEOSOperation, match="grid_size parameter requires GEOS >= 3.9.0"
+        UnsupportedGEOSVersionError, match="grid_size parameter requires GEOS >= 3.9.0"
     ):
         func(point, point, grid_size)
 
@@ -158,7 +158,7 @@ def test_set_operation_reduce_all_none_arr(n, func, related_func):
 @pytest.mark.parametrize("grid_size", [0, 1])
 def test_set_operation_prec_reduce_not_supported(func, related_func, grid_size):
     with pytest.raises(
-        UnsupportedGEOSOperation, match="grid_size parameter requires GEOS >= 3.9.0"
+        UnsupportedGEOSVersionError, match="grid_size parameter requires GEOS >= 3.9.0"
     ):
         func([point, point], grid_size)
 

--- a/shapely/tests/test_strtree.py
+++ b/shapely/tests/test_strtree.py
@@ -7,7 +7,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import shapely
-from shapely import box, UnsupportedGEOSOperation
+from shapely import box
+from shapely.errors import UnsupportedGEOSVersionError
 
 from .common import (
     assert_decreases_refcount,
@@ -1002,7 +1003,7 @@ def test_query_contains_properly_polygons(poly_tree, geometry, expected):
 
 @pytest.mark.skipif(shapely.geos_version >= (3, 10, 0), reason="GEOS >= 3.10")
 def test_query_dwithin_geos_version(tree):
-    with pytest.raises(UnsupportedGEOSOperation, match="requires GEOS >= 3.10"):
+    with pytest.raises(UnsupportedGEOSVersionError, match="requires GEOS >= 3.10"):
         tree.query(shapely.points(0, 0), predicate="dwithin", distance=1)
 
 
@@ -1377,7 +1378,7 @@ def test_query_bulk_predicate_errors(tree):
 
 @pytest.mark.skipif(shapely.geos_version >= (3, 10, 0), reason="GEOS >= 3.10")
 def test_query_bulk_dwithin_geos_version(tree):
-    with pytest.raises(UnsupportedGEOSOperation, match="requires GEOS >= 3.10"):
+    with pytest.raises(UnsupportedGEOSVersionError, match="requires GEOS >= 3.10"):
         tree.query_bulk(shapely.points(0, 0), predicate="dwithin", distance=1)
 
 


### PR DESCRIPTION
We had two classes as a left-over from the merger. I removed the top-level one (from pygeos) and used the one in the `shapely.errors` submodule.