### PR TITLE
ENH: expose fixed precision overlay (grid_size keyword) in the Geometry methods as well

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -476,7 +476,7 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.normalize(self)
 
-    # Binary (overlay) operations
+    # Overlay operations
     # ---------------------------
 
     def difference(self, other, grid_size=None):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -476,25 +476,40 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.normalize(self)
 
-    # Binary operations
-    # -----------------
+    # Binary (overlay) operations
+    # ---------------------------
 
-    def difference(self, other):
-        """Returns the difference of the geometries"""
-        return shapely.difference(self, other)
+    def difference(self, other, grid_size=None):
+        """
+        Returns the difference of the geometries.
 
-    def intersection(self, other):
-        """Returns the intersection of the geometries"""
-        return shapely.intersection(self, other)
+        Refer to `shapely.difference` for full documentation.
+        """
+        return shapely.difference(self, other, grid_size=grid_size)
 
-    def symmetric_difference(self, other):
-        """Returns the symmetric difference of the geometries
-        (Shapely geometry)"""
-        return shapely.symmetric_difference(self, other)
+    def intersection(self, other, grid_size=None):
+        """
+        Returns the intersection of the geometries.
 
-    def union(self, other):
-        """Returns the union of the geometries (Shapely geometry)"""
-        return shapely.union(self, other)
+        Refer to `shapely.intersection` for full documentation.
+        """
+        return shapely.intersection(self, other, grid_size=grid_size)
+
+    def symmetric_difference(self, other, grid_size=None):
+        """
+        Returns the symmetric difference of the geometries.
+
+        Refer to `shapely.symmetric_difference` for full documentation.
+        """
+        return shapely.symmetric_difference(self, other, grid_size=grid_size)
+
+    def union(self, other, grid_size=None):
+        """
+        Returns the union of the geometries.
+
+        Refer to `shapely.union` for full documentation.
+        """
+        return shapely.union(self, other, grid_size=grid_size)
 
     # Unary predicates
     # ----------------

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -99,3 +99,17 @@ def test_reverse():
     line = LineString(coords)
     result = line.reverse()
     assert result.coords[:] == coords[::-1]
+
+
+@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
+@pytest.mark.parametrize(
+    "op", ["union", "intersection", "difference", "symmetric_difference"]
+)
+@pytest.mark.parametrize("grid_size", [0, 1, 2])
+def test_binary_op_grid_size(op, grid_size):
+    geom1 = shapely.box(0, 0, 2.5, 2.5)
+    geom2 = shapely.box(2, 2, 3, 3)
+
+    result = getattr(geom1, op)(geom2, grid_size=grid_size)
+    expected = getattr(shapely, op)(geom1, geom2, grid_size=grid_size)
+    assert result == expected


### PR DESCRIPTION
The fixed precision overlay operation (part of OverlayNG from GEOS) is a new feature in 2.0, and this is already available in the new top-level functions, but it would be good to expose this on the existing methods as well. This is adding the `grid_size` keyword and passing this through.