### PR TITLE
DOC: update class (init/new) docstrings of Geometry subclasses

### DIFF
--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -10,33 +10,32 @@ from shapely.geometry.base import (
 
 
 class GeometryCollection(BaseMultipartGeometry):
+    """
+    A heterogeneous collection of geometries.
 
-    """A heterogeneous collection of geometries
+    Parameters
+    ----------
+    geoms : list
+        A list of shapely geometry instances, which may be heterogeneous.
 
     Attributes
     ----------
     geoms : sequence
         A sequence of Shapely geometry instances
+
+    Examples
+    --------
+    Create a GeometryCollection with a Point and a LineString
+
+    >>> from shapely import LineString, Point
+    >>> p = Point(51, -1)
+    >>> l = LineString([(52, -1), (49, 2)])
+    >>> gc = GeometryCollection([p, l])
     """
 
     __slots__ = []
 
     def __new__(self, geoms=None):
-        """
-        Parameters
-        ----------
-        geoms : list
-            A list of shapely geometry instances, which may be heterogeneous.
-
-        Example
-        -------
-        Create a GeometryCollection with a Point and a LineString
-
-          >>> from shapely.geometry import LineString, Point
-          >>> p = Point(51, -1)
-          >>> l = LineString([(52, -1), (49, 2)])
-          >>> gc = GeometryCollection([p, l])
-        """
         if not geoms:
             # TODO better empty constructor
             return shapely.from_wkt("GEOMETRYCOLLECTION EMPTY")

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -11,12 +11,12 @@ from shapely.geometry.base import (
 
 class GeometryCollection(BaseMultipartGeometry):
     """
-    A heterogeneous collection of geometries.
+    A geometry type that may contain more than one type of geometry.
 
     Parameters
     ----------
     geoms : list
-        A list of shapely geometry instances, which may be heterogeneous.
+        A list of shapely geometry instances, which may be of varying geometry types.
 
     Attributes
     ----------

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -11,12 +11,14 @@ from shapely.geometry.base import (
 
 class GeometryCollection(BaseMultipartGeometry):
     """
-    A geometry type that may contain more than one type of geometry.
+    A collection of one or more geometries that may contain more than one type
+    of geometry.
 
     Parameters
     ----------
     geoms : list
-        A list of shapely geometry instances, which may be of varying geometry types.
+        A list of shapely geometry instances, which may be of varying
+        geometry types.
 
     Attributes
     ----------

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -78,8 +78,8 @@ def shape(context):
     -------
     Geometry object
 
-    Example
-    -------
+    Examples
+    --------
     Create a Point from GeoJSON, and then create a copy using __geo_interface__.
 
     >>> context = {'type': 'Point', 'coordinates': [0, 1]}
@@ -134,8 +134,8 @@ def mapping(ob):
     -------
     dict
 
-    Example
-    -------
+    Examples
+    --------
     >>> pt = Point(0, 0)
     >>> mapping(pt)
     {'type': 'Point', 'coordinates': (0.0, 0.0)}

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -10,17 +10,18 @@ __all__ = ["LineString"]
 
 class LineString(BaseGeometry):
     """
-    A one-dimensional geometry type composed of one or more line segments.
+    A geometry type composed of one or more line segments.
 
-    A LineString has non-zero length and zero area. It may approximate a curve
-    and need not be straight. Unlike a LinearRing, a LineString is not closed.
+    A LineString is a one-dimensional feature and has a non-zero length but
+    zero area. It may approximate a curve and need not be straight. Unlike a
+    LinearRing, a LineString is not closed.
 
     Parameters
     ----------
     coordinates : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or
-        an object that provides the numpy array interface, including
-        another instance of LineString.
+        A sequence of (x, y, [,z]) numeric coordinate pairs or triples, or
+        an array-like with shape (N, 2) or (N, 3).
+        Also can be a sequence of Point objects.
 
     Examples
     --------

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -10,31 +10,30 @@ __all__ = ["LineString"]
 
 class LineString(BaseGeometry):
     """
-    A one-dimensional figure comprising one or more line segments
+    A one-dimensional figure comprising one or more line segments.
 
     A LineString has non-zero length and zero area. It may approximate a curve
     and need not be straight. Unlike a LinearRing, a LineString is not closed.
+
+    Parameters
+    ----------
+    coordinates : sequence
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples or
+        an object that provides the numpy array interface, including
+        another instance of LineString.
+
+    Examples
+    --------
+    Create a line with two segments
+
+    >>> a = LineString([[0, 0], [1, 0], [1, 1]])
+    >>> a.length
+    2.0
     """
 
     __slots__ = []
 
     def __new__(self, coordinates=None):
-        """
-        Parameters
-        ----------
-        coordinates : sequence
-            A sequence of (x, y [,z]) numeric coordinate pairs or triples or
-            an object that provides the numpy array interface, including
-            another instance of LineString.
-
-        Example
-        -------
-        Create a line with two segments
-
-          >>> a = LineString([[0, 0], [1, 0], [1, 1]])
-          >>> a.length
-          2.0
-        """
         if coordinates is None:
             # empty geometry
             # TODO better constructor

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -10,7 +10,7 @@ __all__ = ["LineString"]
 
 class LineString(BaseGeometry):
     """
-    A one-dimensional figure comprising one or more line segments.
+    A one-dimensional geometry type composed of one or more line segments.
 
     A LineString has non-zero length and zero area. It may approximate a curve
     and need not be straight. Unlike a LinearRing, a LineString is not closed.
@@ -18,7 +18,7 @@ class LineString(BaseGeometry):
     Parameters
     ----------
     coordinates : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples or
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or
         an object that provides the numpy array interface, including
         another instance of LineString.
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -25,7 +25,7 @@ class LineString(BaseGeometry):
 
     Examples
     --------
-    Create a line with two segments
+    Create a LineString with two segments
 
     >>> a = LineString([[0, 0], [1, 0], [1, 1]])
     >>> a.length

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -18,9 +18,8 @@ class MultiLineString(BaseMultipartGeometry):
     Parameters
     ----------
     lines : sequence
-        A sequence of line-like coordinate sequences or objects that
-        provide the numpy array interface, including instances of
-        LineString.
+        A sequence LineStrings, or a sequence of line-like coordinate
+        sequences or array-likes (see accepted input for LineString).
 
     Attributes
     ----------
@@ -29,9 +28,9 @@ class MultiLineString(BaseMultipartGeometry):
 
     Examples
     --------
-    Construct a collection containing one line string.
+    Construct a collection containing two LineStrings.
 
-    >>> lines = MultiLineString( [[[0.0, 0.0], [1.0, 2.0]]] )
+    >>> lines = MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]])
     """
 
     __slots__ = []

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -28,7 +28,7 @@ class MultiLineString(BaseMultipartGeometry):
 
     Examples
     --------
-    Construct a collection containing two LineStrings.
+    Construct a MultiLineString containing two LineStrings.
 
     >>> lines = MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]])
     """

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -11,7 +11,7 @@ __all__ = ["MultiLineString"]
 
 class MultiLineString(BaseMultipartGeometry):
     """
