### PR TITLE
DOC: fix / consolidate the readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,10 +10,6 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - pdf
@@ -23,5 +19,5 @@ conda:
 
 python:
   install:
-    - method: setuptools
+    - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,5 +19,5 @@ conda:
 
 python:
   install:
-    - method: pip
+    - method: setuptools
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,6 @@ import sys, os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(os.path.abspath('sphinxext'))
 
-# Load latest source tree
-sys.path.insert(0, os.path.abspath('..'))
-
 import shapely
 
 # For pyplots in code/, load functions here first, so they are visible

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.10
   - geos=3.10
   - numpy
+  - cython
   - sphinx-book-theme
   - numpydoc==1.1.*
   - matplotlib

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,10 +1,10 @@
-name: pygeos
+name: shapely_docs
 channels:
-  - defaults
+  - conda-forge
 dependencies:
-  - python==3.8.*
-  - geos==3.8.*
-  - numpy==1.19.*
+  - python=3.10
+  - geos=3.10
+  - numpy
+  - sphinx-book-theme
   - numpydoc==1.1.*
-  - Cython==0.29.*
-  - docutils==0.16.*
+  - matplotlib

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,5 @@ dependencies:
   - geos=3.10
   - numpy
   - cython
-  - sphinx-book-theme
   - numpydoc==1.1.*
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: _shapely
-channels:
-- defaults
-dependencies:
-- python==3.6.*
-- geos==3.8.*
-- matplotlib
-- descartes

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-python:
-  version: 3
-  pip_install: true
-conda:
-  file: environment.yml


### PR DESCRIPTION
Trying to get the readthedocs build working again. I activated this branch, and so the build output can be seen here (it is now "passing"): https://readthedocs.org/projects/shapely/builds/16978294/

The actual doc build is still failing, because the plot directives are still erroring.

I also switched to use mamba instead of conda, which speeds up the env install step from 4 to 2 min.