### PR TITLE
maint-1.8 CI: upgrade GEOS 3.10.1 (2021-11-02) to 3.10.2 (2022-01-15)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.1]
+        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.2]
         include:
           # 2017
           - python: 3.6
@@ -66,15 +66,15 @@ jobs:
             speedups: 0
           # 2021
           - python: "3.10"
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.21.3
             speedups: 1
           - python: "3.10"
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.21.3
             speedups: 0
           - python: "3.10"
-            geos: 3.10.1
+            geos: 3.10.2
             speedups: 0
           # enable two 32-bit windows builds
           - os: windows-2019
@@ -86,7 +86,7 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: 3.9
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.19.5
             speeedups: 1
 


### PR DESCRIPTION
Upgrade GEOS used in the CI for the `maint-1.8` maintenance branch to [3.10.2 released 2022-01-15](https://lists.osgeo.org/pipermail/geos-devel/2022-January/010638.html)