### PR TITLE
DOC: update the installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Shapely 2.0 requires
 Installing Shapely
 ==================
 
-It is recommended to install shapely using one of the available built
+It is recommended to install Shapely using one of the available built
 distributions, for example using ``pip`` or ``conda``:
 
 .. code-block:: console

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Shapely 2.0 requires
 Installing Shapely
 ==================
 
-It is recommended to install Shapely using one of the available built
+We recommend installing Shapely using one of the available built
 distributions, for example using ``pip`` or ``conda``:
 
 .. code-block:: console
@@ -66,7 +66,7 @@ distributions, for example using ``pip`` or ``conda``:
     $ conda install shapely --channel conda-forge
 
 See the `installation documentation <https://shapely.readthedocs.io/en/latest/installation.html>`__
-for more details (installing from source, using a custom GEOS install, development version, etc).
+for more details and advanced installation instructions.
 
 Integration
 ===========

--- a/README.rst
+++ b/README.rst
@@ -47,60 +47,26 @@ See the manual for more examples and guidance.
 Requirements
 ============
 
-Shapely 1.8 requires
+Shapely 2.0 requires
 
 * Python >=3.6
-* GEOS >=3.3
+* GEOS >=3.5
+* NumPy >=1.13
 
 Installing Shapely
 ==================
 
-Shapely may be installed from a source distribution or one of several kinds
-of built distribution.
-
-Built distributions
--------------------
-
-Built distributions are the only option for users who do not have or do not
-know how to use their platform's compiler and Python SDK, and a good option for
-users who would rather not bother.
-
-Linux, OS X, and Windows users can get Shapely wheels with GEOS included from the
-Python Package Index with a recent version of pip (8+):
+It is recommended to install shapely using one of the available built
+distributions, for example using ``pip`` or ``conda``:
 
 .. code-block:: console
 
     $ pip install shapely
+    # or using conda
+    $ conda install shapely --channel conda-forge
 
-Shapely is available via system package management tools like apt, yum, and
-Homebrew, and is also provided by popular Python distributions like Canopy and
-Anaconda. If you use the Conda package manager to install Shapely, be sure to
-use the conda-forge channel.
-
-Windows users have another good installation options: the wheels published at
-https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely. These can be installed
-using pip by specifying the entire URL.
-
-Source distributions
---------------------
-
-If you want to build Shapely from source for compatibility with other modules
-that depend on GEOS (such as cartopy or osgeo.ogr) or want to use a different
-version of GEOS than the one included in the project wheels you should first
-install the GEOS library, Cython, and Numpy on your system (using apt, yum,
-brew, or other means) and then direct pip to ignore the binary wheels.
-
-.. code-block:: console
-
-    $ pip install shapely --no-binary shapely
-
-If you've installed GEOS to a standard location, the geos-config program will
-be used to get compiler and linker options. If geos-config is not on your
-executable, it can be specified with a GEOS_CONFIG environment variable, e.g.:
-
-.. code-block:: console
-
-    $ GEOS_CONFIG=/path/to/geos-config pip install shapely
+See the `installation documentation <https://shapely.readthedocs.io/en/latest/installation.html>`__
+for more details (installing from source, using a custom GEOS install, development version, etc).
 
 Integration
 ===========
@@ -127,26 +93,6 @@ dicts.
     <shapely.geometry.point.Point object at 0x...>
     >>> print(json.dumps(mapping(s)))
     {"type": "Point", "coordinates": [0.0, 0.0]}
-
-Development and Testing
-=======================
-
-Dependencies for developing Shapely are listed in requirements-dev.txt. Cython
-and Numpy are not required for production installations, only for development.
-Use of a virtual environment is strongly recommended.
-
-.. code-block:: console
-
-    $ virtualenv .
-    $ source bin/activate
-    (env)$ pip install -r requirements-dev.txt
-    (env)$ pip install -e .
-
-The project uses pytest to run Shapely's suite of unittests and doctests.
-
-.. code-block:: console
-
-    (env)$ python -m pytest
 
 Support
 =======

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ available via system package management tools like apt, yum, and Homebrew.
 Installation from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Shapely is available as a binary distribution (wheel) for Linux, OSX and Windows platforms.
+Shapely is available as a binary distribution (wheel) for Linux, macOS and Windows platforms.
 The distribution includes a GEOS version that was most recent at the time of the Shapely release.
 Install the binary wheel with pip as follows::
 
