### PR TITLE
CI: only build Travis on the main branch (not PRs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: focal
 language: python
 python: '3.8'
 
+if: branch = main OR tag IS present
+
 env:
   global:
   - GEOS_VERSION=3.10.1
@@ -27,13 +29,6 @@ jobs:
     - CIBW_BEFORE_ALL="./ci/install_geos.sh"
     - CIBW_TEST_REQUIRES="pytest"
     - CIBW_TEST_COMMAND="pytest --pyargs shapely.tests"
-
-
-branches:
-  only:
-  - main
-  - travis
-  - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: focal
 language: python
 python: '3.8'
 
-if: branch = main OR tag IS present
+if: (branch = main OR tag IS present) AND (type = push)
 
 env:
   global:


### PR DESCRIPTION
Given that we have only limited "credits" for Travis, we can best limit the number of builds, and for example not build on _every_ commit in a PR.

Using the conditions from https://docs.travis-ci.com/user/conditions-v1

Will additionally check if we can still run it when we edit eg the build configuration (as we detect with github actions)