-    A collection of one or more line strings.
+    A collection of one or more LineStrings.
 
     A MultiLineString has non-zero length and zero area.
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -11,33 +11,32 @@ __all__ = ["MultiLineString"]
 
 class MultiLineString(BaseMultipartGeometry):
     """
-    A collection of one or more line strings
+    A collection of one or more line strings.
 
     A MultiLineString has non-zero length and zero area.
+
+    Parameters
+    ----------
+    lines : sequence
+        A sequence of line-like coordinate sequences or objects that
+        provide the numpy array interface, including instances of
+        LineString.
 
     Attributes
     ----------
     geoms : sequence
         A sequence of LineStrings
+
+    Examples
+    --------
+    Construct a collection containing one line string.
+
+    >>> lines = MultiLineString( [[[0.0, 0.0], [1.0, 2.0]]] )
     """
 
     __slots__ = []
 
     def __new__(self, lines=None):
-        """
-        Parameters
-        ----------
-        lines : sequence
-            A sequence of line-like coordinate sequences or objects that
-            provide the numpy array interface, including instances of
-            LineString.
-
-        Example
-        -------
-        Construct a collection containing one line string.
-
-          >>> lines = MultiLineString( [[[0.0, 0.0], [1.0, 2.0]]] )
-        """
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling
             # TODO better empty constructor

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -11,14 +11,14 @@ __all__ = ["MultiPoint"]
 
 class MultiPoint(BaseMultipartGeometry):
     """
-    A collection of one or more points.
+    A collection of one or more Points.
 
     A MultiPoint has zero area and zero length.
 
     Parameters
     ----------
     points : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples or a
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or a
         sequence of objects that implement the numpy array interface,
         including instances of Point.
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -10,39 +10,38 @@ __all__ = ["MultiPoint"]
 
 
 class MultiPoint(BaseMultipartGeometry):
-
-    """A collection of one or more points
+    """
+    A collection of one or more points.
 
     A MultiPoint has zero area and zero length.
+
+    Parameters
+    ----------
+    points : sequence
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples or a
+        sequence of objects that implement the numpy array interface,
+        including instances of Point.
 
     Attributes
     ----------
     geoms : sequence
         A sequence of Points
+
+    Examples
+    --------
+    Construct a 2 point collection
+
+    >>> from shapely import Point
+    >>> ob = MultiPoint([[0.0, 0.0], [1.0, 2.0]])
+    >>> len(ob.geoms)
+    2
+    >>> type(ob.geoms[0]) == Point
+    True
     """
 
     __slots__ = []
 
     def __new__(self, points=None):
