### PR TITLE
Fix GEOSMinimumClearance signature.

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -521,8 +521,8 @@ def prototype(lgeos, geos_version):
             c_void_p, py_object, c_void_p, lgeos.GEOSDistanceCallback, py_object]
         lgeos.GEOSSTRtree_nearest_generic.restype = c_void_p
 
-        lgeos.GEOSMinimumClearance.argtypes = [c_void_p]
-        lgeos.GEOSMinimumClearance.restype = c_double
+        lgeos.GEOSMinimumClearance.argtypes = [c_void_p, POINTER(c_double)]
+        lgeos.GEOSMinimumClearance.restype = c_int
 
     if geos_version >= (3, 8, 0):
         lgeos.GEOSMakeValid.restype = c_void_p


### PR DESCRIPTION
This seems to fix a segmentation fault when calling this function in the test suite on aarch64-darwin. Fixes #1473.