### PR TITLE
CI: upgrade GEOS 3.10.1 (2021-11-02) to 3.10.2 (2022-01-15)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.10.1"
+      GEOS_VERSION: "3.10.2"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.1, main]
+        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.2, main]
         include:
           # 2017
           - python: 3.6
@@ -34,7 +34,7 @@ jobs:
             numpy: 1.19.5
           # 2021
           - python: "3.10"
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.21.3
             # TODO(shapely-2.0) temporary allow warnings
             # extra_pytest_args: "-W error"  # error on warnings
@@ -51,7 +51,7 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: 3.9
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.19.5
 
     env:


### PR DESCRIPTION
Upgrade GEOS used in the CI to [3.10.2 released 2022-01-15](https://lists.osgeo.org/pipermail/geos-devel/2022-January/010638.html)