### PR TITLE
Add CITATION.cff, remove CITATION.txt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,3 +15,11 @@ jobs:
 
       - name: Run black, flake8 and isort
         uses: pre-commit/action@v2.0.0
+
+      - name: Validate citation file
+        shell: bash
+        run: |
+          python -m pip install cffconvert
+          cffconvert --validate
+          cffconvert -f bibtex
+          cffconvert -f apalike

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,6 @@ authors:
     orcid: https://orcid.org/0000-0002-8401-9184
   - given-names: Casper
     family-names: "van der Wel"
-    affiliation: "Nelen & Schuurmans"
     orcid: https://orcid.org/0000-0002-0488-2237
   - given-names: Joris
     family-names: "Van den Bossche"
@@ -30,6 +29,7 @@ authors:
     family-names: Ward
     affiliation: "Astute Spruce, LLC"
     orcid: https://orcid.org/0000-0002-0813-9774
+  - name: others
 keywords:
   - cartography
   - geometry

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,18 +22,14 @@ authors:
     orcid: https://orcid.org/0000-0003-3284-2977
   - given-names: "Mike W."
     family-names: Taves
-    email: mwtoews@gmail.com
     affiliation: "GNS Science"
     orcid: https://orcid.org/0000-0003-3657-7963
   - given-names: Joshua
     family-names: Arnott
-  - given-names: Oliver
-    family-names: Tonnhofer
   - given-names: "Brendan C."
     family-names: Ward
     affiliation: "Astute Spruce, LLC"
     orcid: https://orcid.org/0000-0002-0813-9774
-  - name: "Other Shapely contributors"
 keywords:
   - cartography
   - geometry

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+message: "Please cite this software using these metadata."
+type: software
+title: Shapely
+version: "2.0"
+# date-released: "2022-MM-DD"
+# doi: 10.5281/zenodo.#######
+abstract: "Manipulation and analysis of geometric objects in the Cartesian plane."
+repository-artifact: https://pypi.org/project/Shapely
+repository-code: https://github.com/shapely/shapely
+license: "BSD-3-Clause"
+authors:
+  - given-names: Sean
+    family-names: Gillies
+    orcid: https://orcid.org/0000-0002-8401-9184
+  - given-names: Casper
+    family-names: "van der Wel"
+    affiliation: "Nelen & Schuurmans"
+    orcid: https://orcid.org/0000-0002-0488-2237
+  - given-names: Joris
+    family-names: "Van den Bossche"
+    orcid: https://orcid.org/0000-0003-3284-2977
+  - given-names: "Mike W."
+    family-names: Taves
+    email: mwtoews@gmail.com
+    affiliation: "GNS Science"
+    orcid: https://orcid.org/0000-0003-3657-7963
+  - family-names: Arnott
+    given-names: Joshua
+  - family-names: Tonnhofer
+    given-names: Oliver
+  - family-names: Ward
+    given-names: Brendan
+    affiliation: "Astute Spruce, LLC"
+    orcid: https://orcid.org/0000-0002-0813-9774
+keywords:
+  - cartography
+  - geometry
+  - GEOS
+  - GIS
+  - topology

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,14 +25,15 @@ authors:
     email: mwtoews@gmail.com
     affiliation: "GNS Science"
     orcid: https://orcid.org/0000-0003-3657-7963
-  - family-names: Arnott
-    given-names: Joshua
-  - family-names: Tonnhofer
-    given-names: Oliver
-  - family-names: Ward
-    given-names: Brendan
+  - given-names: Joshua
+    family-names: Arnott
+  - given-names: Oliver
+    family-names: Tonnhofer
+  - given-names: "Brendan C."
+    family-names: Ward
     affiliation: "Astute Spruce, LLC"
     orcid: https://orcid.org/0000-0002-0813-9774
+  - name: "Other Shapely contributors"
 keywords:
   - cartography
   - geometry

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,13 +21,11 @@ authors:
     orcid: https://orcid.org/0000-0003-3284-2977
   - given-names: "Mike W."
     family-names: Taves
-    affiliation: "GNS Science"
     orcid: https://orcid.org/0000-0003-3657-7963
   - given-names: Joshua
     family-names: Arnott
   - given-names: "Brendan C."
     family-names: Ward
-    affiliation: "Astute Spruce, LLC"
     orcid: https://orcid.org/0000-0002-0813-9774
   - name: others
 keywords:

--- a/CITATION.txt
+++ b/CITATION.txt
@@ -1,9 +1,0 @@
-If you use Shapely for any published work, please cite it using the reference
-below:
-
-@Misc{shapely,
-  author =    {Sean Gillies and others},
-  title =     {Shapely: manipulation and analysis of geometric objects},
-  year =      {2007--},
-  url =       {https://github.com/shapely/shapely},
-}


### PR DESCRIPTION
This PR adds a [CITATION.cff](https://citation-file-format.github.io/) file, to replace CITATION.txt. As documented elsewhere, this file is used by a variety of sources, including GitHub, Zenodo, and others. It can be converted into other citation formats, like bibTeX.

The file is intended to be used to cite the software (not the manual), and should ideally be updated before each release to update "version" and "date-released" fields. (If there were a HOW-TO-RELEASE document, then I'd add this note.)

It does not require any integration with Zenodo, but if it were enabled (@sgillies would need to do this for #1379) then a DOI would be issued for each release or tag pushed from GitHub. (There is already a placeholder in README.rst left over from PyGEOS to show the latest DOI). I've experimented in with sandbox.zenodo.org, [and here is what it would look like](https://sandbox.zenodo.org/record/1085914).

I've added a basic validator, but I'm aware that [other's exist too](https://github.com/marketplace/actions/cff-validator). Mine renders the citation as bibTeX and APA-like.

This file more-or-less controls the metadata used to render citations for tools like Zenodo. And with this, I've assigned a subset of [contributors](https://github.com/shapely/shapely/graphs/contributors) as authors: @sgillies @caspervdw @jorisvandenbossche @mwtoews @snorfalorpagus @olt and @brendan-ward . Please let me know if you don't want to be here, and if you do want to stay in the citation, please check the metadata that I've prepared, e.g. that the ORCiD that I've searched is correct. Other attributes can be add, modified or removed. And if I've left out someone that really feels they've made a significant contribution, then leave a comment here.