### PR TITLE
API: all-empty GeometryCollection .geoms to return empty subgeoms

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -729,8 +729,6 @@ class BaseMultipartGeometry(BaseGeometry):
 
     @property
     def geoms(self):
-        if self.is_empty:
-            return []
         return GeometrySequence(self, self.shape_factory)
 
     def __bool__(self):

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -60,8 +60,6 @@ class GeometryCollection(BaseMultipartGeometry):
 
     @property
     def geoms(self):
-        if self.is_empty:
-            return []
         return HeterogeneousGeometrySequence(self)
 
 

--- a/shapely/tests/geometry/test_collection.py
+++ b/shapely/tests/geometry/test_collection.py
@@ -33,15 +33,7 @@ def test_empty(geom):
 
 
 def test_empty_subgeoms():
-    geom = shape(
-        {
-            "type": "GeometryCollection",
-            "geometries": [
-                {"type": "Point", "coordinates": ()},
-                {"type": "LineString", "coordinates": (())},
-            ],
-        }
-    )
+    geom = GeometryCollection([Point(), LineString()])
     assert geom.type == "GeometryCollection"
     assert geom.type == geom.geom_type
     assert geom.is_empty

--- a/shapely/tests/geometry/test_collection.py
+++ b/shapely/tests/geometry/test_collection.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from shapely import GeometryCollection, LineString, wkt
+from shapely import GeometryCollection, LineString, Point, wkt
 from shapely.geometry import shape
 
 
@@ -21,15 +21,6 @@ def geometrycollection_geojson():
     [
         GeometryCollection(),
         shape({"type": "GeometryCollection", "geometries": []}),
-        shape(
-            {
-                "type": "GeometryCollection",
-                "geometries": [
-                    {"type": "Point", "coordinates": ()},
-                    {"type": "LineString", "coordinates": (())},
-                ],
-            }
-        ),
         wkt.loads("GEOMETRYCOLLECTION EMPTY"),
     ],
 )
@@ -38,7 +29,24 @@ def test_empty(geom):
     assert geom.type == geom.geom_type
     assert geom.is_empty
     assert len(geom.geoms) == 0
-    assert geom.geoms == []
+    assert list(geom.geoms) == []
+
+
+def test_empty_subgeoms():
+    geom = shape(
+        {
+            "type": "GeometryCollection",
+            "geometries": [
+                {"type": "Point", "coordinates": ()},
+                {"type": "LineString", "coordinates": (())},
+            ],
+        }
+    )
+    assert geom.type == "GeometryCollection"
+    assert geom.type == geom.geom_type
+    assert geom.is_empty
+    assert len(geom.geoms) == 2
+    assert list(geom.geoms) == [Point(), LineString()]
 
 
 def test_child_with_deleted_parent():


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/956

Currently a GeometryCollection that consists of multiple empty geometries (which is considered as an empty geometry), does not return those geometries in the `.geoms` attribute (because of a special casing in our code for this, to specifically return an empty list).

Actually returning the empty subgeoms makes this more correct (the actual GEOS geometry has those empty subgeoms, also the WKT now displays them) and consistent with the top-level functions `get_num_geometries` / `get_geometry` (to index into the sub-geoms).