### PR TITLE
CI: fix tests with latest setuptools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Build and install Shapely
         run: |
-          pip install .
+          pip install -e .
 
       - name: Overview of the Python environment (pip list)
         run: pip list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,8 +143,7 @@ jobs:
 
       - name: Build and install Shapely
         run: |
-          python setup.py build_ext --inplace
-          pip install . --no-build-isolation
+          pip install .
 
       - name: Overview of the Python environment (pip list)
         run: pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
 source = ["shapely"]

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ from pkg_resources import parse_version
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
+# ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(os.path.dirname(__file__))
 import versioneer
 
 # Skip Cython build if not available


### PR DESCRIPTION
Tests are failing on the main branch. It might be that setuptools broke something (that's the only thing that I notice that is different with the passing build of 4 days ago, a version update of setuptools of 62.1 -> 62.2), although I don't directly see anything mentioned in their changelog that would explain this (https://setuptools.pypa.io/en/latest/history.html#v62-2-0). It seems that it no longer ignores the packages listed in pyproject.toml, even when directly calling `python setup.py build_ext`.