### PR TITLE
DEPR: deprecate the type attribute

### DIFF
--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -92,7 +92,7 @@ def interpret_origin(geom, origin, ndim):
         origin = geom.centroid.coords[0]
     elif isinstance(origin, str):
         raise ValueError(f"'origin' keyword {origin!r} is not recognized")
-    elif hasattr(origin, "type") and origin.type == "Point":
+    elif getattr(origin, "geom_type", None) == "Point":
         origin = origin.coords[0]
 
     # origin should now be tuple-like

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -34,15 +34,15 @@ def dump_coords(geom):
         raise ValueError(
             "Must be instance of a geometry class; found " + geom.__class__.__name__
         )
-    elif geom.type in ("Point", "LineString", "LinearRing"):
+    elif geom.geom_type in ("Point", "LineString", "LinearRing"):
         return geom.coords[:]
-    elif geom.type == "Polygon":
+    elif geom.geom_type == "Polygon":
         return geom.exterior.coords[:] + [i.coords[:] for i in geom.interiors]
-    elif geom.type.startswith("Multi") or geom.type == "GeometryCollection":
+    elif geom.geom_type.startswith("Multi") or geom.geom_type == "GeometryCollection":
         # Recursive call
         return [dump_coords(part) for part in geom.geoms]
     else:
-        raise GeometryTypeError("Unhandled geometry type: " + repr(geom.type))
+        raise GeometryTypeError("Unhandled geometry type: " + repr(geom.geom_type))
 
 
 class CAP_STYLE:
@@ -157,6 +157,12 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def type(self):
+        warn(
+            "The 'type' attribute is deprecated, and will be removed in "
+            "the future. You can use the 'geom_type' attribute instead.",
+            ShapelyDeprecationWarning,
+            stacklevel=2,
+        )
         return self.geom_type
 
     @property

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -77,7 +77,7 @@ def shape(context):
 
     >>> context = {'type': 'Point', 'coordinates': [0, 1]}
     >>> geom = shape(context)
-    >>> geom.type == 'Point'
+    >>> geom.geom_type == 'Point'
     True
     >>> geom.wkt
     'POINT (0 1)'

--- a/shapely/tests/geometry/test_collection.py
+++ b/shapely/tests/geometry/test_collection.py
@@ -25,8 +25,7 @@ def geometrycollection_geojson():
     ],
 )
 def test_empty(geom):
-    assert geom.type == "GeometryCollection"
-    assert geom.type == geom.geom_type
+    assert geom.geom_type == "GeometryCollection"
     assert geom.is_empty
     assert len(geom.geoms) == 0
     assert list(geom.geoms) == []
@@ -34,8 +33,7 @@ def test_empty(geom):
 
 def test_empty_subgeoms():
     geom = GeometryCollection([Point(), LineString()])
-    assert geom.type == "GeometryCollection"
-    assert geom.type == geom.geom_type
+    assert geom.geom_type == "GeometryCollection"
     assert geom.is_empty
     assert len(geom.geoms) == 2
     assert list(geom.geoms) == [Point(), LineString()]

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -86,6 +86,15 @@ def test_GeometryType_deprecated():
     assert geom_type == geom.geom_type
 
 
+def test_type_deprecated():
+    geom = Point(1, 1)
+
+    with pytest.warns(ShapelyDeprecationWarning):
+        geom_type = geom.type
+
+    assert geom_type == geom.geom_type
+
+
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_segmentize():
     line = LineString([(0, 0), (0, 10)])

--- a/tests/test_linemerge.py
+++ b/tests/test_linemerge.py
@@ -40,4 +40,4 @@ class LineMergeTestCase(unittest.TestCase):
             ((1, 0), (0, 1)),
         ]
         result = linemerge(lines5)
-        self.assertEqual(result.type, "MultiLineString")
+        self.assertEqual(result.geom_type, "MultiLineString")

--- a/tests/test_make_valid.py
+++ b/tests/test_make_valid.py
@@ -9,7 +9,7 @@ def test_make_valid_invalid_input():
     geom = Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)])
     valid = make_valid(geom)
     assert len(valid.geoms) == 2
-    assert all(geom.type == 'Polygon' for geom in valid.geoms)
+    assert all(geom.geom_type == 'Polygon' for geom in valid.geoms)
 
 
 @requires_geos_38

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -20,5 +20,5 @@ def test_pickle_round_trip(cls, coords):
     geom2 = loads(data)
     assert geom2.has_z == geom1.has_z
     assert type(geom2) is type(geom1)
-    assert geom2.type == geom1.type
+    assert geom2.geom_type == geom1.geom_type
     assert geom2.wkt == geom1.wkt

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -10,13 +10,13 @@ class TestSplitGeometry(unittest.TestCase):
 	# helper class for testing below
 	def helper(self, geom, splitter, expected_chunks):
 		s = split(geom, splitter)
-		self.assertEqual(s.type, "GeometryCollection")
+		self.assertEqual(s.geom_type, "GeometryCollection")
 		self.assertEqual(len(s.geoms), expected_chunks)
 		if expected_chunks > 1:
 			# split --> expected collection that when merged is again equal to original geometry
-			if s.geoms[0].type == 'LineString':
+			if s.geoms[0].geom_type == 'LineString':
 				self.assertTrue(linemerge(s).simplify(0.000001).equals(geom))
-			elif s.geoms[0].type == 'Polygon':
+			elif s.geoms[0].geom_type == 'Polygon':
 				union = unary_union(s).simplify(0.000001)
 				self.assertTrue(union.equals(geom))
 				self.assertEqual(union.area, geom.area)

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -27,7 +27,7 @@ class SvgTestCase(unittest.TestCase):
         svg_output_dir = None
         # svg_output_dir = '.'  # useful for debugging SVG files
         if svg_output_dir:
-            fname = geom.type
+            fname = geom.geom_type
             if geom.is_empty:
                 fname += '_empty'
             if not geom.is_valid:

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -41,7 +41,7 @@ def test_edges():
     regions = voronoi_diagram(mp, edges=True)
 
     assert len(regions.geoms) == 1
-    assert all(r.type == 'LineString' for r in regions.geoms)
+    assert all(r.geom_type == 'LineString' for r in regions.geoms)
 
 
 @requires_geos_35


### PR DESCRIPTION
This PR deprecates the `.type` attribute, which is an alias for `.geom_type`. It is expected this attribute is used externally with lots of other projects, so this may cause a bit of noise. Are we sure we want to deprecate it?

Closes #975