### PR TITLE
CLN: Rename `__p__`→`_parent`, clean-up `gtag`, `_factory` and `__rings__`

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -824,22 +824,22 @@ class GeometrySequence:
 
     # Attributes
     # ----------
-    # __p__ : object
+    # _parent : object
     #     Parent (Shapely) geometry
-    __p__ = None
+    _parent = None
 
     def __init__(self, parent):
-        self.__p__ = parent
+        self._parent = parent
 
     def _get_geom_item(self, i):
-        return shapely.get_geometry(self.__p__, i)
+        return shapely.get_geometry(self._parent, i)
 
     def __iter__(self):
         for i in range(self.__len__()):
             yield self._get_geom_item(i)
 
     def __len__(self):
-        return shapely.get_num_geometries(self.__p__)
+        return shapely.get_num_geometries(self._parent)
 
     def __getitem__(self, key):
         m = self.__len__()
@@ -856,7 +856,7 @@ class GeometrySequence:
             start, stop, stride = key.indices(m)
             for i in range(start, stop, stride):
                 res.append(self._get_geom_item(i))
-            return type(self.__p__)(res or None)
+            return type(self._parent)(res or None)
         else:
             raise TypeError("key must be an index or slice")
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -121,16 +121,13 @@ shapely.lib.registry[2] = LinearRing
 
 class InteriorRingSequence:
 
-    _factory = None
-    __p__ = None
+    _parent = None
     _ndim = None
     _index = 0
     _length = 0
-    __rings__ = None
-    _gtag = None
 
     def __init__(self, parent):
-        self.__p__ = parent
+        self._parent = parent
         self._ndim = parent._ndim
 
     def __iter__(self):
@@ -147,7 +144,7 @@ class InteriorRingSequence:
             raise StopIteration
 
     def __len__(self):
-        return shapely.get_num_interior_rings(self.__p__)
+        return shapely.get_num_interior_rings(self._parent)
 
     def __getitem__(self, key):
         m = self.__len__()
@@ -168,11 +165,8 @@ class InteriorRingSequence:
         else:
             raise TypeError("key must be an index or slice")
 
-    def gtag(self):
-        return hash(repr(self.__p__))
-
     def _get_ring(self, i):
-        return shapely.get_interior_ring(self.__p__, i)
+        return shapely.get_interior_ring(self._parent, i)
 
 
 class Polygon(BaseGeometry):


### PR DESCRIPTION
This was partially discussed in #983 to rename a few variables. But also clean-up variables that are no longer used with shapely-2.

- Rename `__p__`→`_parent` to make it "private", and generally [avoid non-standard dunder names](https://dbader.org/blog/meaning-of-underscores-in-python). Another consideration is to rename it to `__parent` to enable name mangling for sub classes, see docs [Private Variable](https://docs.python.org/3/tutorial/classes.html#private-variables) and [Reserved classes of identifiers](https://docs.python.org/3/reference/lexical_analysis.html#reserved-classes-of-identifiers). Another consideration is with [`__del__`](https://docs.python.org/3/reference/datamodel.html#object.__del__), "Python guarantees that globals whose name begins with a single underscore are deleted from their module before other globals are deleted", implying that a double underscore variable would be deleted last.
- Remove unused `_factory`, which was formerly a callable that returned instances of Shapely geometries, i.e. `geom_factory`
- Remove unused `__rings__`, which was another former structure