### PR TITLE
[WIP] New SVGTree class

### DIFF
--- a/shapely/svgtree.py
+++ b/shapely/svgtree.py
@@ -1,0 +1,57 @@
+"""svgtree.py: ElementTree based geometry SVG"""
+
+import itertools
+from xml.etree.ElementTree import Element, ElementTree, SubElement
+
+import numpy
+
+
+class SVGTree(ElementTree):
+    @classmethod
+    def path(cls, coords):
+        return "M {} L {}".format(
+            f"{coords[0][0]},{coords[0][1]}",
+            " L ".join(f"{xy[0]},{xy[1]}" for xy in coords[1:]),
+        )
+
+    @classmethod
+    def fromgeom(cls, geom):
+        """Returns Element"""
+        if geom.geom_type == "Point":
+            return cls.frompoint(geom)
+        elif geom.geom_type == "LineString":
+            return cls.fromlinestring(geom)
+        elif geom.geom_type == "LinearRing":
+            return cls.fromlinearring(geom)
+        elif geom.geom_type == "Polygon":
+            return cls.frompolygon(geom)
+        else:
+            raise NotImplementedError
+
+    @classmethod
+    def frompoint(cls, geom):
+        group = Element("g")
+        SubElement(group, "circle", cx=str(geom.x), cy=str(geom.y), r="1.0")
+        return group
+
+    @classmethod
+    def fromlinestring(cls, geom):
+        group = Element("g")        
+        SubElement(group, "path", d=cls.path(geom.coords))
+        return group
+
+    @classmethod
+    def fromlinearring(cls, geom):
+        group = Element("g")        
+        SubElement(group, "path", d="{} Z".format(cls.path(geom.coords[:-1])))
+        return group
+
+    @classmethod
+    def frompolygon(cls, geom):
+        group = Element("g")        
+        path = "  ".join(
+            "{} Z".format(cls.path(ring.coords[:-1]))
+            for ring in itertools.chain([geom.exterior], geom.interiors)
+        )
+        SubElement(group, "path", d=path)
+        return group

--- a/shapely/svgtree.py
+++ b/shapely/svgtree.py
@@ -36,19 +36,19 @@ class SVGTree(ElementTree):
 
     @classmethod
     def fromlinestring(cls, geom):
-        group = Element("g")        
+        group = Element("g")
         SubElement(group, "path", d=cls.path(geom.coords))
         return group
 
     @classmethod
     def fromlinearring(cls, geom):
-        group = Element("g")        
+        group = Element("g")
         SubElement(group, "path", d="{} Z".format(cls.path(geom.coords[:-1])))
         return group
 
     @classmethod
     def frompolygon(cls, geom):
