### PR TITLE
Make parallel_offset an alias for offset_curve

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1699,6 +1699,13 @@ linestring feature (right).
   Returns a LineString or MultiLineString geometry at a distance from the
   object on its right or its left side.
 
+  Alias method to :meth:`offset_curve` method.
+
+.. method:: object.offset_curve(distance, side, resolution=16, join_style=1, mitre_limit=5.0)
+
+  Returns a LineString or MultiLineString geometry at a distance from the
+  object on its right or its left side.
+
   The `distance` parameter must be a positive float value.
 
   The `side` parameter may be 'left' or 'right'. Left and right are determined

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -110,7 +110,7 @@ class LineString(BaseGeometry):
         """
         return self.coords.xy
 
-    def parallel_offset(
+    def offset_curve(
         self,
         distance,
         side="right",
@@ -144,6 +144,31 @@ class LineString(BaseGeometry):
         if side == "right":
             distance *= -1
         return shapely.offset_curve(self, distance, resolution, join_style, mitre_limit)
+
+    def parallel_offset(self, *args, **kwargs):
+        """This method is an alias for offset_curve method.
+
+        Returns a LineString or MultiLineString geometry at a distance from
+        the object on its right or its left side.
+
+        The side parameter may be 'left' or 'right' (default is 'right'). The
+        resolution of the buffer around each vertex of the object increases by
+        increasing the resolution keyword parameter or third positional
+        parameter. Vertices of right hand offset lines will be ordered in
+        reverse.
+
+        The join style is for outside corners between line segments. Accepted
+        values are JOIN_STYLE.round (1), JOIN_STYLE.mitre (2), and
+        JOIN_STYLE.bevel (3).
+
+        The mitre ratio limit is used for very sharp corners. It is the ratio
+        of the distance from the corner to the end of the mitred offset corner.
+        When two line segments meet at a sharp angle, a miter join will extend
+        far beyond the original geometry. To prevent unreasonable geometry, the
+        mitre limit allows controlling the maximum length of the join corner.
+        Corners with a ratio which exceed the limit will be beveled.
+        """
+        return self.offset_curve(*args, **kwargs)
 
 
 shapely.lib.registry[1] = LineString

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -146,27 +146,7 @@ class LineString(BaseGeometry):
         return shapely.offset_curve(self, distance, resolution, join_style, mitre_limit)
 
     def parallel_offset(self, *args, **kwargs):
-        """This method is an alias for offset_curve method.
-
-        Returns a LineString or MultiLineString geometry at a distance from
-        the object on its right or its left side.
-
-        The side parameter may be 'left' or 'right' (default is 'right'). The
-        resolution of the buffer around each vertex of the object increases by
-        increasing the resolution keyword parameter or third positional
-        parameter. Vertices of right hand offset lines will be ordered in
-        reverse.
-
-        The join style is for outside corners between line segments. Accepted
-        values are JOIN_STYLE.round (1), JOIN_STYLE.mitre (2), and
-        JOIN_STYLE.bevel (3).
-
-        The mitre ratio limit is used for very sharp corners. It is the ratio
-        of the distance from the corner to the end of the mitred offset corner.
-        When two line segments meet at a sharp angle, a miter join will extend
-        far beyond the original geometry. To prevent unreasonable geometry, the
-        mitre limit allows controlling the maximum length of the join corner.
-        Corners with a ratio which exceed the limit will be beveled.
+        """Alias method to :meth:`offset_curve` method.
         """
         return self.offset_curve(*args, **kwargs)
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -146,8 +146,7 @@ class LineString(BaseGeometry):
         return shapely.offset_curve(self, distance, resolution, join_style, mitre_limit)
 
     def parallel_offset(self, *args, **kwargs):
-        """Alias method to :meth:`offset_curve` method.
-        """
+        """Alias method to :meth:`offset_curve` method."""
         return self.offset_curve(*args, **kwargs)
 
 

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -25,9 +25,18 @@ class OperationsTestCase(unittest.TestCase):
         assert_geometries_equal(line2.parallel_offset(2, 'left', join_style=2,
                                                       resolution=1),
                                 LineString([(0, 2), (7, 2), (7, -5)]))
+        # offset_curve alias
+        assert_geometries_equal(
+            line1.offset_curve(2, 'left', resolution=1),
+            line1.parallel_offset(2, 'left', resolution=1)
+        )
 
-    def test_offset_curve_linear_ring(self):
+    def test_parallel_offset_linear_ring(self):
         lr1 = LinearRing([(0, 0), (5, 0), (5, 5), (0, 5), (0, 0)])
-        assert_geometries_equal(lr1.offset_curve(2, 'left', resolution=1),
+        assert_geometries_equal(lr1.parallel_offset(2, 'left', resolution=1),
                                 LineString([(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)]))
-        assert_geometries_equal(lr1.offset_curve(2, 'left', resolution=1),lr1.parallel_offset(2, 'left', resolution=1)) 
+        # offset_curve alias
+        assert_geometries_equal(
+            lr1.offset_curve(2, 'left', resolution=1),
+            lr1.parallel_offset(2, 'left', resolution=1)
+        )

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -26,7 +26,8 @@ class OperationsTestCase(unittest.TestCase):
                                                       resolution=1),
                                 LineString([(0, 2), (7, 2), (7, -5)]))
 
-    def test_parallel_offset_linear_ring(self):
+    def test_offset_curve_linear_ring(self):
         lr1 = LinearRing([(0, 0), (5, 0), (5, 5), (0, 5), (0, 0)])
-        assert_geometries_equal(lr1.parallel_offset(2, 'left', resolution=1),
+        assert_geometries_equal(lr1.offset_curve(2, 'left', resolution=1),
                                 LineString([(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)]))
+        assert_geometries_equal(lr1.offset_curve(2, 'left', resolution=1),lr1.parallel_offset(2, 'left', resolution=1)) 


### PR DESCRIPTION
See https://github.com/shapely/shapely/issues/1276

ref foss4g2022 codesprint
parallel_offset as ALIAS OF offset_curve new method