@@ -39,7 +39,7 @@ On Linux::
     $ sudo apt install libgeos-dev  # skip this if you already have GEOS
     $ pip install shapely --no-binary shapely
 
-On OSX::
+On macOS::
 
     $ brew install geos  # skip this if you already have GEOS
     $ pip install shapely --no-binary shapely
@@ -101,13 +101,13 @@ Shapely can be tested using ``pytest``::
 GEOS discovery (compile time)
 -----------------------------
 
-If GEOS is installed on Linux or OSX, normally the ``geos-config`` command line utility
+If GEOS is installed on Linux or macOS, normally the ``geos-config`` command line utility
 will be available and ``pip`` will find GEOS automatically.
-If the correct ``geos-config`` is not on the PATH, you can add it as follows (on Linux/OSX)::
+If the correct ``geos-config`` is not on the PATH, you can add it as follows (on Linux/macOS)::
 
     $ export PATH=/path/to/geos/bin:$PATH
 
-Alternatively, you can specify where Shapely should look for GEOS (on Linux/OSX)::
+Alternatively, you can specify where Shapely should look for GEOS (on Linux/macOS)::
 
     $ export GEOS_INCLUDE_PATH=/path/to/geos/include
     $ export GEOS_LIBRARY_PATH=/path/to/geos/lib
@@ -120,7 +120,7 @@ specified manually in any case::
 
 Common locations of GEOS (to be suffixed by ``lib``, ``include`` or ``bin``):
 
-* Anaconda (Linux/OSX): ``$CONDA_PREFIX/Library``
+* Anaconda (Linux/macOS): ``$CONDA_PREFIX/Library``
 * Anaconda (Windows): ``%CONDA_PREFIX%\Library``
 * OSGeo4W (Windows): ``C:\OSGeo4W64``
 
@@ -152,12 +152,12 @@ general four ways of making Python aware of the location of shared library:
 3. Copy the shared libraries into some system location (``C:\Windows\System32``; ``/usr/local/lib``,
    this happens if you installed GEOS through ``apt`` or ``brew``)
 4. Add the shared library location to a the dynamic linker path variable at runtime.
-   (Advanced usage; Linux and OSX only; on Windows this method was deprecated in Python 3.8)
+   (Advanced usage; Linux and macOS only; on Windows this method was deprecated in Python 3.8)
 
 The filenames of the GEOS shared libraries are:
 
 * On Linux: ``libgeos-*.so.*, libgeos_c-*.so.*``
-* On OSX: ``libgeos.dylib, libgeos_c.dylib``
+* On macOS: ``libgeos.dylib, libgeos_c.dylib``
 * On Windows: ``geos-*.dll, geos_c-*.dll``
 
 Note that shapely does not make use of any RUNPATH (RPATH) header. The location

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,70 +1,101 @@
 Installation
 ============
 
-Installation from PyPI
-----------------------
+Built distributions
+-------------------
 
-PyGEOS is available as a binary distribution (wheel) for Linux, OSX and Windows platforms.
-The distribution includes a GEOS version that was most recent at the time of the PyGEOS release.
+Built distributions don't require to compile Shapely and its Dependencies,
+and can be installed using ``pip`` or ``conda``. In addition, Shapely is also
+available via system package management tools like apt, yum, and Homebrew.
+
+Installation from PyPI
+^^^^^^^^^^^^^^^^^^^^^^
+
+Shapely is available as a binary distribution (wheel) for Linux, OSX and Windows platforms.
+The distribution includes a GEOS version that was most recent at the time of the Shapely release.
 Install the binary wheel with pip as follows::
 
-    $ pip install pygeos
+    $ pip install shapely
+
+Installation using conda
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Shapely is available on the conda-forge channel. Install as follows::
+
+    $ conda install shapely --channel conda-forge
 
 
-Installation using Anaconda
----------------------------
-
-PyGEOS is available on the conda-forge channel. Install as follows::
-
-    $ conda install pygeos --channel conda-forge
-
-
-Installation with custom GEOS libary
-------------------------------------
+Installation from source with custom GEOS libary
+------------------------------------------------
 
 You may want to use a specific GEOS version or a GEOS distribution that is already present on
-your system. In such cases you will need to compile PyGEOS yourself.
+your system (for example for compatibility with other modules that depend on GEOS, such as
+cartopy or osgeo.ogr). In such cases you will need to ensure the GEOS library is install
+and then compile Shapely yourself, installing it from source (by directing pip to ignore
+the binary wheels).
 
 On Linux::
 
     $ sudo apt install libgeos-dev  # skip this if you already have GEOS
