### PR TITLE
CI: macOS-10.15 is deprecated, upgrade to macOS-11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,13 @@ jobs:
         - os: windows-2019
           arch: AMD64
           msvc_arch: x64
-        - os: macos-10.15
+        - os: macos-11
           arch: x86_64
           cmake_osx_architectures: x86_64
-        - os: macos-10.15
+        - os: macos-11
           arch: arm64
           cmake_osx_architectures: arm64
-        - os: macos-10.15
+        - os: macos-11
           arch: universal2
           cmake_osx_architectures: "x86_64;arm64"
 


### PR DESCRIPTION
Shown in recent builds:
> The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583