### PR TITLE
MAINT: remove workarounds when numpy was optional

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -9,18 +9,12 @@ import math
 from itertools import islice
 from warnings import warn
 
+import numpy as np
+
 import shapely
 from shapely.affinity import affine_transform
 from shapely.coords import CoordinateSequence
 from shapely.errors import GeometryTypeError, GEOSException, ShapelyDeprecationWarning
-
-try:
-    import numpy as np
-
-    integer_types = (int, np.integer)
-except ImportError:
-    integer_types = (int,)
-
 
 GEOMETRY_TYPES = [
     "Point",
@@ -849,7 +843,7 @@ class GeometrySequence:
 
     def __getitem__(self, key):
         m = self.__len__()
-        if isinstance(key, integer_types):
+        if isinstance(key, (int, np.integer)):
             if key + m < 0 or key >= m:
                 raise IndexError("index out of range")
             if key < 0:

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,6 +1,8 @@
 """
 Geometry factories based on the geo interface
 """
+import numpy as np
+
 from shapely.errors import GeometryTypeError
 
 from .collection import GeometryCollection
@@ -11,14 +13,6 @@ from .multipolygon import MultiPolygon
 from .point import Point
 from .polygon import LinearRing, Polygon
 
-# numpy is an optional dependency
-try:
-    import numpy as np
-except ImportError:
-    _has_numpy = False
-else:
-    _has_numpy = True
-
 
 def _is_coordinates_empty(coordinates):
     """Helper to identify if coordinates or subset of coordinates are empty"""
@@ -26,8 +20,7 @@ def _is_coordinates_empty(coordinates):
     if coordinates is None:
         return True
 
-    is_numpy_array = _has_numpy and isinstance(coordinates, np.ndarray)
-    if isinstance(coordinates, (list, tuple)) or is_numpy_array:
+    if isinstance(coordinates, (list, tuple, np.ndarray)):
         if len(coordinates) == 0:
             return True
         return all(map(_is_coordinates_empty, coordinates))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,23 +11,14 @@ if os.name == 'nt' and sys.version_info[1] >= 8:
 
 from shapely.geos import geos_version_string
 
+import numpy
 import pytest
 
-
-test_int_types = [int]
-
-try:
-    import numpy
-    numpy_version = numpy.version.version
-    test_int_types.extend([int, numpy.int16, numpy.int32, numpy.int64])
-except ImportError:
-    numpy = False
-    numpy_version = 'not available'
 
 # Show some diagnostic information; handy for CI
 print('Python version: ' + sys.version.replace('\n', ' '))
 print('GEOS version: ' + geos_version_string)
-print('Numpy version: ' + numpy_version)
+print('Numpy version: ' + numpy.version.version)
 
 
 shapely20_deprecated = pytest.mark.filterwarnings(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
-import sys
-
+import numpy
 import pytest
 
 from shapely.geos import geos_version
@@ -13,11 +12,5 @@ shapely20_wontfix = pytest.mark.xfail(strict=True, reason="Will fail for Shapely
 
 
 def pytest_report_header(config):
-    headers = []
-    try:
-        import numpy
-    except ImportError:
-        headers.append("numpy: not available")
-    else:
-        headers.append("numpy: {}".format(numpy.__version__))
-    return '\n'.join(headers)
+    """Header for pytest."""
+    return f"dependencies: numpy-{numpy.__version__}"

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,13 +1,12 @@
-from . import unittest
 from math import pi
+
+import numpy as np
+
 from shapely import affinity
 from shapely.wkt import loads as load_wkt
 from shapely.geometry import Point
 
-try:
-    import numpy
-except ImportError:
-    numpy = False
+from . import unittest
 
 
 class AffineTestCase(unittest.TestCase):
@@ -164,17 +163,16 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(rls.equals(els))
 
-    @unittest.skipIf(not numpy, 'numpy not installed')
     def test_rotate_angle_array(self):
         ls = load_wkt('LINESTRING(240 400, 240 300, 300 300)')
         els = load_wkt('LINESTRING(220 320, 320 320, 320 380)')
         # check with degrees
-        theta = numpy.array([90.0])
+        theta = np.array([90.0])
         rls = affinity.rotate(ls, theta)
         self.assertEqual(theta[0], 90.0)
         self.assertTrue(rls.equals(els))
         # check with radians
-        theta = numpy.array([pi/2])
+        theta = np.array([pi/2])
         rls = affinity.rotate(ls, theta, use_radians=True)
         self.assertEqual(theta[0], pi/2)
         self.assertTrue(rls.equals(els))
@@ -261,20 +259,19 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(sls.equals(els))
 
-    @unittest.skipIf(not numpy, 'numpy not installed')
     def test_skew_xs_ys_array(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
         els = load_wkt('LINESTRING (253.39745962155615 417.3205080756888, '
                        '226.60254037844385 317.3205080756888, '
                        '286.60254037844385 282.67949192431126)')
         # check with degrees
-        xs_ys = numpy.array([15.0, -30.0])
+        xs_ys = np.array([15.0, -30.0])
         sls = affinity.skew(ls, xs_ys[0:1], xs_ys[1:2])
         self.assertEqual(xs_ys[0], 15.0)
         self.assertEqual(xs_ys[1], -30.0)
         self.assertTrue(sls.equals_exact(els, 1e-6))
         # check with radians
-        xs_ys = numpy.array([pi/12, -pi/6])
+        xs_ys = np.array([pi/12, -pi/6])
         sls = affinity.skew(ls, xs_ys[0:1], xs_ys[1:2], use_radians=True)
         self.assertEqual(xs_ys[0], pi/12)
         self.assertEqual(xs_ys[1], -pi/6)

--- a/tests/test_ndarrays.py
+++ b/tests/test_ndarrays.py
@@ -1,23 +1,18 @@
 # Tests of support for Numpy ndarrays. See
 # https://github.com/sgillies/shapely/issues/26 for discussion.
-# Requires numpy.
 
 from functools import reduce
+
+import numpy as np
 
 from . import unittest, shapely20_deprecated
 from shapely import geometry
 
-try:
-    import numpy
-except ImportError:
-    numpy = False
-
 
 class TransposeTestCase(unittest.TestCase):
 
-    @unittest.skipIf(not numpy, 'numpy not installed')
     def test_multipoint(self):
-        arr = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        arr = np.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         tarr = arr.T
         shape = geometry.MultiPoint(tarr)
         coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape.geoms])
@@ -26,9 +21,8 @@ class TransposeTestCase(unittest.TestCase):
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
         )
 
-    @unittest.skipIf(not numpy, 'numpy not installed')
     def test_linestring(self):
-        a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        a = np.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         t = a.T
         s = geometry.LineString(t)
         self.assertEqual(
@@ -36,9 +30,8 @@ class TransposeTestCase(unittest.TestCase):
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
         )
 
-    @unittest.skipIf(not numpy, 'numpy not installed')
     def test_polygon(self):
-        a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        a = np.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         t = a.T
         s = geometry.Polygon(t)
         self.assertEqual(


### PR DESCRIPTION
This cleans up some logic that was used when numpy was optional. As of shapely-2.0 it is required.