-        """
-        Parameters
-        ----------
-        points : sequence
-            A sequence of (x, y [,z]) numeric coordinate pairs or triples or a
-            sequence of objects that implement the numpy array interface,
-            including instances of Point.
-
-        Example
-        -------
-        Construct a 2 point collection
-
-          >>> from shapely.geometry import Point
-          >>> ob = MultiPoint([[0.0, 0.0], [1.0, 2.0]])
-          >>> len(ob.geoms)
-          2
-          >>> type(ob.geoms[0]) == Point
-          True
-        """
         if points is None:
             # allow creation of empty multipoints, to support unpickling
             # TODO better empty constructor

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -18,9 +18,8 @@ class MultiPoint(BaseMultipartGeometry):
     Parameters
     ----------
     points : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or a
-        sequence of objects that implement the numpy array interface,
-        including instances of Point.
+        A sequence Points, or a sequence of (x, y [,z]) numeric coordinate
+        pairs or triples, or an array-like of shape (N, 2) or (N, 3).
 
     Attributes
     ----------

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -18,7 +18,7 @@ class MultiPoint(BaseMultipartGeometry):
     Parameters
     ----------
     points : sequence
-        A sequence Points, or a sequence of (x, y [,z]) numeric coordinate
+        A sequence of Points, or a sequence of (x, y [,z]) numeric coordinate
         pairs or triples, or an array-like of shape (N, 2) or (N, 3).
 
     Attributes
@@ -28,7 +28,7 @@ class MultiPoint(BaseMultipartGeometry):
 
     Examples
     --------
-    Construct a 2 point collection
+    Construct a MultiPoint containing two Points
 
     >>> from shapely import Point
     >>> ob = MultiPoint([[0.0, 0.0], [1.0, 2.0]])

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -29,7 +29,7 @@ class MultiPolygon(BaseMultipartGeometry):
 
     Examples
     --------
