### PR TITLE
CI: add testing for 2022, including GEOS-3.11 (maint-1.8)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3]
+        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, 3.11.0]
         include:
           # 2017
           - python: 3.6
@@ -75,6 +75,18 @@ jobs:
             speedups: 0
           - python: "3.10"
             geos: 3.10.3
+            speedups: 0
+          # 2022
+          - python: "3.10"  # switch to "3.11" when released (PEP 664)
+            geos: 3.11.0
+            numpy: 1.23.0
+            speedups: 1
+          - python: "3.10"
+            geos: 3.11.0
+            numpy: 1.23.0
+            speedups: 0
+          - python: "3.10"
+            geos: 3.11.0
             speedups: 0
           # enable two 32-bit windows builds
           - os: windows-2019

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -9,9 +9,11 @@ class OperationsTestCase(unittest.TestCase):
         left = line1.parallel_offset(5, 'left')
         self.assertEqual(left, LineString([(0, 5), (10, 5)]))
         right = line1.parallel_offset(5, 'right')
-        self.assertEqual(right, LineString([(10, -5), (0, -5)]))
+        # using spatial equality because the order of coordinates is not guaranteed
+        # (GEOS 3.11 changed this, see https://github.com/shapely/shapely/issues/1436)
+        assert right.equals(LineString([(10, -5), (0, -5)]))
         right = line1.parallel_offset(-5, 'left')
-        self.assertEqual(right, LineString([(10, -5), (0, -5)]))
+        assert right.equals(LineString([(10, -5), (0, -5)]))
         left = line1.parallel_offset(-5, 'right')
         self.assertEqual(left, LineString([(0, 5), (10, 5)]))
 


### PR DESCRIPTION
Similar to #1437 but for the maintenance branch for shapely 1.8