### PR TITLE
Add aliases for project/interpolate/representative_point methods

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -274,8 +274,18 @@ class BaseGeometry(shapely.Geometry):
         """Returns the geometric center of the object"""
         return shapely.centroid(self)
 
+    def point_on_surface(self):
+        """Returns a point guaranteed to be within the object, cheaply.
+
+        Alias of `representative_point`.
+        """
+        return shapely.point_on_surface(self)
+
     def representative_point(self):
-        """Returns a point guaranteed to be within the object, cheaply."""
+        """Returns a point guaranteed to be within the object, cheaply.
+
+        Alias of `point_on_surface`.
+        """
         return shapely.point_on_surface(self)
 
     @property
@@ -667,14 +677,40 @@ class BaseGeometry(shapely.Geometry):
     # Linear referencing
     # ------------------
 
+    def line_locate_point(self, other, normalized=False):
+        """Returns the distance along this geometry to a point nearest the
+        specified point
+
+        If the normalized arg is True, return the distance normalized to the
+        length of the linear geometry.
+
+        Alias of `project`.
+        """
+        return shapely.line_locate_point(self, other, normalized=normalized)
+
     def project(self, other, normalized=False):
         """Returns the distance along this geometry to a point nearest the
         specified point
 
         If the normalized arg is True, return the distance normalized to the
         length of the linear geometry.
+
+        Alias of `line_locate_point`.
         """
         return shapely.line_locate_point(self, other, normalized=normalized)
+
+    def line_interpolate_point(self, distance, normalized=False):
+        """Return a point at the specified distance along a linear geometry
+
+        Negative length values are taken as measured in the reverse
+        direction from the end of the geometry. Out-of-range index
+        values are handled by clamping them to the valid range of values.
+        If the normalized arg is True, the distance will be interpreted as a
+        fraction of the geometry's length.
+
+        Alias of `interpolate`.
+        """
+        return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
     def interpolate(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry
@@ -684,6 +720,8 @@ class BaseGeometry(shapely.Geometry):
         values are handled by clamping them to the valid range of values.
         If the normalized arg is True, the distance will be interpreted as a
         fraction of the geometry's length.
+
+        Alias of `line_interpolate_point`.
         """
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 

--- a/tests/test_linear_referencing.py
+++ b/tests/test_linear_referencing.py
@@ -19,6 +19,10 @@ class LinearReferencingTestCase(unittest.TestCase):
         self.assertEqual(self.line1.project(self.point), 1.0)
         self.assertEqual(self.line1.project(self.point, normalized=True), 0.5)
 
+    def test_alias_project(self):
+        self.assertEqual(self.line1.line_locate_point(self.point), 1.0)
+        self.assertEqual(self.line1.line_locate_point(self.point, normalized=True), 0.5)
+
     def test_line2_project(self):
         self.assertEqual(self.line2.project(self.point), 1.0)
         self.assertAlmostEqual(
@@ -44,6 +48,14 @@ class LinearReferencingTestCase(unittest.TestCase):
             self.line1.interpolate(0.5, normalized=True).equals(Point(1, 0)))
         self.assertTrue(
             self.line1.interpolate(-0.5, normalized=True).equals(Point(1, 0)))
+
+    def test_alias_interpolate(self):
+        self.assertTrue(self.line1.line_interpolate_point(0.5).equals(Point(0.5, 0.0)))
+        self.assertTrue(self.line1.line_interpolate_point(-0.5).equals(Point(1.5, 0.0)))
+        self.assertTrue(
+            self.line1.line_interpolate_point(0.5, normalized=True).equals(Point(1, 0)))
+        self.assertTrue(
+            self.line1.line_interpolate_point(-0.5, normalized=True).equals(Point(1, 0)))
 
     def test_line2_interpolate(self):
         self.assertTrue(self.line2.interpolate(0.5).equals(Point(3.0, 0.5)))

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -63,6 +63,8 @@ class OperationsTestCase(unittest.TestCase):
         self.assertIsInstance(point.union(Point(-1, 1)), MultiPoint)
 
         self.assertIsInstance(point.representative_point(), Point)
+        self.assertIsInstance(point.point_on_surface(), Point)
+        self.assertEqual(point.representative_point(), point.point_on_surface())
 
         self.assertIsInstance(point.centroid, Point)
 


### PR DESCRIPTION
One possible solution for part of https://github.com/shapely/shapely/issues/1276