-    $ pip install pygeos --no-binary
+    $ pip install shapely --no-binary shapely
 
 On OSX::
 
     $ brew install geos  # skip this if you already have GEOS
-    $ pip install pygeos --no-binary
+    $ pip install shapely --no-binary shapely
+
+If you've installed GEOS to a standard location, the installation will automatically
+find it using ``geos-config``. See the notes below on GEOS discovery at compile time
+to configure this.
 
 We do not have a recipe for Windows platforms. The following steps should enable you
-to build PyGEOS yourself:
+to build Shapely yourself:
 
 - Get a C compiler applicable to your Python version (https://wiki.python.org/moin/WindowsCompilers)
 - Download and install a GEOS binary (https://trac.osgeo.org/osgeo4w/)
 - Set GEOS_INCLUDE_PATH and GEOS_LIBRARY_PATH environment variables (see below for notes on GEOS discovery)
-- Run ``pip install pygeos --no-binary``
+- Run ``pip install shapely --no-binary``
 - Make sure the GEOS .dll files are available on the PATH
 
 
-Installation from source
-------------------------
+Installation of development version
+-----------------------------------
 
-The same as installation with a custom GEOS binary, but then instead of installing pygeos
-with pip, you clone the package from Github::
+The same as installation with a custom GEOS binary, but then instead of installing
+Shapely with pip from PyPI, you clone the package from Github::
 
-    $ git clone git@github.com:pygeos/pygeos.git
+    $ git clone git@github.com:shapely/shapely.git
+    $ cd shapely/
 
 Install it in development mode using ``pip``::
 
     $ pip install -e .[test]
 
+For development, use of a virtual environment is strongly recommended. For example
+using ``venv``:
 
-Testing PyGEOS
---------------
+.. code-block:: console
 
-PyGEOS can be tested using ``pytest``::
+    $ python3 -m venv .
+    $ source bin/activate
+    (env) $ pip install -r requirements-dev.txt
+    (env) $ pip install -e .
 
-    $ pip install pytest  # or pygeos[test]
-    $ pytest --pyargs pygeos.tests
+Or using ``conda``:
+
+.. code-block:: console
+
+    $ conda create -n env python=3 geos numpy cython pytest
+    $ conda activate env
+    (env) $ pip install -e .
+
+Testing Shapely
+---------------
+
+Shapely can be tested using ``pytest``::
+
+    $ pip install pytest  # or shapely[test]
+    $ pytest --pyargs shapely.tests
 
 
 GEOS discovery (compile time)
@@ -76,7 +107,7 @@ If the correct ``geos-config`` is not on the PATH, you can add it as follows (on
 
     $ export PATH=/path/to/geos/bin:$PATH
 
-Alternatively, you can specify where PyGEOS should look for GEOS (on Linux/OSX)::
+Alternatively, you can specify where Shapely should look for GEOS (on Linux/OSX)::
 
     $ export GEOS_INCLUDE_PATH=/path/to/geos/include
     $ export GEOS_LIBRARY_PATH=/path/to/geos/lib
@@ -97,8 +128,8 @@ Common locations of GEOS (to be suffixed by ``lib``, ``include`` or ``bin``):
 GEOS discovery (runtime)
 ------------------------
 
-PyGEOS is dynamically linked to GEOS. This means that the same GEOS library that was used
-during PyGEOS compilation is required on your system at runtime. When using pygeos that was distributed
+Shapely is dynamically linked to GEOS. This means that the same GEOS library that was used
+during Shapely compilation is required on your system at runtime. When using shapely that was distributed
 as a binary wheel or through conda, this is automatically the case and you can stop reading.
 
 In other cases this can be tricky, especially if you have multiple GEOS installations next
@@ -114,8 +145,8 @@ If you encounter exceptions like:
 You will have to make the shared library file available to the Python interpreter. There are in
 general four ways of making Python aware of the location of shared library:
 
-1. Copy the shared libraries into the pygeos module directory (this is how Windows binary wheels work:
-   they are distributed with the correct dlls in the pygeos module directory)
+1. Copy the shared libraries into the shapely module directory (this is how Windows binary wheels work:
+   they are distributed with the correct dlls in the shapely module directory)
 2. Copy the shared libraries into the library directory of the Python interpreter (this is how
    Anaconda environments work)
 3. Copy the shared libraries into some system location (``C:\Windows\System32``; ``/usr/local/lib``,
@@ -129,5 +160,5 @@ The filenames of the GEOS shared libraries are:
 * On OSX: ``libgeos.dylib, libgeos_c.dylib``
 * On Windows: ``geos-*.dll, geos_c-*.dll``
 
-Note that pygeos does not make use of any RUNPATH (RPATH) header. The location
-of the GEOS shared library is not stored inside the compiled PyGEOS library.
+Note that shapely does not make use of any RUNPATH (RPATH) header. The location
+of the GEOS shared library is not stored inside the compiled Shapely library.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,9 +11,10 @@ available via system package management tools like apt, yum, and Homebrew.
 Installation from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Shapely is available as a binary distribution (wheel) for Linux, macOS, and Windows platforms on `PyPI <https://pypi.org/project/Shapely/>`__.
-The distribution includes the most recent version of GEOS available at the time of the Shapely release.
-Install the binary wheel with pip as follows::
+Shapely is available as a binary distribution (wheel) for Linux, macOS, and
+Windows platforms on `PyPI <https://pypi.org/project/Shapely/>`__. The
+distribution includes the most recent version of GEOS available at the time
+of the Shapely release. Install the binary wheel with pip as follows::
 
     $ pip install shapely
 
@@ -28,11 +29,11 @@ Shapely is available on the conda-forge channel. Install as follows::
 Installation from source with custom GEOS libary
 ------------------------------------------------
 
-You may want to use a specific GEOS version or a GEOS distribution that is already present on
-your system (for compatibility with other modules that depend on GEOS, such as
-cartopy or osgeo.ogr). In such cases you will need to ensure the GEOS library is installed on your system
-and then compile Shapely from source yourself, by directing pip to ignore
-the binary wheels.
+You may want to use a specific GEOS version or a GEOS distribution that is
+already present on your system (for compatibility with other modules that
+depend on GEOS, such as cartopy or osgeo.ogr). In such cases you will need to
+ensure the GEOS library is installed on your system and then compile Shapely
+from source yourself, by directing pip to ignore the binary wheels.
 
 On Linux::
 
@@ -101,13 +102,14 @@ Shapely can be tested using ``pytest``::
 GEOS discovery (compile time)
 -----------------------------
 
-If GEOS is installed on Linux or macOS the ``geos-config`` command line utility should be available
-will be available and ``pip`` will find GEOS automatically.
+If GEOS is installed on Linux or macOS, the ``geos-config`` command line utility
+should be available and ``pip`` will find GEOS automatically.
 If the correct ``geos-config`` is not on the PATH, you can add it as follows (on Linux/macOS)::
 
     $ export PATH=/path/to/geos/bin:$PATH
 
-Alternatively, you can specify where Shapely should look for GEOS library and header files using environment variables (on Linux/macOS)::
+Alternatively, you can specify where Shapely should look for GEOS library and
+header files using environment variables (on Linux/macOS)::
 
     $ export GEOS_INCLUDE_PATH=/path/to/geos/include
     $ export GEOS_LIBRARY_PATH=/path/to/geos/lib

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,15 +4,15 @@ Installation
 Built distributions
 -------------------
 
-Built distributions don't require to compile Shapely and its dependencies,
+Built distributions don't require compiling Shapely and its dependencies,
 and can be installed using ``pip`` or ``conda``. In addition, Shapely is also
 available via system package management tools like apt, yum, and Homebrew.
 
 Installation from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Shapely is available as a binary distribution (wheel) for Linux, macOS and Windows platforms.
-The distribution includes a GEOS version that was most recent at the time of the Shapely release.
+Shapely is available as a binary distribution (wheel) for Linux, macOS, and Windows platforms on `PyPI <https://pypi.org/project/Shapely/>`__.
+The distribution includes the most recent version of GEOS available at the time of the Shapely release.
 Install the binary wheel with pip as follows::
 
     $ pip install shapely
@@ -29,10 +29,10 @@ Installation from source with custom GEOS libary
 ------------------------------------------------
 
 You may want to use a specific GEOS version or a GEOS distribution that is already present on
-your system (for example for compatibility with other modules that depend on GEOS, such as
-cartopy or osgeo.ogr). In such cases you will need to ensure the GEOS library is install
-and then compile Shapely yourself, installing it from source (by directing pip to ignore
-the binary wheels).
+your system (for compatibility with other modules that depend on GEOS, such as
+cartopy or osgeo.ogr). In such cases you will need to ensure the GEOS library is installed on your system
+and then compile Shapely from source yourself, by directing pip to ignore
+the binary wheels.
 
 On Linux::
 
@@ -44,7 +44,7 @@ On macOS::
     $ brew install geos  # skip this if you already have GEOS
     $ pip install shapely --no-binary shapely
 
-If you've installed GEOS to a standard location, the installation will automatically
+If you've installed GEOS to a standard location on Linux or macOS, the installation will automatically
 find it using ``geos-config``. See the notes below on GEOS discovery at compile time
 to configure this.
 
@@ -58,10 +58,10 @@ to build Shapely yourself:
 - Make sure the GEOS .dll files are available on the PATH
 
 
-Installation of development version
+Installation for local development
 -----------------------------------
 
-The same as installation with a custom GEOS binary, but then instead of installing
+This is similar to installing with a custom GEOS binary, but then instead of installing
 Shapely with pip from PyPI, you clone the package from Github::
 
     $ git clone git@github.com:shapely/shapely.git
@@ -101,13 +101,13 @@ Shapely can be tested using ``pytest``::
 GEOS discovery (compile time)
 -----------------------------
 
-If GEOS is installed on Linux or macOS, normally the ``geos-config`` command line utility
+If GEOS is installed on Linux or macOS the ``geos-config`` command line utility should be available
 will be available and ``pip`` will find GEOS automatically.
 If the correct ``geos-config`` is not on the PATH, you can add it as follows (on Linux/macOS)::
 
     $ export PATH=/path/to/geos/bin:$PATH
 
-Alternatively, you can specify where Shapely should look for GEOS (on Linux/macOS)::
+Alternatively, you can specify where Shapely should look for GEOS library and header files using environment variables (on Linux/macOS)::
 
     $ export GEOS_INCLUDE_PATH=/path/to/geos/include
     $ export GEOS_LIBRARY_PATH=/path/to/geos/lib

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Built distributions
 
 Built distributions don't require compiling Shapely and its dependencies,
 and can be installed using ``pip`` or ``conda``. In addition, Shapely is also
-available via system package management tools like apt, yum, and Homebrew.
+available via some system package management tools like apt.
 
 Installation from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -129,7 +129,7 @@ GEOS discovery (runtime)
 ------------------------
 
 Shapely is dynamically linked to GEOS. This means that the same GEOS library that was used
-during Shapely compilation is required on your system at runtime. When using shapely that was distributed
+during Shapely compilation is required on your system at runtime. When using Shapely that was distributed
 as a binary wheel or through conda, this is automatically the case and you can stop reading.
 
 In other cases this can be tricky, especially if you have multiple GEOS installations next
@@ -145,8 +145,8 @@ If you encounter exceptions like:
 You will have to make the shared library file available to the Python interpreter. There are in
 general four ways of making Python aware of the location of shared library:
 
-1. Copy the shared libraries into the shapely module directory (this is how Windows binary wheels work:
-   they are distributed with the correct dlls in the shapely module directory)
+1. Copy the shared libraries into the ``shapely`` module directory (this is how Windows binary wheels work:
+   they are distributed with the correct dlls in the ``shapely`` module directory)
 2. Copy the shared libraries into the library directory of the Python interpreter (this is how
    Anaconda environments work)
 3. Copy the shared libraries into some system location (``C:\Windows\System32``; ``/usr/local/lib``,
@@ -160,5 +160,5 @@ The filenames of the GEOS shared libraries are:
 * On macOS: ``libgeos.dylib, libgeos_c.dylib``
 * On Windows: ``geos-*.dll, geos_c-*.dll``
 
-Note that shapely does not make use of any RUNPATH (RPATH) header. The location
+Note that Shapely does not make use of any RUNPATH (RPATH) header. The location
 of the GEOS shared library is not stored inside the compiled Shapely library.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Built distributions
 -------------------
 
-Built distributions don't require to compile Shapely and its Dependencies,
+Built distributions don't require to compile Shapely and its dependencies,
 and can be installed using ``pip`` or ``conda``. In addition, Shapely is also
 available via system package management tools like apt, yum, and Homebrew.
 


### PR DESCRIPTION
This updates / consolidates the documentation on installing shapely. Apart from some pygeos->shapely renaming, I did:

* I moved most content about installation in the README to the specific documentation page (and linking that page), and in the README kept it short. My goal here is to avoid duplication (and going into details in the README). 
* I tried to combine the installation doc page from pygeos with some of the content from Shapely's README. But I didn't keep everything (some aspects were a bit outdated), so it would be good to give this a check. 