### PR TITLE
TST: Update benchmarks for pygeos=>shapely

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,10 +4,10 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "pygeos",
+    "project": "shapely",
 
     // The project's homepage
-    "project_url": "https://github.com/pygeos/pygeos",
+    "project_url": "https://github.com/shapely/shapely",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
@@ -51,7 +51,7 @@
     //"install_timeout": 600,
 
     // the base URL to show a commit for the project.
-    "show_commit_url": "http://github.com/caspervdw/pygeos/commit/",
+    "show_commit_url": "http://github.com/shapely/shapely/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
@@ -71,11 +71,11 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
-     "matrix": {
-         "Cython": [],
-         "numpy": [],
-         "geos": [],
-     },
+    "matrix": {
+        "Cython": [],
+        "numpy": [],
+        "geos": []
+    },
 
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional
@@ -124,7 +124,7 @@
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
-    "html_dir": ".asv/html",
+    "html_dir": ".asv/html"
 
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,5 +1,14 @@
+"""
+Shapely benchmarks
+
+These are run using asv: "pip install asv" or "conda install -c conda-forge asv"
+
+To run a specific test within the existing environment, e.g., PointPolygonTimeSuite:
+$ asv run -b PointPolygonTimeSuite -E 'existing'
+"""
+
 import numpy as np
-import pygeos
+import shapely
 
 
 # Seed the numpy random generator for more reproducible benchmarks
@@ -10,38 +19,38 @@ class PointPolygonTimeSuite:
     """Benchmarks running on 100000 points and one polygon"""
 
     def setup(self):
-        self.points = pygeos.points(np.random.random((100000, 2)))
-        self.polygon = pygeos.polygons(np.random.random((3, 2)))
+        self.points = shapely.points(np.random.random((100000, 2)))
+        self.polygon = shapely.polygons(np.random.random((3, 2)))
 
     def time_contains(self):
-        pygeos.contains(self.points, self.polygon)
+        shapely.contains(self.points, self.polygon)
 
     def time_distance(self):
-        pygeos.distance(self.points, self.polygon)
+        shapely.distance(self.points, self.polygon)
 
     def time_intersection(self):
-        pygeos.intersection(self.points, self.polygon)
+        shapely.intersection(self.points, self.polygon)
 
 
 class IOSuite:
     """Benchmarks I/O operations (WKT and WKB) on a set of 10000 polygons"""
 
     def setup(self):
-        self.to_write = pygeos.polygons(np.random.random((10000, 100, 2)))
-        self.to_read_wkt = pygeos.to_wkt(self.to_write)
-        self.to_read_wkb = pygeos.to_wkb(self.to_write)
+        self.to_write = shapely.polygons(np.random.random((10000, 100, 2)))
+        self.to_read_wkt = shapely.to_wkt(self.to_write)
+        self.to_read_wkb = shapely.to_wkb(self.to_write)
 
     def time_write_to_wkt(self):
-        pygeos.to_wkt(self.to_write)
+        shapely.to_wkt(self.to_write)
 
     def time_write_to_wkb(self):
-        pygeos.to_wkb(self.to_write)
+        shapely.to_wkb(self.to_write)
 
     def time_read_from_wkt(self):
-        pygeos.from_wkt(self.to_read_wkt)
+        shapely.from_wkt(self.to_read_wkt)
 
     def time_read_from_wkb(self):
-        pygeos.from_wkb(self.to_read_wkb)
+        shapely.from_wkb(self.to_read_wkb)
 
 
 class ConstructiveSuite:
@@ -49,22 +58,22 @@ class ConstructiveSuite:
 
     def setup(self):
         self.coords = np.random.random((10000, 2))
-        self.points = pygeos.points(self.coords)
+        self.points = shapely.points(self.coords)
 
     def time_voronoi_polygons(self):
-        pygeos.voronoi_polygons(self.points)
+        shapely.voronoi_polygons(self.points)
 
     def time_envelope(self):
-        pygeos.envelope(self.points)
+        shapely.envelope(self.points)
 
     def time_convex_hull(self):
-        pygeos.convex_hull(self.points)
+        shapely.convex_hull(self.points)
 
     def time_delaunay_triangles(self):
-        pygeos.delaunay_triangles(self.points)
+        shapely.delaunay_triangles(self.points)
 
     def time_box(self):
-        pygeos.box(*np.hstack([self.coords, self.coords + 100]).T)
+        shapely.box(*np.hstack([self.coords, self.coords + 100]).T)
 
 
 class ClipSuite:
@@ -72,22 +81,22 @@ class ClipSuite:
 
     def setup(self):
         # create irregular polygons by merging overlapping point buffers
