### PR TITLE
DOC: update migration guide to use 'packaging' instead of 'distutils'

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -261,9 +261,9 @@ manager that can be copied into your project::
     import contextlib
     import shapely
     import warnings
-    from distutils.version import LooseVersion
+    from packaging import version  # https://packaging.pypa.io/
 
-    SHAPELY_GE_20 = str(shapely.__version__) >= LooseVersion("2.0")
+    SHAPELY_GE_20 = version.parse(shapely.__version__) >= version.parse("2.0a1")
 
     try:
         from shapely.errors import ShapelyDeprecationWarning as shapely_warning


### PR DESCRIPTION
Distutils is deprecated, so the documentation should suggest an alternative method to compare versions (one of [many](https://stackoverflow.com/q/11887762)).

Also, this approach needed `version.parse("2.0a1")` to be compared to work with the existing pre-release.