### PR TITLE
Note about collections not preserving order

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -636,6 +636,10 @@ Collections can also be sliced.
   When possible, it is better to use one of the homogeneous collection types
   described below.
 
+.. note::
+
+  Collections are not guaranteed to preserve the order of their elements.
+
 .. _multipoints:
 
 Collections of Points


### PR DESCRIPTION
Addresses #696 and #703

`MultiPoint` not preserving the insert order has gotten me a few times and I think a note of this in the docs could be helpful. 

I'm not aware of any collections that guarantee honoring the insert order but if there are than maybe this note would be better placed in the individual collection types that don't honor order?