### PR TITLE
CLN: actually remove the base class Geometry() constructor

### DIFF
--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -77,6 +77,11 @@ def test_comparison_notimplemented(geom):
     assert not result.any()
 
 
+def test_base_class_not_callable():
+    with pytest.raises(TypeError):
+        shapely.Geometry("POINT (1 1)")
+
+
 def test_GeometryType_deprecated():
     geom = Point(1, 1)
 

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -504,37 +504,6 @@ def test_box_nan(coords):
     assert shapely.box(*coords) is None
 
 
-class BaseGeometry(shapely.Geometry):
-    @property
-    def type_id(self):
-        return shapely.get_type_id(self)
-
-
-class Point(BaseGeometry):
-    @property
-    def x(self):
-        return shapely.get_x(self)
-
-    @property
-    def y(self):
-        return shapely.get_y(self)
-
-
-@pytest.fixture
-def with_point_in_registry():
-    orig = shapely.lib.registry[0]
-    shapely.lib.registry[0] = Point
-    yield
-    shapely.lib.registry[0] = orig
-
-
-def test_subclasses(with_point_in_registry):
-    for _point in [Point("POINT (1 1)"), shapely.points(1, 1)]:
-        assert isinstance(_point, Point)
-        assert shapely.get_type_id(_point) == shapely.GeometryType.POINT
-        assert _point.x == 1
-
-
 def test_prepare():
     arr = np.array([shapely.points(1, 1), None, shapely.box(0, 0, 1, 1)])
     assert arr[0]._geom_prepared == 0
@@ -560,14 +529,6 @@ def test_destroy_prepared():
     assert arr[1] is None
     assert arr[2]._geom_prepared == 0
     shapely.destroy_prepared(arr)  # does not error
-
-
-def test_subclass_is_geometry(with_point_in_registry):
-    assert shapely.is_geometry(Point("POINT (1 1)"))
-
-
-def test_subclass_is_valid_input(with_point_in_registry):
-    assert shapely.is_valid_input(Point("POINT (1 1)"))
 
 
 @pytest.mark.parametrize("geom_type", [None, GeometryType.MISSING, -1])

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -380,21 +380,6 @@ finish:
   return result;
 }
 
-static PyObject* GeometryObject_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-  PyObject* value;
-
-  if (!PyArg_ParseTuple(args, "O", &value)) {
-    return NULL;
-  } else if (PyUnicode_Check(value)) {
-    return GeometryObject_FromWKT(value);
-  } else if (PyBytes_Check(value)) {
-    return GeometryObject_FromWKB(value);
-  } else {
-    PyErr_Format(PyExc_TypeError, "Expected string, got %s", value->ob_type->tp_name);
-    return NULL;
-  }
-}
-
 static PyMethodDef GeometryObject_methods[] = {
     {NULL} /* Sentinel */
 };
@@ -405,7 +390,6 @@ PyTypeObject GeometryType = {
     .tp_basicsize = sizeof(GeometryObject),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = GeometryObject_new,
     .tp_dealloc = (destructor)GeometryObject_dealloc,
     .tp_members = GeometryObject_members,
     .tp_methods = GeometryObject_methods,


### PR DESCRIPTION
Closes #1330

In https://github.com/shapely/shapely/pull/1414 we already removed all usage of the base class Geometry() constructor in code, tests and documentation. But the constructor itself wasn't yet removed, so it could still be called. This PR also actually makes the base class not callable.