### PR TITLE
DOC: replace pygeos -> shapely in the reference docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,7 +233,7 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
 }
 
-# set an environment variable for pygeos.decorators.requires_geos to see if we
+# set an environment variable for shapely.decorators.requires_geos to see if we
 # are in a doc build
 import os
 os.environ["SPHINX_DOC_BUILD"] = "1"

--- a/docs/constructive.rst
+++ b/docs/constructive.rst
@@ -1,7 +1,7 @@
 Constructive operations
 =======================
 
-.. automodule:: pygeos.constructive
+.. automodule:: shapely.constructive
    :members:
    :exclude-members: BufferCapStyles, BufferJoinStyles, minimum_rotated_rectangle
    :special-members:

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -1,7 +1,7 @@
 Coordinate operations
 =====================
 
-.. automodule:: pygeos.coordinates
+.. automodule:: shapely.coordinates
    :members:
    :undoc-members:
    :special-members:

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -1,7 +1,7 @@
 Geometry creation
 =================
 
-.. automodule:: pygeos.creation
+.. automodule:: shapely.creation
    :members:
    :exclude-members:
    :special-members:

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -70,7 +70,7 @@ Properties
 Geometry objects have neither properties nor methods.
 Instead, use the functions listed below to obtain information about geometry objects.
 
-.. automodule:: pygeos.geometry
+.. automodule:: shapely.geometry
    :members:
    :exclude-members: GeometryType
    :special-members:

--- a/docs/io.rst
+++ b/docs/io.rst
@@ -1,7 +1,7 @@
 Input/Output
 ============
 
-.. automodule:: pygeos.io
+.. automodule:: shapely.io
    :members:
    :exclude-members:
    :special-members:

--- a/docs/linear.rst
+++ b/docs/linear.rst
@@ -1,7 +1,7 @@
 Linestring operations
 =====================
 
-.. automodule:: pygeos.linear
+.. automodule:: shapely.linear
    :members:
    :undoc-members:
    :special-members:

--- a/docs/measurement.rst
+++ b/docs/measurement.rst
@@ -1,7 +1,7 @@
 Measurement
 ===========
 
-.. automodule:: pygeos.measurement
+.. automodule:: shapely.measurement
    :members:
    :exclude-members:
    :special-members:

--- a/docs/predicates.rst
+++ b/docs/predicates.rst
@@ -1,7 +1,7 @@
 Predicates
 ==========
 
-.. automodule:: pygeos.predicates
+.. automodule:: shapely.predicates
    :members:
    :undoc-members:
    :special-members:

--- a/docs/set_operations.rst
+++ b/docs/set_operations.rst
@@ -1,7 +1,7 @@
 Set operations
 ==============
 
-.. automodule:: pygeos.set_operations
+.. automodule:: shapely.set_operations
    :members:
    :exclude-members:
    :special-members:

--- a/docs/strtree.rst
+++ b/docs/strtree.rst
@@ -1,6 +1,6 @@
 STRTree
 =======
 
-.. automodule:: pygeos.strtree
+.. automodule:: shapely.strtree
    :members: STRtree
    :exclude-members: BinaryPredicate

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,12 +1,12 @@
 Testing
 =======
 
-The functions in this module are not directly importable from the root ``pygeos`` module.
+The functions in this module are not directly importable from the root ``shapely`` module.
 Instead, import them from the submodule as follows:
 
-  >>> from pygeos.testing import assert_geometries_equal
+  >>> from shapely.testing import assert_geometries_equal
 
-.. automodule:: pygeos.testing
+.. automodule:: shapely.testing
    :members:
    :exclude-members:
    :special-members:


### PR DESCRIPTION
This already allows to build the docs and all those autodoc reference pages (I still get a bunch of warnings to resolve though). 