### PR TITLE
Improved test_minimum_rotated_rectangle.py 

### DIFF
--- a/tests/test_minimum_rotated_rectangle.py
+++ b/tests/test_minimum_rotated_rectangle.py
@@ -2,14 +2,14 @@ from . import unittest
 from shapely import geometry
 
 class MinimumRotatedRectangleTestCase(unittest.TestCase):
-    
+
     def test_minimum_rectangle(self):
         poly = geometry.Polygon([(0,1), (1, 2), (2, 1), (1, 0), (0, 1)])
         rect = poly.minimum_rotated_rectangle
         self.assertIsInstance(rect, geometry.Polygon)
         self.assertEqual(rect.area - poly.area < 0.1, True)
         self.assertEqual(len(rect.exterior.coords), 5)
-        
+
         ls = geometry.LineString([(0,1), (1, 2), (2, 1), (1, 0)])
         rect = ls.minimum_rotated_rectangle
         self.assertIsInstance(rect, geometry.Polygon)
@@ -17,13 +17,26 @@ class MinimumRotatedRectangleTestCase(unittest.TestCase):
         self.assertEqual(len(rect.exterior.coords), 5)
 
     def test_degenerate(self):
-        rect = geometry.Point((0,1)).minimum_rotated_rectangle
-        self.assertIsInstance(rect, geometry.Point)
-        self.assertEqual(len(rect.coords), 1)
-        self.assertEqual(rect.coords[0], (0,1))
+        # point
+        rect1 = geometry.Point((0,1)).minimum_rotated_rectangle
+        self.assertIsInstance(rect1, geometry.Point)
+        self.assertEqual(len(rect1.coords), 1)
+        self.assertEqual(rect1.coords[0], (0,1))
 
-        rect = geometry.LineString([(0,0),(2,2)]).minimum_rotated_rectangle
-        self.assertIsInstance(rect, geometry.LineString)
-        self.assertEqual(len(rect.coords), 2)
-        self.assertEqual(rect.coords[0], (0,0))
-        self.assertEqual(rect.coords[1], (2,2))
+        # invalid linestring: point
+        rect2 = geometry.LineString([(0,1), (0,1), (0,1)]).minimum_rotated_rectangle
+        self.assertIsInstance(rect2, geometry.Point)
+        self.assertEqual(len(rect2.coords), 1)
+        self.assertEqual(rect2.coords[0], (0,1))
+
+        # linestring
+        rect3 = geometry.LineString([(0,0), (2,2)]).minimum_rotated_rectangle
+        self.assertIsInstance(rect3, geometry.LineString)
+        self.assertEqual(len(rect3.coords), 2)
+        self.assertSetEqual(set(rect3.coords), set([(0,0), (2,2)]))
+
+        # complex linestring
+        rect4 = geometry.LineString([(2,2), (0,0), (-2,-2)]).minimum_rotated_rectangle
+        self.assertIsInstance(rect4, geometry.LineString)
+        self.assertEqual(len(rect4.coords), 2)
+        self.assertSetEqual(set(rect4.coords), set([(2,2), (-2,-2)]))

--- a/tests/test_minimum_rotated_rectangle.py
+++ b/tests/test_minimum_rotated_rectangle.py
@@ -4,13 +4,13 @@ from shapely import geometry
 class MinimumRotatedRectangleTestCase(unittest.TestCase):
 
     def test_minimum_rectangle(self):
-        poly = geometry.Polygon([(0,1), (1, 2), (2, 1), (1, 0), (0, 1)])
+        poly = geometry.Polygon([(0, 1), (1, 2), (2, 1), (1, 0), (0, 1)])
         rect = poly.minimum_rotated_rectangle
         self.assertIsInstance(rect, geometry.Polygon)
         self.assertEqual(rect.area - poly.area < 0.1, True)
         self.assertEqual(len(rect.exterior.coords), 5)
 
-        ls = geometry.LineString([(0,1), (1, 2), (2, 1), (1, 0)])
+        ls = geometry.LineString([(0, 1), (1, 2), (2, 1), (1, 0)])
         rect = ls.minimum_rotated_rectangle
         self.assertIsInstance(rect, geometry.Polygon)
         self.assertEqual(rect.area - ls.convex_hull.area < 0.1, True)
@@ -18,25 +18,31 @@ class MinimumRotatedRectangleTestCase(unittest.TestCase):
 
     def test_degenerate(self):
         # point
-        rect1 = geometry.Point((0,1)).minimum_rotated_rectangle
+        rect1 = geometry.Point((0, 1)).minimum_rotated_rectangle
         self.assertIsInstance(rect1, geometry.Point)
         self.assertEqual(len(rect1.coords), 1)
-        self.assertEqual(rect1.coords[0], (0,1))
+        self.assertEqual(rect1.coords[0], (0, 1))
 
         # invalid linestring: point
-        rect2 = geometry.LineString([(0,1), (0,1), (0,1)]).minimum_rotated_rectangle
+        rect2 = geometry.LineString([(0, 1), (0, 1), (0, 1)]).minimum_rotated_rectangle
         self.assertIsInstance(rect2, geometry.Point)
         self.assertEqual(len(rect2.coords), 1)
-        self.assertEqual(rect2.coords[0], (0,1))
+        self.assertEqual(rect2.coords[0], (0, 1))
 
         # linestring
-        rect3 = geometry.LineString([(0,0), (2,2)]).minimum_rotated_rectangle
+        rect3 = geometry.LineString([(0, 0), (2, 2)]).minimum_rotated_rectangle
         self.assertIsInstance(rect3, geometry.LineString)
         self.assertEqual(len(rect3.coords), 2)
-        self.assertSetEqual(set(rect3.coords), set([(0,0), (2,2)]))
+        self.assertSetEqual(set(rect3.coords), set([(0, 0), (2, 2)]))
 
-        # complex linestring
-        rect4 = geometry.LineString([(2,2), (0,0), (-2,-2)]).minimum_rotated_rectangle
+        # linestring2
+        rect4 = geometry.LineString([(2, 2), (0, 0), (-2, -2)]).minimum_rotated_rectangle
         self.assertIsInstance(rect4, geometry.LineString)
         self.assertEqual(len(rect4.coords), 2)
-        self.assertSetEqual(set(rect4.coords), set([(2,2), (-2,-2)]))
+        self.assertSetEqual(set(rect4.coords), set([(2, 2), (-2, -2)]))
+
+        # complex linestring
+        rect5 = geometry.LineString([(2, 2), (-2, -2), (0, 0)]).minimum_rotated_rectangle
+        self.assertIsInstance(rect5, geometry.LineString)
+        self.assertEqual(len(rect5.coords), 2)
+        self.assertSetEqual(set(rect5.coords), set([(2, 2), (-2, -2)]))

--- a/tests/test_minimum_rotated_rectangle.py
+++ b/tests/test_minimum_rotated_rectangle.py
@@ -16,7 +16,7 @@ class MinimumRotatedRectangleTestCase(unittest.TestCase):
         self.assertEqual(rect.area - ls.convex_hull.area < 0.1, True)
         self.assertEqual(len(rect.exterior.coords), 5)
 
-    def test_digenerate(self):
+    def test_degenerate(self):
         rect = geometry.Point((0,1)).minimum_rotated_rectangle
         self.assertIsInstance(rect, geometry.Point)
         self.assertEqual(len(rect.coords), 1)


### PR DESCRIPTION
- fixed typo: digenerate -> degenerate
- added more tests
- compare set of coords of linestring, instead of specific points in coords