### PR TITLE
DEPR: deprecate the GeometryType attribute

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -169,6 +169,12 @@ class BaseGeometry(shapely.Geometry):
     # ----------------------------------------
 
     def geometryType(self):
+        warn(
+            "The 'GeometryType()' method is deprecated, and will be removed in "
+            "the future. You can use the 'geom_type' attribute instead.",
+            ShapelyDeprecationWarning,
+            stacklevel=2,
+        )
         return self.geom_type
 
     @property

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -11,6 +11,7 @@ from shapely import (
     Point,
     Polygon,
 )
+from shapely.errors import ShapelyDeprecationWarning
 
 
 def test_polygon():
@@ -73,3 +74,12 @@ def test_comparison_notimplemented(geom):
     result = geom != arr
     assert isinstance(result, np.ndarray)
     assert not result.any()
+
+
+def test_GeometryType_deprecated():
+    geom = Point(1, 1)
+
+    with pytest.warns(ShapelyDeprecationWarning):
+        geom_type = geom.geometryType()
+
+    assert geom_type == geom.geom_type


### PR DESCRIPTION
Part of https://github.com/shapely/shapely/issues/975. This PR already deprecates the `GeometryType()` method, which isn't used internally or used in the documentation.