### PR TITLE
Raise ValueError for non-finite distance to buffer/parallel_offset (maint-1.8)

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -622,6 +622,8 @@ class BaseGeometry:
         if mitre_limit == 0.0:
             raise ValueError(
                 'Cannot compute offset from zero-length line segment')
+        elif not math.isfinite(distance):
+            raise ValueError("buffer distance must be finite")
 
         if 'buffer_with_params' in self.impl:
             params = self._lgeos.GEOSBufferParams_create()

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -2,6 +2,7 @@
 """
 
 from ctypes import c_double
+import math
 import warnings
 
 from shapely.coords import CoordinateSequence
@@ -171,6 +172,8 @@ class LineString(BaseGeometry):
         if mitre_limit == 0.0:
             raise ValueError(
                 'Cannot compute offset from zero-length line segment')
+        elif not math.isfinite(distance):
+            raise ValueError("parallel_offset distance must be finite")
         try:
             return geom_factory(self.impl['parallel_offset'](
                 self, distance, resolution, join_style, mitre_limit, side))

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,5 +1,14 @@
+import pytest
+
 from . import unittest
 from shapely import geometry
+
+
+@pytest.mark.parametrize("distance", [float("nan"), float("inf")])
+def test_non_finite_distance(distance):
+    g = geometry.Point(0, 0)
+    with pytest.raises(ValueError, match="distance must be finite"):
+        g.buffer(distance)
 
 
 class BufferSingleSidedCase(unittest.TestCase):

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -1,6 +1,15 @@
+import pytest
+
 from . import unittest
 from shapely.geometry import LineString, LinearRing
-from shapely.wkt import loads
+
+
+@pytest.mark.parametrize("distance", [float("nan"), float("inf")])
+def test_non_finite_distance(distance):
+    g = LineString([(0, 0), (10, 0)])
+    with pytest.raises(ValueError, match="distance must be finite"):
+        g.parallel_offset(distance)
+
 
 class OperationsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #1483 and fixes #1515 for the shapely 1.8.x maintenance branch.

I'll apply a similar approach for the main branch soon (sometime after #1514 is merged).