### PR TITLE
CI: macOS-10.15 is deprecated, upgrade to macOS-11 (maint-1.8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,13 @@ jobs:
         - os: windows-2019
           arch: AMD64
           msvc_arch: x64
-        - os: macos-10.15
+        - os: macos-11
           arch: x86_64
           cmake_osx_architectures: x86_64
-        - os: macos-10.15
+        - os: macos-11
           arch: arm64
           cmake_osx_architectures: arm64
-        - os: macos-10.15
+        - os: macos-11
           arch: universal2
           cmake_osx_architectures: "x86_64;arm64"
 


### PR DESCRIPTION
This is a backport of #1458