-        self.polygon = pygeos.union_all(
-            pygeos.buffer(pygeos.points(np.random.random((1000, 2)) * 500), 10)
+        self.polygon = shapely.union_all(
+            shapely.buffer(shapely.points(np.random.random((1000, 2)) * 500), 10)
         )
         xmin = np.random.random(100) * 100
         xmax = xmin + 100
         ymin = np.random.random(100) * 100
         ymax = ymin + 100
         self.bounds = np.array([xmin, ymin, xmax, ymax]).T
-        self.boxes = pygeos.box(xmin, ymin, xmax, ymax)
+        self.boxes = shapely.box(xmin, ymin, xmax, ymax)
 
     def time_clip_by_box(self):
-        pygeos.intersection(self.polygon, self.boxes)
+        shapely.intersection(self.polygon, self.boxes)
 
     def time_clip_by_rect(self):
         for bounds in self.bounds:
-            pygeos.clip_by_rect(self.polygon, *bounds)
+            shapely.clip_by_rect(self.polygon, *bounds)
 
 
 class GetParts:
@@ -96,7 +105,7 @@ class GetParts:
     def setup(self):
         self.multipolygons = np.array(
             [
-                pygeos.multipolygons(pygeos.polygons(np.random.random((2, 100, 2))))
+                shapely.multipolygons(shapely.polygons(np.random.random((2, 100, 2))))
                 for i in range(10000)
             ],
             dtype=object,
@@ -104,15 +113,15 @@ class GetParts:
 
     def time_get_parts(self):
         """Cython implementation of get_parts"""
-        pygeos.get_parts(self.multipolygons)
+        shapely.get_parts(self.multipolygons)
 
     def time_get_parts_python(self):
         """Python / ufuncs version of get_parts"""
 
         parts = []
         for i in range(len(self.multipolygons)):
-            num_parts = pygeos.get_num_geometries(self.multipolygons[i])
-            parts.append(pygeos.get_geometry(self.multipolygons[i], range(num_parts)))
+            num_parts = shapely.get_num_geometries(self.multipolygons[i])
+            parts.append(shapely.get_geometry(self.multipolygons[i], range(num_parts)))
 
         parts = np.concatenate(parts)
 
@@ -122,56 +131,56 @@ class OverlaySuite:
 
     def setup(self):
         # create irregular polygons by merging overlapping point buffers
-        self.left = pygeos.union_all(
-            pygeos.buffer(pygeos.points(np.random.random((500, 2)) * 500), 15)
+        self.left = shapely.union_all(
+            shapely.buffer(shapely.points(np.random.random((500, 2)) * 500), 15)
         )
         # shift this up and right
-        self.right = pygeos.apply(self.left, lambda x: x + 50)
+        self.right = shapely.apply(self.left, lambda x: x + 50)
 
     def time_difference(self):
-        pygeos.difference(self.left, self.right)
+        shapely.difference(self.left, self.right)
 
     def time_difference_prec1(self):
-        pygeos.difference(self.left, self.right, grid_size=1)
+        shapely.difference(self.left, self.right, grid_size=1)
 
     def time_difference_prec2(self):
-        pygeos.difference(self.left, self.right, grid_size=2)
+        shapely.difference(self.left, self.right, grid_size=2)
 
     def time_intersection(self):
-        pygeos.intersection(self.left, self.right)
+        shapely.intersection(self.left, self.right)
 
     def time_intersection_prec1(self):
-        pygeos.intersection(self.left, self.right, grid_size=1)
+        shapely.intersection(self.left, self.right, grid_size=1)
 
     def time_intersection_prec2(self):
-        pygeos.intersection(self.left, self.right, grid_size=2)
+        shapely.intersection(self.left, self.right, grid_size=2)
 
     def time_symmetric_difference(self):
-        pygeos.symmetric_difference(self.left, self.right)
+        shapely.symmetric_difference(self.left, self.right)
 
     def time_symmetric_difference_prec1(self):
-        pygeos.symmetric_difference(self.left, self.right, grid_size=1)
+        shapely.symmetric_difference(self.left, self.right, grid_size=1)
 
     def time_symmetric_difference_prec2(self):
-        pygeos.symmetric_difference(self.left, self.right, grid_size=2)
+        shapely.symmetric_difference(self.left, self.right, grid_size=2)
 
     def time_union(self):
-        pygeos.union(self.left, self.right)
+        shapely.union(self.left, self.right)
 
     def time_union_prec1(self):
-        pygeos.union(self.left, self.right, grid_size=1)
+        shapely.union(self.left, self.right, grid_size=1)
 
     def time_union_prec2(self):
-        pygeos.union(self.left, self.right, grid_size=2)
+        shapely.union(self.left, self.right, grid_size=2)
 
     def time_union_all(self):
-        pygeos.union_all([self.left, self.right])
+        shapely.union_all([self.left, self.right])
 
     def time_union_all_prec1(self):
-        pygeos.union_all([self.left, self.right], grid_size=1)
+        shapely.union_all([self.left, self.right], grid_size=1)
 
     def time_union_all_prec2(self):
-        pygeos.union_all([self.left, self.right], grid_size=2)
+        shapely.union_all([self.left, self.right], grid_size=2)
 
 
 class STRtree:
@@ -179,32 +188,32 @@ class STRtree:
 
     def setup(self):
         # create irregular polygons my merging overlapping point buffers
-        self.polygons = pygeos.get_parts(
-            pygeos.union_all(
-                pygeos.buffer(pygeos.points(np.random.random((2000, 2)) * 500), 5)
+        self.polygons = shapely.get_parts(
+            shapely.union_all(
+                shapely.buffer(shapely.points(np.random.random((2000, 2)) * 500), 5)
             )
         )
-        self.tree = pygeos.STRtree(self.polygons)
+        self.tree = shapely.STRtree(self.polygons)
         # initialize the tree by making a tiny query first
-        self.tree.query(pygeos.points(0, 0))
+        self.tree.query(shapely.points(0, 0))
 
         # create points that extend beyond the domain of the above polygons to ensure
         # some don't overlap
-        self.points = pygeos.points((np.random.random((2000, 2)) * 750) - 125)
-        self.point_tree = pygeos.STRtree(
-            pygeos.points(np.random.random((2000, 2)) * 750)
+        self.points = shapely.points((np.random.random((2000, 2)) * 750) - 125)
+        self.point_tree = shapely.STRtree(
+            shapely.points(np.random.random((2000, 2)) * 750)
         )
-        self.point_tree.query(pygeos.points(0, 0))
+        self.point_tree.query(shapely.points(0, 0))
 
         # create points on a grid for testing equidistant nearest neighbors
         # creates 2025 points
         grid_coords = np.mgrid[:45, :45].T.reshape(-1, 2)
-        self.grid_point_tree = pygeos.STRtree(pygeos.points(grid_coords))
-        self.grid_points = pygeos.points(grid_coords + 0.5)
+        self.grid_point_tree = shapely.STRtree(shapely.points(grid_coords))
+        self.grid_points = shapely.points(grid_coords + 0.5)
 
     def time_tree_create(self):
-        tree = pygeos.STRtree(self.polygons)
-        tree.query(pygeos.points(0, 0))
+        tree = shapely.STRtree(self.polygons)
+        tree.query(shapely.points(0, 0))
 
     def time_tree_query_bulk(self):
         self.tree.query_bulk(self.polygons)
@@ -251,15 +260,15 @@ class STRtree:
         # result
         l, r = self.grid_point_tree.nearest(self.grid_points)
         # calculate distance to nearest neighbor
-        dist = pygeos.distance(
+        dist = shapely.distance(
             self.grid_points.take(l), self.grid_point_tree.geometries.take(r)
         )
         # include a slight epsilon to ensure nearest are within this radius
-        b = pygeos.buffer(self.grid_points, dist + 1e-8)
+        b = shapely.buffer(self.grid_points, dist + 1e-8)
 
         # query the tree for others in the same buffer distance
         left, right = self.grid_point_tree.query_bulk(b, predicate="intersects")
-        dist = pygeos.distance(
+        dist = shapely.distance(
             self.grid_points.take(left), self.grid_point_tree.geometries.take(right)
         )
 
@@ -311,9 +320,9 @@ class STRtree:
         # use an arbitrary search tolerance that seems appropriate for the density of
         # geometries
         tolerance = 200
-        b = pygeos.buffer(self.points, tolerance, quadsegs=1)
+        b = shapely.buffer(self.points, tolerance, quadsegs=1)
         left, right = self.tree.query_bulk(b)
-        dist = pygeos.distance(self.points.take(left), self.polygons.take(right))
+        dist = shapely.distance(self.points.take(left), self.polygons.take(right))
 
         # sort by left, distance
         ix = np.lexsort((right, dist, left))


### PR DESCRIPTION
This fixes the benchmark suite as part of the PyGEOS to Shapely 2.0 migration.  Other than minor whitespace changes, the only changes here are instructions at the top of `benchmarks.py` and find / replace `pygeos` => `shapely`.

Note: `STRtree` benchmarks are currently broken pending #1422 (they were written for the indices-only tree API).  The other benchmarks work properly.