-    Construct a collection from a sequence of coordinate tuples
+    Construct a MultiPolygon from a sequence of coordinate tuples
 
     >>> from shapely import Polygon
     >>> ob = MultiPolygon([

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -9,45 +9,45 @@ __all__ = ["MultiPolygon"]
 
 
 class MultiPolygon(BaseMultipartGeometry):
+    """
+    A collection of one or more polygons.
 
-    """A collection of one or more polygons
-
-    If component polygons overlap the collection is `invalid` and some
+    If component polygons overlap the collection is invalid and some
     operations on it may fail.
+
+    Parameters
+    ----------
+    polygons : sequence
+        A sequence of (shell, holes) tuples where shell is the sequence
+        representation of a linear ring (see linearring.py) and holes is
+        a sequence of such linear rings.
+        Also can be a sequence of Polygon objects.
 
     Attributes
     ----------
     geoms : sequence
         A sequence of `Polygon` instances
+
+    Examples
+    --------
+    Construct a collection from a sequence of coordinate tuples
+
+    >>> from shapely import Polygon
+    >>> ob = MultiPolygon([
+    ...     (
+    ...     ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
+    ...     [((0.1,0.1), (0.1,0.2), (0.2,0.2), (0.2,0.1))]
+    ...     )
+    ... ])
+    >>> len(ob.geoms)
+    1
+    >>> type(ob.geoms[0]) == Polygon
+    True
     """
 
     __slots__ = []
 
     def __new__(self, polygons=None):
-        """
-        Parameters
-        ----------
-        polygons : sequence
-            A sequence of (shell, holes) tuples where shell is the sequence
-            representation of a linear ring (see linearring.py) and holes is
-            a sequence of such linear rings
-
-        Example
-        -------
-        Construct a collection from a sequence of coordinate tuples
-
-          >>> from shapely.geometry import Polygon
-          >>> ob = MultiPolygon( [
-          ...     (
-          ...     ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
-          ...     [((0.1,0.1), (0.1,0.2), (0.2,0.2), (0.2,0.1))]
-          ...     )
-          ... ] )
-          >>> len(ob.geoms)
-          1
-          >>> type(ob.geoms[0]) == Polygon
-          True
-        """
         if not polygons:
             # allow creation of empty multipolygons, to support unpickling
             # TODO better empty constructor

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -10,7 +10,7 @@ __all__ = ["MultiPolygon"]
 
 class MultiPolygon(BaseMultipartGeometry):
     """
-    A collection of one or more polygons.
+    A collection of one or more Polygons.
 
     If component polygons overlap the collection is invalid and some
     operations on it may fail.
@@ -18,10 +18,9 @@ class MultiPolygon(BaseMultipartGeometry):
     Parameters
     ----------
     polygons : sequence
-        A sequence of (shell, holes) tuples where shell is the sequence
-        representation of a linear ring (see linearring.py) and holes is
-        a sequence of such linear rings.
-        Also can be a sequence of Polygon objects.
+        A sequence of Polygons, or a sequence of (shell, holes) tuples
+        where shell is the sequence representation of a linear ring
+        (see LinearRing) and holes is a sequence of such linear rings.
 
     Attributes
     ----------

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -10,38 +10,37 @@ __all__ = ["Point"]
 
 class Point(BaseGeometry):
     """
-    A zero dimensional feature
+    A zero dimensional feature.
 
     A point has zero length and zero area.
+
+    Parameters
+    ----------
+    There are 2 cases:
+
+    1) 1 parameter: this must satisfy the numpy array protocol.
+    2) 2 or more parameters: x, y, z : float
+        Easting, northing, and elevation.
 
     Attributes
     ----------
     x, y, z : float
         Coordinate values
 
-    Example
-    -------
-      >>> p = Point(1.0, -1.0)
-      >>> print(p)
-      POINT (1 -1)
-      >>> p.y
-      -1.0
-      >>> p.x
-      1.0
+    Examples
+    --------
+    >>> p = Point(1.0, -1.0)
+    >>> print(p)
+    POINT (1 -1)
+    >>> p.y
+    -1.0
+    >>> p.x
+    1.0
     """
 
     __slots__ = []
 
     def __new__(self, *args):
-        """
-        Parameters
-        ----------
-        There are 2 cases:
-
-        1) 1 parameter: this must satisfy the numpy array protocol.
-        2) 2 or more parameters: x, y, z : float
-            Easting, northing, and elevation.
-        """
         if len(args) == 0:
             # empty geometry
             # TODO better constructor

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -10,17 +10,19 @@ __all__ = ["Point"]
 
 class Point(BaseGeometry):
     """
-    A geometry type that represents a single coordinate with x,y and possibly z values.
+    A geometry type that represents a single coordinate with
+    x,y and possibly z values.
 
-    A point has zero length and zero area.
+    A point is a zero-dimensional feature and has zero length and zero area.
 
     Parameters
     ----------
-    There are 2 cases:
+    args : float, or sequence of floats
+        The coordinates can either be passed as a single parameter, or as
+        individual float values using multiple parameters:
 
-    1) 1 parameter: this must satisfy the numpy array protocol with shape (N, 2) or (N, 3).
-    2) 2 or more parameters: x, y, and possibly z : float
-        Easting, northing, and elevation.
+        1) 1 parameter: a sequence or array-like of with 2 or 3 values.
+        2) 2 or 3 parameters (float): x, y, and possibly z.
 
     Attributes
     ----------
@@ -29,7 +31,13 @@ class Point(BaseGeometry):
 
     Examples
     --------
+    Constructing the Point using separate parameters for x and y:
+
     >>> p = Point(1.0, -1.0)
+
+    Constructing the Point using a list of x, y coordinates:
+
+    >>> p = Point([1.0, -1.0])
     >>> print(p)
     POINT (1 -1)
     >>> p.y

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -10,7 +10,7 @@ __all__ = ["Point"]
 
 class Point(BaseGeometry):
     """
-    A zero dimensional feature.
+    A geometry type that represents a single coordinate with x,y and possibly z values.
 
     A point has zero length and zero area.
 
@@ -18,8 +18,8 @@ class Point(BaseGeometry):
     ----------
     There are 2 cases:
 
-    1) 1 parameter: this must satisfy the numpy array protocol.
-    2) 2 or more parameters: x, y, z : float
+    1) 1 parameter: this must satisfy the numpy array protocol with shape (N, 2) or (N, 3).
+    2) 2 or more parameters: x, y, and possibly z : float
         Easting, northing, and elevation.
 
     Attributes

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -24,15 +24,18 @@ def _unpickle_linearring(wkb):
 
 class LinearRing(LineString):
     """
-    A closed one-dimensional feature comprising one or more line segments.
+    A geometry type composed of one or more line segments
+    that forms a closed loop.
 
+    A LinearRing is a closed, one-dimensional feature.
     A LinearRing that crosses itself or touches itself at a single point is
     invalid and operations on it may fail.
 
     Parameters
     ----------
     coordinates : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples.
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or
+        an array-like with shape (N, 2) or (N, 3).
         Also can be a sequence of Point objects.
 
     Notes
@@ -178,14 +181,16 @@ class Polygon(BaseGeometry):
     """
     A geometry type representing an area that is enclosed by a linear ring.
 
