### PR TITLE
BUG: fix versioneer.py to work with PEP 660

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1550,6 +1550,8 @@ def get_cmdclass():
             cfg = get_config_from_root(root)
             versions = get_versions()
             _build_py.run(self)
+            if self.editable_mode:
+                return
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:


### PR DESCRIPTION
A fresh issue with editable installs (`pip install -e .`) with `pyproject.toml`-based projects just cropped up with #1467, which has a comment:
> error: Support for editable installs via [PEP 660](https://peps.python.org/pep-0660/) was recently introduced in `setuptools`. If you are seeing this error, please report to: https://github.com/pypa/setuptools/issues

The fix in this PR applies the second suggestion [described here](https://github.com/pypa/setuptools/issues/3501#issuecomment-1212476025). I might watch other solutions for another day, as this is relatively fresh.