### PR TITLE
REF: Move ShapelyError base class to C, GEOSException becomes subclass

### DIFF
--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -1,9 +1,7 @@
 """Shapely errors."""
 import warnings
 
-
-class ShapelyError(Exception):
-    """Base error class."""
+from shapely.lib import GEOSException, ShapelyError  # NOQA
 
 
 class UnsupportedGEOSVersionError(ShapelyError):

--- a/src/geos.c
+++ b/src/geos.c
@@ -12,7 +12,9 @@
 PyObject* geos_exception[1] = {NULL};
 
 int init_geos(PyObject* m) {
-  geos_exception[0] = PyErr_NewException("shapely.GEOSException", NULL, NULL);
+  PyObject* base_class = PyErr_NewException("shapely.errors.ShapelyError", NULL, NULL);
+  PyModule_AddObject(m, "ShapelyError", base_class);
+  geos_exception[0] = PyErr_NewException("shapely.errors.GEOSException", base_class, NULL);
   PyModule_AddObject(m, "GEOSException", geos_exception[0]);
   return 0;
 }


### PR DESCRIPTION
See https://github.com/shapely/shapely/pull/1306#issuecomment-1032362619, and related to discussion in https://github.com/shapely/shapely/issues/991