### PR TITLE
TST: update tests to pass with numpy 1.22 and pytest 8

### DIFF
--- a/shapely/tests/geometry/test_linestring.py
+++ b/shapely/tests/geometry/test_linestring.py
@@ -106,14 +106,11 @@ def test_from_invalid_dim():
     with pytest.raises(shapely.GEOSException):
         LineString([(1, 2)])
 
-    with pytest.raises(
-        ValueError, match="Input operand 0 does not have enough dimensions"
-    ):
+    # exact error depends on numpy version
+    with pytest.raises((ValueError, TypeError)):
         LineString([(1, 2, 3), (4, 5)])
 
-    with pytest.raises(
-        ValueError, match="Input operand 0 does not have enough dimensions"
-    ):
+    with pytest.raises((ValueError, TypeError)):
         LineString([(1, 2), (3, 4, 5)])
 
     msg = r"The ordinate \(last\) dimension should be 2 or 3, got {}"

--- a/shapely/tests/geometry/test_linestring.py
+++ b/shapely/tests/geometry/test_linestring.py
@@ -100,6 +100,7 @@ def test_numpy_object_array():
     assert ar[0] == geom
 
 
+@pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences:")
 def test_from_invalid_dim():
     # TODO(shapely-2.0) better error message?
     # pytest.raises(ValueError, match="at least 2 coordinate tuples|at least 2 coordinates"):

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1,6 +1,7 @@
 import json
 import pickle
 import struct
+import warnings
 
 import numpy as np
 import pytest
@@ -175,10 +176,12 @@ def test_from_wkt_warn_on_invalid():
 
 
 def test_from_wkb_ignore_on_invalid():
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         shapely.from_wkt("", on_invalid="ignore")
 
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         shapely.from_wkt("NOT A WKT STRING", on_invalid="ignore")
 
 
@@ -257,13 +260,13 @@ def test_from_wkb_warn_on_invalid_warn():
 
 def test_from_wkb_ignore_on_invalid_ignore():
     # invalid WKB
-    with pytest.warns(None) as w:
+    with pytest.warns() as w:
         result = shapely.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="ignore")
         assert result is None
         assert len(w) == 0  # no warning
 
     # invalid ring in WKB
-    with pytest.warns(None) as w:
+    with pytest.warns() as w:
         result = shapely.from_wkb(INVALID_WKB, on_invalid="ignore")
         assert result is None
         assert len(w) == 0  # no warning
@@ -670,7 +673,8 @@ def test_from_geojson_warn_on_invalid():
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 1), reason="GEOS < 3.10.1")
 def test_from_geojson_ignore_on_invalid():
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         assert shapely.from_geojson("", on_invalid="ignore") is None
 
 

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -260,16 +260,16 @@ def test_from_wkb_warn_on_invalid_warn():
 
 def test_from_wkb_ignore_on_invalid_ignore():
     # invalid WKB
-    with pytest.warns() as w:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning
         result = shapely.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="ignore")
         assert result is None
-        assert len(w) == 0  # no warning
 
     # invalid ring in WKB
-    with pytest.warns() as w:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning
         result = shapely.from_wkb(INVALID_WKB, on_invalid="ignore")
         assert result is None
-        assert len(w) == 0  # no warning
 
 
 def test_from_wkb_on_invalid_unsupported_option():

--- a/tests/test_create_inconsistent_dimensionality.py
+++ b/tests/test_create_inconsistent_dimensionality.py
@@ -44,16 +44,17 @@ wkt_cases = [
 
 @pytest.mark.parametrize('geojson', geojson_cases)
 def test_create_from_geojson(geojson):
-    with pytest.raises(ValueError) as exc:
+    # exact error depends on numpy version
+    with pytest.raises((ValueError, TypeError)) as exc:
         wkt = shape(geojson).wkt
-    assert exc.match("Inconsistent coordinate dimensionality|Input operand 0 does not have enough dimensions")
+    assert exc.match("Inconsistent coordinate dimensionality|Input operand 0 does not have enough dimensions|ufunc 'linestrings' not supported for the input types")
 
 
 @pytest.mark.parametrize('constructor, args', direct_cases)
 def test_create_directly(constructor, args):
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises((ValueError, TypeError)) as exc:
         geom = constructor(*args)
-    assert exc.match("Inconsistent coordinate dimensionality|Input operand 0 does not have enough dimensions")
+    assert exc.match("Inconsistent coordinate dimensionality|Input operand 0 does not have enough dimensions|ufunc 'linestrings' not supported for the input types")
 
 
 @pytest.mark.parametrize('wkt_geom,expected', wkt_cases)

--- a/tests/test_create_inconsistent_dimensionality.py
+++ b/tests/test_create_inconsistent_dimensionality.py
@@ -42,6 +42,7 @@ wkt_cases = [
 ]
 
 
+@pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences:")
 @pytest.mark.parametrize('geojson', geojson_cases)
 def test_create_from_geojson(geojson):
     # exact error depends on numpy version
@@ -50,6 +51,7 @@ def test_create_from_geojson(geojson):
     assert exc.match("Inconsistent coordinate dimensionality|Input operand 0 does not have enough dimensions|ufunc 'linestrings' not supported for the input types")
 
 
+@pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences:")
 @pytest.mark.parametrize('constructor, args', direct_cases)
 def test_create_directly(constructor, args):
     with pytest.raises((ValueError, TypeError)) as exc:


### PR DESCRIPTION
Numpy 1.22 starts to check the dtype of an array before the dimensionality, and so when passing a 1D object array into a ufunc that expects a 2+D array, we now get a TypeError instead of a ValueError (and this 1D object array comes from passing an inconsistent dimensioned list of coordinates).

We have numpy 1.22 on the build with GEOS main, but the failures were not visible because that build allows failures .. (there are more failures related to GEOS that would need to be fixed first)