-    A polygon has a non-zero area. It may have one or more negative-space
-    "holes" which are also bounded by linear rings. If any rings cross each
-    other, the feature is invalid and operations on it may fail.
+    A polygon is a two-dimensional feature and has a non-zero area. It may
+    have one or more negative-space "holes" which are also bounded by linear
+    rings. If any rings cross each other, the feature is invalid and
+    operations on it may fail.
 
     Parameters
     ----------
     shell : sequence
-        A sequence of (x, y [,z]) numeric coordinate pairs or triples.
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples, or
+        an array-like with shape (N, 2) or (N, 3).
         Also can be a sequence of Point objects.
     holes : sequence
         A sequence of objects which satisfy the same requirements as the

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -37,7 +37,7 @@ class LinearRing(LineString):
 
     Notes
     -----
-    Rings are implicitly closed. There is no need to specify a final
+    Rings are automatically closed. There is no need to specify a final
     coordinate pair identical to the first.
 
     Examples
@@ -176,7 +176,7 @@ class InteriorRingSequence:
 
 class Polygon(BaseGeometry):
     """
-    A two-dimensional figure bounded by a linear ring.
+    A geometry type representing an area that is enclosed by a linear ring.
 
     A polygon has a non-zero area. It may have one or more negative-space
     "holes" which are also bounded by linear rings. If any rings cross each

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -24,35 +24,39 @@ def _unpickle_linearring(wkb):
 
 class LinearRing(LineString):
     """