-        group = Element("g")        
+        group = Element("g")
         path = "  ".join(
             "{} Z".format(cls.path(ring.coords[:-1]))
             for ring in itertools.chain([geom.exterior], geom.interiors)

--- a/shapely/svgtree.py
+++ b/shapely/svgtree.py
@@ -3,8 +3,6 @@
 import itertools
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
-import numpy
-
 
 class SVGTree(ElementTree):
     @classmethod

--- a/tests/test_svgtree.py
+++ b/tests/test_svgtree.py
@@ -9,13 +9,17 @@ from shapely.svgtree import SVGTree
 def test_point():
     elem = SVGTree.fromgeom(Point(0, 0))
     assert (
-        ET.tostring(elem, encoding="unicode") == '<g><circle cx="0.0" cy="0.0" r="1.0" /></g>'
+        ET.tostring(elem, encoding="unicode")
+        == '<g><circle cx="0.0" cy="0.0" r="1.0" /></g>'
     )
 
 
 def test_linestring():
     elem = SVGTree.fromgeom(LineString([(0, 0), (1, 1)]))
-    assert ET.tostring(elem, encoding="unicode") == '<g><path d="M 0.0,0.0 L 1.0,1.0" /></g>'
+    assert (
+        ET.tostring(elem, encoding="unicode")
+        == '<g><path d="M 0.0,0.0 L 1.0,1.0" /></g>'
+    )
 
 
 def test_linearring():

--- a/tests/test_svgtree.py
+++ b/tests/test_svgtree.py
@@ -1,0 +1,42 @@
+"""svgtree module tests."""
+
+from xml.etree import ElementTree as ET
+
+from shapely import Point, LinearRing, LineString, Polygon, set_precision
+from shapely.svgtree import SVGTree
+
+
+def test_point():
+    elem = SVGTree.fromgeom(Point(0, 0))
+    assert (
+        ET.tostring(elem, encoding="unicode") == '<g><circle cx="0.0" cy="0.0" r="1.0" /></g>'
+    )
+
+
+def test_linestring():
+    elem = SVGTree.fromgeom(LineString([(0, 0), (1, 1)]))
+    assert ET.tostring(elem, encoding="unicode") == '<g><path d="M 0.0,0.0 L 1.0,1.0" /></g>'
+
+
+def test_linearring():
+    elem = SVGTree.fromgeom(LinearRing([(0, 0), (100, 100), (100, 0)]))
+    assert (
+        ET.tostring(elem, encoding="unicode")
+        == '<g><path d="M 0.0,0.0 L 100.0,100.0 L 100.0,0.0 Z" /></g>'
+    )
+
+
+def test_polygon():
+    elem = SVGTree.fromgeom(
+        set_precision(
+            Polygon(
+                [(0, 0), (100, 100), (100, 0)],
+                [Point(75, 25).buffer(20, quadsegs=2).exterior],
+            ),
+            0.01,
+        )
+    )
+    assert (
+        ET.tostring(elem, encoding="unicode")
+        == '<g><path d="M 100.0,100.0 L 100.0,0.0 L 0.0,0.0 Z  M 89.14,39.14 L 75.0,45.0 L 60.86,39.14 L 55.0,25.0 L 60.86,10.86 L 75.0,5.0 L 89.14,10.86 L 95.0,25.0 Z" /></g>'
+    )

--- a/tests/test_svgtree.py
+++ b/tests/test_svgtree.py
@@ -42,7 +42,7 @@ def test_polygon():
         set_precision(
             Polygon(
                 [(0, 0), (100, 100), (100, 0)],
-                [Point(75, 25).buffer(20, quadsegs=2).exterior],
+                [Point(75, 25).buffer(20, resolution=2).exterior],
             ),
             0.01,
         )

--- a/tests/test_svgtree.py
+++ b/tests/test_svgtree.py
@@ -2,7 +2,10 @@
 
 from xml.etree import ElementTree as ET
 
+import pytest
+
 from shapely import Point, LinearRing, LineString, Polygon, set_precision
+from shapely.geos import geos_version
 from shapely.svgtree import SVGTree
 
 
@@ -30,6 +33,10 @@ def test_linearring():
     )
 
 
+@pytest.mark.skipif(
+    geos_version < (3, 9, 0),
+    reason="GEOS >= 3.9.0 is required to test order of interior ring coordinates.",
+)
 def test_polygon():
     elem = SVGTree.fromgeom(
         set_precision(


### PR DESCRIPTION
Towards resolving #1196.

In a nutshell, this is the draft API:

* SVGTree derives from xml.etree.ElementTree.
* It adds a `fromgeom` method which is a factory for `<g>` tag instances of `Element`. These instances contain one or more `<path>` sub-elements. In other words, `ET.tostring(SVGTree.fromgeom(LineString(...)))` returns `<g><path>...</path></g>`.
* Styling is someone else's problem :)
* If you want to control the precision of coordinates in SVG, call Shapely 2's new `set_precision()` function on the geometry object before passing it to `SVGTree.fromgeom()`.

Names of things in this API will hew close to etree (fromgeom, for example, in analogy to ET.fromstring).

@jorisvandenbossche @brendan-ward this is what I was referring to earlier today.