### PR TITLE
CLN: remove no longer used custom error classes

### DIFF
--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -10,28 +10,12 @@ class UnsupportedGEOSVersionError(ShapelyError):
     """Raised when the system's GEOS library version is unsupported."""
 
 
-class ReadingError(ShapelyError):
-    """A WKT or WKB reading error."""
-
-
-class WKBReadingError(ReadingError):
-    """A WKB reading error."""
-
-
-class WKTReadingError(ReadingError):
-    """A WKT reading error."""
-
-
 class DimensionError(ShapelyError):
     """An error in the number of coordinate dimensions."""
 
 
 class TopologicalError(ShapelyError):
     """A geometry is invalid or topologically incorrect."""
-
-
-class PredicateError(ShapelyError):
-    """A geometric predicate has failed to return True/False."""
 
 
 class ShapelyDeprecationWarning(FutureWarning):
@@ -54,20 +38,6 @@ class GeometryTypeError(ShapelyError, TypeError, ValueError):
     def __init__(self, msg):
         warnings.warn(
             "GeometryTypeError will derive from ShapelyError and not TypeError or ValueError in Shapely 2.0.",
-            ShapelyDeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(msg)
-
-
-class InvalidGeometryError(ShapelyError, TypeError, ValueError):
-    """
-    An error raised when an operation is attempted on a null geometry
-    """
-
-    def __init__(self, msg):
-        warnings.warn(
-            "InvalidGeometryError will derive from ShapelyError and not TypeError or ValueError in Shapely 2.0.",
             ShapelyDeprecationWarning,
             stacklevel=2,
         )

--- a/shapely/wkb.py
+++ b/shapely/wkb.py
@@ -11,7 +11,7 @@ def loads(data, hex=False):
 
     Raises
     ------
-    WKBReadingError, UnicodeDecodeError
+    GEOSException, UnicodeDecodeError
         If ``data`` contains an invalid geometry.
     """
     return shapely.from_wkb(data)
@@ -22,7 +22,7 @@ def load(fp, hex=False):
 
     Raises
     ------
-    WKBReadingError, UnicodeDecodeError
+    GEOSException, UnicodeDecodeError
         If the given file contains an invalid geometry.
     """
     data = fp.read()

--- a/tests/test_geos_err_handler.py
+++ b/tests/test_geos_err_handler.py
@@ -5,7 +5,6 @@ import pytest
 import shapely
 
 from shapely.geometry import LineString
-from shapely.errors import ReadingError
 from shapely.wkt import loads
 
 from tests.conftest import shapely20_todo
@@ -21,7 +20,7 @@ def test_error_handler_exception(tmpdir):
 
     # This calls error_handler with a format string of "%s" and one
     # value.
-    with pytest.raises((ReadingError, shapely.GEOSException)):
+    with pytest.raises(shapely.GEOSException):
         loads('POINT (LOLWUT)')
 
     log = open(logfile).read()

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -2,7 +2,6 @@
 """
 from . import unittest
 from shapely.geometry import Point, Polygon
-from shapely.errors import TopologicalError, PredicateError
 import pytest
 
 import shapely

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -6,7 +6,6 @@ import sys
 import pytest
 
 from shapely import wkt
-from shapely.errors import WKBReadingError
 from shapely.geometry import Point
 from shapely.geos import geos_version
 from shapely.wkb import dumps, loads, dump, load
@@ -129,7 +128,7 @@ def test_dump_hex_load_binary(some_point, tmpdir):
     with open(file, "w") as file_pointer:
         dump(some_point, file_pointer, hex=True)
 
-    with pytest.raises(WKBReadingError):
+    with pytest.raises(TypeError):
         with open(file, "rb") as file_pointer:
             load(file_pointer)
 
@@ -148,7 +147,7 @@ def test_dump_binary_load_hex(some_point, tmpdir):
         assert some_point != restored
         return
 
-    with pytest.raises((WKBReadingError, UnicodeEncodeError, UnicodeDecodeError)):
+    with pytest.raises((UnicodeEncodeError, UnicodeDecodeError)):
         with open(file, "r") as file_pointer:
             load(file_pointer, hex=True)
 


### PR DESCRIPTION
Related to the discussion in https://github.com/shapely/shapely/issues/991

This removes some custom exception subclasses that are no longer used after the merge with pygeos (eg reading invalid WKB or WKT now raises a GEOSException)