### PR TITLE
PERF: use GEOSCoordSeq_copyToBuffer for get_coordinates (GEOS >= 3.10)

### DIFF
--- a/src/geos.c
+++ b/src/geos.c
@@ -950,20 +950,18 @@ GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* b
  *
  * Returns 0 on error, 1 on success.
  */
-char coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_seq,
-                        double* buf, unsigned int size, unsigned int dims) {
-  char *cp1, *cp2;
-  unsigned int i, j;
+int coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_seq,
+                       double* buf, unsigned int size, unsigned int dims) {
 
 #if GEOS_SINCE_3_10_0
 
   int hasZ = dims == 3;
-  if (!GEOSCoordSeq_copyToBuffer_r(ctx, coord_seq, buf, hasZ, 0)) {
-    return 0;
-  }
-  return 1;
+  return GEOSCoordSeq_copyToBuffer_r(ctx, coord_seq, buf, hasZ, 0);
 
-#endif
+#else
+
+  char *cp1, *cp2;
+  unsigned int i, j;
 
   cp1 = (char*)buf;
   for (i = 0; i < size; i++, cp1 += 8 * dims) {
@@ -975,4 +973,6 @@ char coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_
     }
   }
   return 1;
+
+#endif
 }

--- a/src/geos.h
+++ b/src/geos.h
@@ -178,7 +178,7 @@ GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double 
 GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* buf,
                                         unsigned int size, unsigned int dims, char ring_closure,
                                         npy_intp cs1, npy_intp cs2);
-extern char coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_seq,
+extern int coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_seq,
                                double* buf, unsigned int size, unsigned int dims);
 
 #endif  // _GEOS_H

--- a/src/geos.h
+++ b/src/geos.h
@@ -178,5 +178,7 @@ GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double 
 GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* buf,
                                         unsigned int size, unsigned int dims, char ring_closure,
                                         npy_intp cs1, npy_intp cs2);
+extern char coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_seq,
+                               double* buf, unsigned int size, unsigned int dims);
 
 #endif  // _GEOS_H


### PR DESCRIPTION
Similar as https://github.com/pygeos/pygeos/pull/436, but now for getting coordinates.

Small example showing the speed-up (10,000 polygons of 100 vertices):

```python
geoms = shapely.polygons(np.random.randn(10000, 100, 2))

In [10]: %timeit shapely.get_coordinates(l)
13.6 ms ± 314 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <-- main
6.46 ms ± 322 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <-- PR
```