### PR TITLE
Change simplify() preserve_topology default to True (match the Geometry method)

### DIFF
--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -709,7 +709,7 @@ def segmentize(geometry, tolerance, **kwargs):
 
 
 @multithreading_enabled
-def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
+def simplify(geometry, tolerance, preserve_topology=True, **kwargs):
     """Returns a simplified version of an input geometry using the
     Douglas-Peucker algorithm.
 
@@ -720,7 +720,9 @@ def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
         The maximum allowed geometry displacement. The higher this value, the
         smaller the number of vertices in the resulting geometry.
     preserve_topology : bool, default False
-        If set to True, the operation will avoid creating invalid geometries.
+        By default (True), the operation will avoid creating invalid
+        geometries (checking for collapses, ring-intersections, etc), but
+        this is computationally more expensive.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.


### PR DESCRIPTION
xref https://github.com/shapely/shapely/issues/1276

The Geometry class' `simplify()` method has a default of `preserve_topology=True`, while the vectorized function from pygeos was using `True`. But I think we have been thinking in the past we should probably move to `True` anyway (to return valid geometries by default, eg https://github.com/pygeos/pygeos/issues/233#issuecomment-943856854), and that also ensures that the function and geometry class method use a consistent default.