-    A closed one-dimensional feature comprising one or more line segments
+    A closed one-dimensional feature comprising one or more line segments.
 
     A LinearRing that crosses itself or touches itself at a single point is
     invalid and operations on it may fail.
+
+    Parameters
+    ----------
+    coordinates : sequence
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples.
+        Also can be a sequence of Point objects.
+
+    Notes
+    -----
+    Rings are implicitly closed. There is no need to specify a final
+    coordinate pair identical to the first.
+
+    Examples
+    --------
+    Construct a square ring.
+
+    >>> ring = LinearRing( ((0, 0), (0, 1), (1 ,1 ), (1 , 0)) )
+    >>> ring.is_closed
+    True
+    >>> list(ring.coords)
+    [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]
+    >>> ring.length
+    4.0
+
     """
 
     __slots__ = []
 
     def __new__(self, coordinates=None):
-        """
-        Parameters
-        ----------
-        coordinates : sequence
-            A sequence of (x, y [,z]) numeric coordinate pairs or triples.
-            Also can be a sequence of Point objects.
-
-        Rings are implicitly closed. There is no need to specific a final
-        coordinate pair identical to the first.
-
-        Example
-        -------
-        Construct a square ring.
-
-          >>> ring = LinearRing( ((0, 0), (0, 1), (1 ,1 ), (1 , 0)) )
-          >>> ring.is_closed
-          True
-          >>> ring.length
-          4.0
-        """
         if coordinates is None:
             # empty geometry
             # TODO better way?
@@ -172,11 +176,20 @@ class InteriorRingSequence:
 
 class Polygon(BaseGeometry):
     """
-    A two-dimensional figure bounded by a linear ring
+    A two-dimensional figure bounded by a linear ring.
 
     A polygon has a non-zero area. It may have one or more negative-space
     "holes" which are also bounded by linear rings. If any rings cross each
     other, the feature is invalid and operations on it may fail.
+
+    Parameters
+    ----------
+    shell : sequence
+        A sequence of (x, y [,z]) numeric coordinate pairs or triples.
+        Also can be a sequence of Point objects.
+    holes : sequence
+        A sequence of objects which satisfy the same requirements as the
+        shell parameters above
 
     Attributes
     ----------
@@ -184,30 +197,20 @@ class Polygon(BaseGeometry):
         The ring which bounds the positive space of the polygon.
     interiors : sequence
         A sequence of rings which bound all existing holes.
+
+    Examples
+    --------
+    Create a square polygon with no holes
+
+    >>> coords = ((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.))
+    >>> polygon = Polygon(coords)
+    >>> polygon.area
+    1.0
     """
 
     __slots__ = []
 
     def __new__(self, shell=None, holes=None):
-        """
-        Parameters
-        ----------
-        shell : sequence
-            A sequence of (x, y [,z]) numeric coordinate pairs or triples.
-            Also can be a sequence of Point objects.
-        holes : sequence
-            A sequence of objects which satisfy the same requirements as the
-            shell parameters above
-
-        Example
-        -------
-        Create a square polygon with no holes
-
-          >>> coords = ((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.))
-          >>> polygon = Polygon(coords)
-          >>> polygon.area
-          1.0
-        """
         if shell is None:
             # empty geometry
             # TODO better way?


### PR DESCRIPTION
This makes a few changes to the main docstrings of the Geometry subclass objects:

- "Example" -> "Examples" to follow numpydoc convention
- Combined the class docstring with the `__new__` docstring. I think this is more useful for users (interactively, you will typically only check the class docstring (`Polygon?` in IPython)).
- Some small formatting changes, and ensuring everything builds fine with sphinx.