### PR TITLE
Require Python 3.7+, NumPy 1.14+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: pp* *musllinux* cp310-manylinux_i686
+          CIBW_SKIP: cp36-* pp* *musllinux* cp310-manylinux_i686
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
         geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, 3.11.0, main]
         include:
           # 2017
-          - python: 3.6
+          - python: 3.7  # 3.6 is dropped
             geos: 3.6.5
-            numpy: 1.13.3
+            numpy: 1.14.6
           # 2018
           - python: 3.7
             geos: 3.7.5
@@ -49,9 +49,9 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: 3.6
-            geos: 3.6.5
-            numpy: 1.13.3
+            python: 3.7
+            geos: 3.7.5
+            numpy: 1.15.4
           - os: windows-2019
             architecture: x86
             python: 3.9

--- a/README.rst
+++ b/README.rst
@@ -111,9 +111,9 @@ Requirements
 
 Shapely 2.0 requires
 
-* Python >=3.6
+* Python >=3.7
 * GEOS >=3.5
-* NumPy >=1.13
+* NumPy >=1.14
 
 Installing Shapely
 ==================

--- a/setup.py
+++ b/setup.py
@@ -226,8 +226,8 @@ setup(
     author="Sean Gillies",
     maintainer="Shapely contributors",
     packages=find_packages(include=["shapely", "shapely.*"]),
-    install_requires=["numpy>=1.13"],
-    python_requires=">=3.6",
+    install_requires=["numpy>=1.14"],
+    python_requires=">=3.7",
     extras_require={
         "test": ["pytest"],
         "docs": ["sphinx", "numpydoc"],
@@ -244,7 +244,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
For Shapely 2.0, it time to finally drop Python 3.6. NumPy 1.14+ is required for Python 3.7+ support.

As well removing an old version of Python, this will enable #1426 to move static metadata to `pyproject.toml`.

Closes #1205