### PR TITLE
Move static metadata from setup.py to setup.cfg, add sdist check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,10 @@ jobs:
 
       - name: Build a source tarball
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip
+          python -m pip install build twine
           python -m build --sdist
+          twine check --strict dist/*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,49 @@
+[metadata]
+name = shapely
+author = Sean Gillies
+maintainer = Shapely contributors
+description = Manipulation and analysis of geometric objects
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+keywords = geometry, topology, gis
+license = BSD 3-Clause
+url = https://github.com/shapely/shapely
+project_urls =
+    documentation = https://shapely.readthedocs.io/
+    repository = https://github.com/shapely/shapely
+    changelog = https://github.com/shapely/shapely/blob/main/CHANGELOG.rst
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: Unix
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Scientific/Engineering :: GIS
+
+[options]
+include_package_data = True
+packages = find:
+python_requires = >=3.6
+install_requires =
+    numpy>=1.13
+
+[options.extras_require]
+test = pytest
+docs = sphinx; numpydoc
+
+[options.packages.find]
+include =
+    shapely
+    shapely.*
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -204,51 +204,14 @@ else:
     )
 
 
-try:
-    descr = open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
-except IOError:
-    descr = ""
-
-
 version = versioneer.get_version()
 cmdclass = versioneer.get_cmdclass()
 cmdclass["build_ext"] = build_ext
 
 
+# see setup.cfg for static project metadata
 setup(
-    name="shapely",
     version=version,
-    description="Manipulation and analysis of geometric objects",
-    long_description=descr,
-    license="BSD 3-Clause",
-    url="https://github.com/shapely/shapely",
-    keywords="geometry topology gis",
-    author="Sean Gillies",
-    maintainer="Shapely contributors",
-    packages=find_packages(include=["shapely", "shapely.*"]),
-    install_requires=["numpy>=1.13"],
-    python_requires=">=3.6",
-    extras_require={
-        "test": ["pytest"],
-        "docs": ["sphinx", "numpydoc"],
-    },
-    include_package_data=True,
     ext_modules=ext_modules,
     cmdclass=cmdclass,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: Unix",
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Topic :: Scientific/Engineering :: GIS",
-    ],
 )


### PR DESCRIPTION
This is an alternative proposal to #1426 following [these setuptools instructions](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) to move static metadata from `setup.py` to `setup.cfg`. Curious to see how the outcome of release.yml compares.