### PR TITLE
API: remove __geom__, keep _geom read-only access to GEOS pointer

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -69,15 +69,6 @@ class BaseGeometry(shapely.Geometry):
 
     """
 
-    # Attributes
-    # ----------
-    # __geom__ : c_void_p
-    #     Cached ctypes pointer to GEOS geometry. Not to be accessed.
-    # _geom : c_void_p
-    #     Property by which the GEOS geometry is accessed.
-    # _ndim : int
-    #     Number of dimensions (2 or 3, generally)
-
     __slots__ = []
 
     def __new__(self):
@@ -89,14 +80,6 @@ class BaseGeometry(shapely.Geometry):
             stacklevel=2,
         )
         return shapely.from_wkt("GEOMETRYCOLLECTION EMPTY")
-
-    @property
-    def _geom(self):
-        return self._ptr
-
-    @property
-    def __geom__(self):
-        return self._ptr
 
     @property
     def _ndim(self):
@@ -763,14 +746,11 @@ class GeometrySequence:
     # ----------
     # _factory : callable
     #     Returns instances of Shapely geometries
-    # _geom : c_void_p
-    #     Ctypes pointer to the parent's GEOS geometry
     # _ndim : int
     #     Number of dimensions (2 or 3, generally)
     # __p__ : object
     #     Parent (Shapely) geometry
     shape_factory = None
-    _geom = None
     __p__ = None
     _ndim = None
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -122,7 +122,6 @@ shapely.lib.registry[2] = LinearRing
 class InteriorRingSequence:
 
     _factory = None
-    _geom = None
     __p__ = None
     _ndim = None
     _index = 0
@@ -132,7 +131,6 @@ class InteriorRingSequence:
 
     def __init__(self, parent):
         self.__p__ = parent
-        self._geom = parent._geom
         self._ndim = parent._ndim
 
     def __iter__(self):

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -532,28 +532,28 @@ def test_subclasses(with_point_in_registry):
 
 def test_prepare():
     arr = np.array([shapely.points(1, 1), None, shapely.box(0, 0, 1, 1)])
-    assert arr[0]._ptr_prepared == 0
-    assert arr[2]._ptr_prepared == 0
+    assert arr[0]._geom_prepared == 0
+    assert arr[2]._geom_prepared == 0
     shapely.prepare(arr)
-    assert arr[0]._ptr_prepared != 0
+    assert arr[0]._geom_prepared != 0
     assert arr[1] is None
-    assert arr[2]._ptr_prepared != 0
+    assert arr[2]._geom_prepared != 0
 
     # preparing again actually does nothing
-    original = arr[0]._ptr_prepared
+    original = arr[0]._geom_prepared
     shapely.prepare(arr)
-    assert arr[0]._ptr_prepared == original
+    assert arr[0]._geom_prepared == original
 
 
 def test_destroy_prepared():
     arr = np.array([shapely.points(1, 1), None, shapely.box(0, 0, 1, 1)])
     shapely.prepare(arr)
-    assert arr[0]._ptr_prepared != 0
-    assert arr[2]._ptr_prepared != 0
+    assert arr[0]._geom_prepared != 0
+    assert arr[2]._geom_prepared != 0
     shapely.destroy_prepared(arr)
-    assert arr[0]._ptr_prepared == 0
+    assert arr[0]._geom_prepared == 0
     assert arr[1] is None
-    assert arr[2]._ptr_prepared == 0
+    assert arr[2]._geom_prepared == 0
     shapely.destroy_prepared(arr)  # does not error
 
 

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -32,7 +32,6 @@ from .common import (
     polygon_with_hole,
     polygon_with_hole_z,
     polygon_z,
-    shapely20_todo,
 )
 
 
@@ -211,13 +210,10 @@ def test_new_from_wkt(geom):
     assert_geometries_equal(actual, geom)
 
 
-# TODO(shapely-2.0) Python 3.10 build triggers warnings as errors, and this still
-# raise the deprecation warning (which should be removed)
-@shapely20_todo
 def test_adapt_ptr_raises():
     point = shapely.Geometry("POINT (2 2)")
     with pytest.raises(AttributeError):
-        point._ptr += 1
+        point._geom += 1
 
 
 @pytest.mark.parametrize(

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -88,51 +88,6 @@ GEOJSON_COLLECTION_EXPECTED = [
 ]
 
 
-class ShapelyGeometryMock:
-    def __init__(self, g):
-        self.g = g
-        self.__geom__ = g._ptr if hasattr(g, "_ptr") else g
-
-    @property
-    def __array_interface__(self):
-        # this should not be called
-        # (starting with numpy 1.20 it is called, but not used)
-        return np.array([1.0, 2.0]).__array_interface__
-
-    @property
-    def wkb(self):
-        return shapely.to_wkb(self.g)
-
-    @property
-    def geom_type(self):
-        idx = shapely.get_type_id(self.g)
-        return [
-            "None",
-            "Point",
-            "LineString",
-            "LinearRing",
-            "Polygon",
-            "MultiPoint",
-            "MultiLineString",
-            "MultiPolygon",
-            "GeometryCollection",
-        ][idx]
-
-    @property
-    def is_empty(self):
-        return shapely.is_empty(self.g)
-
-
-class ShapelyPreparedMock:
-    def __init__(self, g):
-        self.context = ShapelyGeometryMock(g)
-
-
-def shapely_wkb_loads_mock(wkb):
-    geom = shapely.from_wkb(wkb)
-    return ShapelyGeometryMock(geom)
-
-
 def test_from_wkt():
     expected = shapely.points(1, 1)
     actual = shapely.from_wkt("POINT (1 1)")

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -55,9 +55,9 @@ static void GeometryObject_dealloc(GeometryObject* self) {
 }
 
 static PyMemberDef GeometryObject_members[] = {
-    {"_ptr", T_PYSSIZET, offsetof(GeometryObject, ptr), READONLY,
+    {"_geom", T_PYSSIZET, offsetof(GeometryObject, ptr), READONLY,
      "pointer to GEOSGeometry"},
-    {"_ptr_prepared", T_PYSSIZET, offsetof(GeometryObject, ptr_prepared), READONLY,
+    {"_geom_prepared", T_PYSSIZET, offsetof(GeometryObject, ptr_prepared), READONLY,
      "pointer to PreparedGEOSGeometry"},
     {NULL} /* Sentinel */
 };


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/999. This removes the `__geom__` dunder attribute and keeps `_geom` (renaming the `_ptr` inherited from pygeos to `_geom`).