### PR TITLE
DOC/RLS: update CHANGES.txt with last releases, move old releases to docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,84 @@
 Changes
 =======
 
+2.0a1 (2022-08-03)
+------------------
+
+Shapely version 2.0 alpha 1 is the first of a major release featuring a
+complete refactor of the internals and new vectorized (element-wise) array
+operations providing considerable performance improvements. For a full
+changelog, see https://shapely.readthedocs.io/en/latest/release/2.x.html#version-2-0-0
+
+Wheels for 2.0a1 published on PyPI include GEOS 3.10.3.
+
+1.8.4 (2022-08-17)
+------------------
+
+Bug fixes:
+
+- The new c_geom_p type caused a regression and has been removed (#1487).
+
+1.8.3 (2022-08-16)
+------------------
+
+Deprecations:
+
+The STRtree class will be changed in 2.0.0 and will not be compatible with the
+class in versions 1.8.x. This change obsoletes the deprecation announcement in
+1.8a3 (below).
+
+Packaging:
+
+Wheels for 1.8.3 published on PyPI include GEOS 3.10.3.
+
+Bug fixes:
+
+- The signature for GEOSMinimumClearance has been corrected, fixing an issue
+  affecting aarch64-darwin (#1480)
+- Return and arg types have been corrected and made more strict for area,
+  length, and distance properties.
+- A new c_geom_p type has been created to replace c_void_p when calling GEOS
+  functions (#1479).
+- An incorrect polygon-line intersection (#1427) has been fixed in GEOS 3.10.3,
+  which will be included in wheels published to PyPI.
+- GEOS buffer parameters are now destroyed, fixing a memory leak (#1440).
+
+1.8.2 (2022-05-03)
+------------------
+
+- Make Polygons and MultiPolygons closed by definition, like LinearRings.
+  Resolves #1246.
+- Perform frozen app check for GEOS before conda env check on macos as we
+  already do on linux (#1301).
+- Fix leak of GEOS coordinate sequence in nearest_points reported in #1098.
+
+1.8.1.post1 (2022-02-17)
+------------------------
+
+This post-release addresses a defect in the 1.8.1 source distribution. No .c
+files are included in the 1.8.1.post1 sdist and Cython is required to build and
+install from source.
+
+1.8.1 (2022-02-16)
+------------------
+
+Packaging:
+
+Wheels for 1.8.1 published on PyPI include GEOS 3.10.2. This version is the
+best version of GEOS yet. Discrepancies in behavior compared to previous
+versions are considered to be improvements.
+
+For the first time, we will publish wheels for macos_arm64 (see PR #1310).
+
+Python version support:
+
+Shapely 1.8.1 works with Pythons 3.6-3.10.
+
+Bug fixes:
+
+- Require Cython >= 0.29.24 to support Python 3.10 (#1224).
+- Fix array_interface_base (#1235).
+
 1.8.0 (2021-10-25)
 ------------------
 
@@ -144,716 +222,7 @@ Packaging:
 
 - The wheels uploaded to PyPI will include GEOS 3.9.1.
 
-1.7.1 (2020-08-20)
-------------------
+Previous releases
+-----------------
 
-- ``STRtree`` now safely implements the pickle protocol (#915).
-- Documentation has been added for ``minimum_clearance`` (#875, #874).
-- In ``STRtree.__del__()`` we guard against calling ``GEOSSTRtree_destroy``
-  when the lgeos module has already been torn down on exit (#897, #830).
-- Documentation for the ``overlaps()`` method has been corrected (#920).
-- Correct the test in ``shapely.geometry.base.BaseGeometry.empty()`` to
-  eliminate memory leaks like the one reported in #745.
-- Get free() not from libc but from the processes global symbols (#891),
-  fixing a bug that manifests on OS X 10.15 and 10.16.
-- Extracting substrings from complex lines has been made more correct (#848,
-  #849).
-- Splitting of complex geometries has been sped up by preparing the input
-  geometry (#871).
-- Fix bug in concatenation of function argtypes (#866).
-- Improved documentation of STRtree usage (#857).
-- Improved handling for empty list or list of lists in GeoJSON coordinates
-  (#852).
-- The polylabel algorithm now accounts for polygon holes (#851, #817).
-
-1.7.0 (2020-01-28)
-------------------
-
-This is the final 1.7.0 release. There have been no changes since 1.7b1.
-
-1.7b1 (2020-01-13)
-------------------
-
-First beta release.
-
-1.7a3 (2019-12-31)
-------------------
-
-New features:
-
-- The buffer operation can now be single-sides (#806, #727).
-
-Bug fixes:
-
-- Add /usr/local/lib to the list of directories to be searched for the GEOS
-  shared library (#795).
-- ops.substring now returns a line with coords in end-to-front order when given
-  a start position that is greater than the end position (#628).
-- Implement ``__bool__()`` for geometry base classes so that ``bool(geom)``
-  returns the logical complement of ``geom.is_empty`` (#754).
-- Remove assertion on the number of version-like strings found in the GEOS
-  version string. It could be 2 or 3.
-
-1.7a2 (2019-06-21)
-------------------
-
-- Nearest neighbor search has been added to STRtree (#668).
-- Disallow sequences of MultiPolygons as arguments to the MultiPolygon
-  constructor, resolving #588.
-- Removed vendorized `functools` functions previously used to support
-  Python 2.5.
-
-Bug fixes:
-
-- Avoid reloading the GEOS shared library when using an installed binary wheel
-  on OS X (#735), resolving issue #553.
-- The shapely.ops.orient function can now orient multi polygons and geometry
-  collections as well as polygons (#733).
-- Polygons can now be constructed from sequences of point objects as well as
-  sequences of x, y sequences (#732).
-- The exterior of an empty polygon is now equal to an empty linear ring (#731).
-- The bounds property of an empty point object now returns an empty tuple,
-  consistent with other geometry types (#723).
-- Segmentation faults when non-string values are passed to the WKT loader are
-  avoided by #700.
-- Failure of ops.substring when the sub linestring coincides with the beginning
-  of the linestring has been fixed (#658).
-- Segmentation faults from interpolating on an empty linestring are prevented
-  by #655.
-- A missing special case for rectangular polygons has been added to the
-  polylabel algorithm (#644).
-- LinearRing can be created from a LineString (#638).
-- The prepared geometry validation condition has been tightened in #632 to fix
-  the bug reported in #631.
-- Attempting to interpolate an empty geometry no longer results in a
-  segmentation fault, raising `ValueError` instead (#653).
-
-1.7a1 (2018-07-29)
-------------------
-
-New features:
-
-- A Python version check is made by the package setup script. Shapely 1.7
-  supports only Python versions 2.7 and 3.4+ (#610).
-- Added a new `EmptyGeometry` class to support GeoPandas (#514).
-- Added new `shapely.ops.substring` function (#459).
-- Added new `shapely.ops.clip_by_rect` function (#583).
-- Use DLLs indicated in sys._MEIPASS' to support PyInstaller frozen apps
-  (#523).
-- `shapely.wkb.dumps` now accepts an `srid` integer keyword argument to write
-  WKB data including a spatial reference ID in the output data (#593).
-
-Bug fixes:
-
-- `shapely.geometry.shape` can now marshal empty GeoJSON representations
-  (#573).
-- An exception is raised when an attempt is made to `prepare`
-  a `PreparedGeometry` (#577, #595).
-- Keyword arguments have been removed from a geometry object's `wkt` property
-  getter (#581, #594).
-
-1.6.4.post1 (2018-01-24)
-------------------------
-
-- Fix broken markup in this change log, which restores our nicely formatted
-  readme on PyPI.
-
-1.6.4 (2018-01-24)
-------------------
-
-- Handle a ``TypeError`` that can occur when geometries are torn down (#473,
-  #528).
-
-
-1.6.3 (2017-12-09)
-------------------
-
-- AttributeError is no longer raised when accessing __geo_interface__ of an
-  empty polygon (#450).
-- ``asShape`` now handles empty coordinates in mappings as ``shape`` does
-  (#542). Please note that ``asShape`` is likely to be deprecated in a future
-  version of Shapely.
-- Check for length of LineString coordinates in speed mode, preventing crashes
-  when using LineStrings with only one coordinate (#546).
-
-1.6.2 (2017-10-30)
-------------------
-
-- A 1.6.2.post1 release has been made to fix a problem with macosx wheels
-  uploaded to PyPI.
-
-1.6.2 (2017-10-26)
-------------------
-
-- Splitting a linestring by one of its end points will now succeed instead of
-  failing with a ``ValueError`` (#524, #533).
-- Missing documentation of a geometry's ``overlaps`` predicate has been added
-  (#522).
-
-1.6.1 (2017-09-01)
-------------------
-
-- Avoid ``STRTree`` crashes due to dangling references (#505) by maintaining
-  references to added geometries.
-- Reduce log level to debug when reporting on calls to ctypes ``CDLL()`` that
-  don't succeed and are retried (#515).
-- Clarification: applications like GeoPandas that need an empty geometry object
-  should use ``BaseGeometry()`` instead of ``Point()`` or ``Polygon()``. An
-  ``EmptyGeometry`` class has been added in the master development branch and
-  will be available in the next non-bugfix release.
-
-1.6.0 (2017-08-21)
-------------------
-
-Shapely 1.6.0 adds new attributes to existing geometry classes and new
-functions (``split()`` and ``polylabel()``) to the shapely.ops module.
-Exceptions are consolidated in a shapely.errors module and logging practices
-have been improved. Shapely's optional features depending on Numpy are now
-gathered into a requirements set named "vectorized" and these may be installed
-like ``pip install shapely[vectorized]``.
-
-Much of the work on 1.6.0 was aimed to improve the project's build and
-packaging scripts and to minimize run-time dependencies. Shapely now vendorizes
-packaging to use during builds only and never again invokes the geos-config
-utility at run-time.
-
-In addition to the changes listed under the alpha and beta pre-releases below,
-the following change has been made to the project:
-
-- Project documentation is now hosted at 
-  https://shapely.readthedocs.io/en/latest/.
-
-Thank you all for using, promoting, and contributing to the Shapely project.
-
-1.6b5 (2017-08-18)
-------------------
-
-Bug fixes:
-
-- Passing a single coordinate to ``LineString()`` with speedups disabled now
-  raises a ValueError as happens with speedups enabled. This resolves #509.
-
-1.6b4 (2017-02-15)
-------------------
-
-Bug fixes:
-
-- Isolate vendorized packaging in a _vendor directory, remove obsolete
-  dist-info, and remove packaging from project requirements (resolves #468).
-
-1.6b3 (2016-12-31)
-------------------
-
-Bug fixes:
-
-- Level for log messages originating from the GEOS notice handler reduced from
-  WARNING to INFO (#447).
-- Permit speedups to be imported again without Numpy (#444).
-
-1.6b2 (2016-12-12)
-------------------
-
-New features:
-
-- Add support for GeometryCollection to shape and asShape functions (#422).
-
-1.6b1 (2016-12-12)
-------------------
-
-Bug fixes:
-
-- Implemented __array_interface__ for empty Points and LineStrings (#403).
-
-1.6a3 (2016-12-01)
-------------------
-
-Bug fixes:
-
-- Remove accidental hard requirement of Numpy (#431).
-
-Packaging:
-
-- Put Numpy in an optional requirement set named "vectorized" (#431).
-
-1.6a2 (2016-11-09)
-------------------
-
-Bug fixes:
-
-- Shapely no longer configures logging in ``geos.py`` (#415).
-
-Refactoring:
-
-- Consolidation of exceptions in ``shapely.errors``.
-- ``UnsupportedGEOSVersionError`` is raised when GEOS < 3.3.0 (#407).
-
-Packaging:
-
-- Added new library search paths to assist Anaconda (#413).
-- geos-config will now be bypassed when NO_GEOS_CONFIG env var is set. This
-  allows configuration of Shapely builds on Linux systems that for whatever
-  reasons do not include the geos-config program (#322).
-
-1.6a1 (2016-09-14)
-------------------
-
-New features:
-
-- A new error derived from NotImplementedError, with a more useful message, is
-  raised when the GEOS backend doesn't support a called method (#216).
-- The ``project()`` method of LineString has been extended to LinearRing
-  geometries (#286).
-- A new ``minimum_rotated_rectangle`` attribute has been added to the base
-  geometry class (#354).
-- A new ``shapely.ops.polylabel()`` function has been added. It
-  computes a point suited for labeling concave polygons (#395).
-- A new ``shapely.ops.split()`` function has been added. It splits a
-  geometry by another geometry of lesser dimension: polygon by line, line by
-  point (#293, #371).
-- ``Polygon.from_bounds()`` constructs a Polygon from bounding coordinates
-  (#392).
-- Support for testing with Numpy 1.4.1 has been added (#301).
-- Support creating all kinds of empty geometries from empty lists of Python
-  objects (#397, #404).
-
-Refactoring:
-
-- Switch from ``SingleSidedBuffer()`` to ``OffsetCurve()`` for GEOS >= 3.3
-  (#270).
-- Cython speedups are now enabled by default (#252).
-
-Packaging:
-
-- Packaging 16.7, a setup dependency, is vendorized (#314).
-- Infrastructure for building manylinux1 wheels has been added (#391).
-- The system's ``geos-config`` program is now only checked when ``setup.py``
-  is executed, never during normal use of the module (#244).
-- Added new library search paths to assist PyInstaller (#382) and Windows
-  (#343).
-
-1.5.17 (2016-08-31)
--------------------
-- Bug fix: eliminate memory leak in geom_factory() (#408).
-- Bug fix: remove mention of negative distances in parallel_offset and note
-  that vertices of right hand offset lines are reversed (#284).
-
-1.5.16 (2016-05-26)
--------------------
-- Bug fix: eliminate memory leak when unpickling geometry objects (#384, #385).
-- Bug fix: prevent crashes when attempting to pickle a prepared geometry,
-  raising ``PicklingError`` instead (#386).
-- Packaging: extension modules in the OS X wheels uploaded to PyPI link only
-  libgeos_c.dylib now (you can verify and compare to previous releases with
-  ``otool -L shapely/vectorized/_vectorized.so``).
-
-1.5.15 (2016-03-29)
--------------------
-- Bug fix: use uintptr_t to store pointers instead of long in _geos.pxi,
-  preventing an overflow error (#372, #373). Note that this bug fix was
-  erroneously reported to have been made in 1.5.14, but was not.
-
-1.5.14 (2016-03-27)
--------------------
-- Bug fix: use ``type()`` instead of ``isinstance()`` when evaluating geometry
-  equality, preventing instances of base and derived classes from 
-  being mistaken for equals (#317).
-- Bug fix: ensure that empty geometries are created when constructors have no
-  args (#332, #333).
-- Bug fix: support app "freezing" better on Windows by not relying on the
-  ``__file__`` attribute (#342, #377).
-- Bug fix: ensure that empty polygons evaluate to be ``==`` (#355).
-- Bug fix: filter out empty geometries that can cause segfaults when creating
-  and loading STRtrees (#345, #348).
-- Bug fix: no longer attempt to reuse GEOS DLLs already loaded by Rasterio
-  or Fiona on OS X (#374, #375).
-
-1.5.13 (2015-10-09)
--------------------
-- Restore setup and runtime discovery and loading of GEOS shared library to
-  state at version 1.5.9 (#326).
-- On OS X we try to reuse any GEOS shared library that may have been loaded
-  via import of Fiona or Rasterio in order to avoid a bug involving the
-  GEOS AbstractSTRtree (#324, #327).
-
-1.5.12 (2015-08-27)
--------------------
-- Remove configuration of root logger from libgeos.py (#312).
-- Skip test_fallbacks on Windows (#308).
-- Call setlocale(locale.LC_ALL, "") instead of resetlocale() on Windows when
-  tearing down the locale test (#308).
-- Fix for Sphinx warnings (#309).
-- Addition of .cache, .idea, .pyd, .pdb to .gitignore (#310).
-
-1.5.11 (2015-08-23)
--------------------
-- Remove packaging module requirement added in 1.5.10 (#305). Distutils can't 
-  parse versions using 'rc', but if we stick to 'a' and 'b' we will be fine.
-
-1.5.10 (2015-08-22)
--------------------
-- Monkey patch affinity module by absolute reference (#299).
-- Raise TopologicalError in relate() instead of crashing (#294, #295, #303).
-
-1.5.9 (2015-05-27)
-------------------
-- Fix for 64 bit speedups compatibility (#274).
-
-1.5.8 (2015-04-29)
-------------------
-- Setup file encoding bug fix (#254).
-- Support for pyinstaller (#261).
-- Major prepared geometry operation fix for Windows (#268, #269).
-- Major fix for OS X binary wheel (#262).
-
-1.5.7 (2015-03-16)
-------------------
-- Test and fix buggy error and notice handlers (#249).
-
-1.5.6 (2015-02-02)
-------------------
-- Fix setup regression (#232, #234).
-- SVG representation improvements (#233, #237).
-
-1.5.5 (2015-01-20)
-------------------
-- MANIFEST changes to restore _geox.pxi (#231).
-
-1.5.4 (2015-01-19)
-------------------
-- Fixed OS X binary wheel library load path (#224).
-
-1.5.3 (2015-01-12)
-------------------
-- Fixed ownership and potential memory leak in polygonize (#223).
-- Wider release of binary wheels for OS X.
-
-1.5.2 (2015-01-04)
-------------------
-- Fail installation if GEOS dependency is not met, preventing update breakage
-  (#218, #219).
-
-1.5.1 (2014-12-04)
-------------------
-- Restore geometry hashing (#209).
-
-1.5.0 (2014-12-02)
-------------------
-- Affine transformation speedups (#197).
-- New `==` rich comparison (#195).
-- Geometry collection constructor (#200).
-- ops.snap() backed by GEOSSnap (#201).
-- Clearer exceptions in cases of topological invalidity (#203).
-
-1.4.4 (2014-11-02)
-------------------
-- Proper conversion of numpy float32 vals to coords (#186).
-
-1.4.3 (2014-10-01)
-------------------
-- Fix for endianness bug in WKB writer (#174).
-
-1.4.2 (2014-09-29)
-------------------
-- Fix bungled 1.4.1 release (#176).
-
-1.4.1 (2014-09-23)
-------------------
-- Return of support for GEOS 3.2 (#176, #178).
-
-1.4.0 (2014-09-08)
-------------------
-- SVG representations for IPython's inline image protocol.
-- Efficient and fast vectorized contains().
-- Change mitre_limit default to 5.0; raise ValueError with 0.0 (#139).
-- Allow mix of tuples and Points in sped-up LineString ctor (#152).
-- New STRtree class (#73).
-- Add ops.nearest_points() (#147).
-- Faster creation of geometric objects from others (cloning) (#165).
-- Removal of tests from package.
-
-1.3.3 (2014-07-23)
-------------------
-- Allow single-part geometries as argument to ops.cacaded_union() (#135).
-- Support affine transformations of LinearRings (#112).
-
-1.3.2 (2014-05-13)
-------------------
-- Let LineString() take a sequence of Points (#130).
-
-1.3.1 (2014-04-22)
-------------------
-- More reliable proxy cleanup on exit (#106).
-- More robust DLL loading on all platforms (#114).
-
-1.3.0 (2013-12-31)
-------------------
-- Include support for Python 3.2 and 3.3 (#56), minimum version is now 2.6.
-- Switch to GEOS WKT/WKB Reader/Writer API, with defaults changed to enable 3D
-  output dimensions, and to 'trim' WKT output for GEOS >=3.3.0.
-- Use GEOS version instead of GEOS C API version to determine library
-  capabilities (#65).
-
-1.2.19 (2013-12-30)
--------------------
-- Add buffering style options (#55).
-
-1.2.18 (2013-07-23)
---------------------
-- Add shapely.ops.transform.
-- Permit empty sequences in collection constructors (#49, #50).
-- Individual polygons in MultiPolygon.__geo_interface__ are changed to tuples
-  to match Polygon.__geo_interface__ (#51).
-- Add shapely.ops.polygonize_full (#57).
-
-1.2.17 (2013-01-27)
--------------------
-- Avoid circular import between wkt/wkb and geometry.base by moving calls
-  to GEOS serializers to the latter module.
-- Set _ndim when unpickling (issue #6).
-- Don't install DLLs to Python's DLL directory (#37).
-- Add affinity module of affine transformation (#31).
-- Fix NameError that blocked installation with PyPy (#40, #41).
-
-1.2.16 (2012-09-18)
--------------------
-- Add ops.unary_union function.
-- Alias ops.cascaded_union to ops.unary_union when GEOS CAPI >= (1,7,0).
-- Add geos_version_string attribute to shapely.geos.
-- Ensure parent is set when child geometry is accessed.
-- Generate _speedups.c using Cython when building from repo when missing,
-  stale, or the build target is "sdist".
-- The is_simple predicate of invalid, self-intersecting linear rings now
-  returns ``False``.
-- Remove VERSION.txt from repo, it's now written by the distutils setup script
-  with value of shapely.__version__.
-
-1.2.15 (2012-06-27)
--------------------
-- Eliminate numerical sensitivity in a method chaining test (Debian bug
-  #663210).
-- Account for cascaded union of random buffered test points being a polygon
-  or multipolygon (Debian bug #666655).
-- Use Cython to build speedups if it is installed.
-- Avoid stumbling over SVN revision numbers in GEOS C API version strings.
-
-1.2.14 (2012-01-23)
--------------------
-- A geometry's coords property is now sliceable, yielding a list of coordinate
-  values.
-- Homogeneous collections are now sliceable, yielding a new collection of the
-  same type.
-
-1.2.13 (2011-09-16)
--------------------
-- Fixed errors in speedups on 32bit systems when GEOS references memory above
-  2GB.
-- Add shapely.__version__ attribute.
-- Update the manual.
-
-1.2.12 (2011-08-15)
--------------------
-- Build Windows distributions with VC7 or VC9 as appropriate.
-- More verbose report on failure to speed up.
-- Fix for prepared geometries broken in 1.2.11.
-- DO NOT INSTALL 1.2.11
-
-1.2.11 (2011-08-04)
--------------------
-- Ignore AttributeError during exit.
-- PyPy 1.5 support.
-- Prevent operation on prepared geometry crasher (#12).
-- Optional Cython speedups for Windows.
-- Linux 3 platform support.
-
-1.2.10 (2011-05-09)
--------------------
-- Add optional Cython speedups.
-- Add is_cww predicate to LinearRing.
-- Add function that forces orientation of Polygons.
-- Disable build of speedups on Windows pending packaging work.
-
-1.2.9 (2011-03-31)
-------------------
-- Remove extra glob import.
-- Move examples to shapely.examples.
-- Add box() constructor for rectangular polygons.
-- Fix extraneous imports.
-
-1.2.8 (2011-12-03)
-------------------
-- New parallel_offset method (#6).
-- Support for Python 2.4.
-
-1.2.7 (2010-11-05)
-------------------
-- Support for Windows eggs.
-
-1.2.6 (2010-10-21)
-------------------
-- The geoms property of an empty collection yields [] instead of a ValueError
-  (#3).
-- The coords and geometry type sproperties have the same behavior as above.
-- Ensure that z values carry through into products of operations (#4).
-
-1.2.5 (2010-09-19)
-------------------
-- Stop distributing docs/_build.
-- Include library fallbacks in test_dlls.py for linux platform.
-
-1.2.4 (2010-09-09)
-------------------
-- Raise AttributeError when there's no backend support for a method.
-- Raise OSError if libgeos_c.so (or variants) can't be found and loaded.
-- Add geos_c DLL loading support for linux platforms where find_library doesn't
-  work.
-
-1.2.3 (2010-08-17)
-------------------
-- Add mapping function.
-- Fix problem with GEOSisValidReason symbol for GEOS < 3.1.
-
-1.2.2 (2010-07-23)
-------------------
-- Add representative_point method.
-
-1.2.1 (2010-06-23)
-------------------
-- Fixed bounds of singular polygons.
-- Added shapely.validation.explain_validity function (#226).
-
-1.2 (2010-05-27)
-----------------
-- Final release.
-
-1.2rc2 (2010-05-26)
--------------------
-- Add examples and tests to MANIFEST.in.
-- Release candidate 2.
-
-1.2rc1 (2010-05-25)
--------------------
-- Release candidate.
-
-1.2b7 (2010-04-22)
-------------------
-- Memory leak associated with new empty geometry state fixed.
-
-1.2b6 (2010-04-13)
-------------------
-- Broken GeometryCollection fixed.
-
-1.2b5 (2010-04-09)
-------------------
-- Objects can be constructed from others of the same type, thereby making
-  copies. Collections can be constructed from sequences of objects, also making
-  copies.
-- Collections are now iterators over their component objects.
-- New code for manual figures, using the descartes package.
-
-1.2b4 (2010-03-19)
-------------------
-- Adds support for the "sunos5" platform.
-
-1.2b3 (2010-02-28)
-------------------
-- Only provide simplification implementations for GEOS C API >= 1.5.
-
-1.2b2 (2010-02-19)
-------------------
-- Fix cascaded_union bug introduced in 1.2b1 (#212).
-
-1.2b1 (2010-02-18)
-------------------
-- Update the README. Remove cruft from setup.py. Add some version 1.2 metadata
-  regarding required Python version (>=2.5,<3) and external dependency
-  (libgeos_c >= 3.1).
-
-1.2a6 (2010-02-09)
-------------------
-- Add accessor for separate arrays of X and Y values (#210).
-
-TODO: fill gap here
-
-1.2a1 (2010-01-20)
-------------------
-- Proper prototyping of WKB writer, and avoidance of errors on 64-bit systems
-  (#191).
-- Prototype libgeos_c functions in a way that lets py2exe apps import shapely
-  (#189).
-
-1.2 Branched (2009-09-19)
-
-1.0.12 (2009-04-09)
--------------------
-- Fix for references held by topology and predicate descriptors.
-
-1.0.11 (2008-11-20)
--------------------
-- Work around bug in GEOS 2.2.3, GEOSCoordSeq_getOrdinate not exported properly
-  (#178).
-
-1.0.10 (2008-11-17)
--------------------
-- Fixed compatibility with GEOS 2.2.3 that was broken in 1.0.8 release (#176).
-
-1.0.9 (2008-11-16)
-------------------
-- Find and load MacPorts libgeos.
-
-1.0.8 (2008-11-01)
-------------------
-- Fill out GEOS function result and argument types to prevent faults on a
-  64-bit arch.
-
-1.0.7 (2008-08-22)
-------------------
-- Polygon rings now have the same dimensions as parent (#168).
-- Eliminated reference cycles in polygons (#169).
-
-1.0.6 (2008-07-10)
-------------------
-- Fixed adaptation of multi polygon data.
-- Raise exceptions earlier from binary predicates.
-- Beginning distributing new windows DLLs (#166).
-
-1.0.5 (2008-05-20)
-------------------
-- Added access to GEOS polygonizer function.
-- Raise exception when insufficient coordinate tuples are passed to LinearRing
-  constructor (#164).
-
-1.0.4 (2008-05-01)
-------------------
-- Disentangle Python and topological equality (#163).
-- Add shape(), a factory that copies coordinates from a geo interface provider.
-  To be used instead of asShape() unless you really need to store coordinates
-  outside shapely for efficient use in other code.
-- Cache GEOS geometries in adapters (#163).
-
-1.0.3 (2008-04-09)
-------------------
-- Do not release GIL when calling GEOS functions (#158).
-- Prevent faults when chaining multiple GEOS operators (#159).
-
-1.0.2 (2008-02-26)
-------------------
-- Fix loss of dimensionality in polygon rings (#155).
-
-1.0.1 (2008-02-08)
-------------------
-- Allow chaining expressions involving coordinate sequences and geometry parts
-  (#151).
-- Protect against abnormal use of coordinate accessors (#152).
-- Coordinate sequences now implement the numpy array protocol (#153).
-
-1.0 (2008-01-18)
-----------------
-- Final release.
-
-1.0 RC2 (2008-01-16)
---------------------
-- Added temporary solution for #149.
-
-1.0 RC1 (2008-01-14)
---------------------
-- First release candidate
+For older releases in the 1.x line, see https://shapely.readthedocs.io/en/latest/release/1.x.html

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -3,6 +3,7 @@ Release notes
 =============
 
 .. toctree::
+   :maxdepth: 2
 
    release/2.x
    release/1.x

--- a/docs/release/1.x.rst
+++ b/docs/release/1.x.rst
@@ -1,1 +1,927 @@
-.. include:: ../../CHANGES.txt
+Version 1.x
+===========
+
+1.8.4 (2022-08-17)
+------------------
+
+Bug fixes:
+
+- The new c_geom_p type caused a regression and has been removed (#1487).
+
+1.8.3 (2022-08-16)
+------------------
+
+Deprecations:
+
+The STRtree class will be changed in 2.0.0 and will not be compatible with the
+class in versions 1.8.x. This change obsoletes the deprecation announcement in
+1.8a3 (below).
+
+Packaging:
+
+Wheels for 1.8.3 published on PyPI include GEOS 3.10.3.
+
+Bug fixes:
+
+- The signature for GEOSMinimumClearance has been corrected, fixing an issue
+  affecting aarch64-darwin (#1480)
+- Return and arg types have been corrected and made more strict for area,
+  length, and distance properties.
+- A new c_geom_p type has been created to replace c_void_p when calling GEOS
+  functions (#1479).
+- An incorrect polygon-line intersection (#1427) has been fixed in GEOS 3.10.3,
+  which will be included in wheels published to PyPI.
+- GEOS buffer parameters are now destroyed, fixing a memory leak (#1440).
+
+1.8.2 (2022-05-03)
+------------------
+
+- Make Polygons and MultiPolygons closed by definition, like LinearRings.
+  Resolves #1246.
+- Perform frozen app check for GEOS before conda env check on macos as we
+  already do on linux (#1301).
+- Fix leak of GEOS coordinate sequence in nearest_points reported in #1098.
+
+1.8.1.post1 (2022-02-17)
+------------------------
+
+This post-release addresses a defect in the 1.8.1 source distribution. No .c
+files are included in the 1.8.1.post1 sdist and Cython is required to build and
+install from source.
+
+1.8.1 (2022-02-16)
+------------------
+
+Packaging:
+
+Wheels for 1.8.1 published on PyPI include GEOS 3.10.2. This version is the
+best version of GEOS yet. Discrepancies in behavior compared to previous
+versions are considered to be improvements.
+
+For the first time, we will publish wheels for macos_arm64 (see PR #1310).
+
+Python version support:
+
+Shapely 1.8.1 works with Pythons 3.6-3.10.
+
+Bug fixes:
+
+- Require Cython >= 0.29.24 to support Python 3.10 (#1224).
+- Fix array_interface_base (#1235).
+
+1.8.0 (2021-10-25)
+------------------
+
+This is the final 1.8.0 release. There have been no changes since 1.8rc2.
+
+1.8rc2 (2021-10-19)
+-------------------
+
+Build:
+
+A pyproject.toml file has been added to specify build dependencies for the
+_vectorized and _speedups modules (#1128). To install shapely without these
+build dependencies, use the features of your build tool that disable PEP 517
+and 518 support.
+
+Bug fixes:
+
+- Part of PR #1042, which added a new primary GEOS library name to be searched
+  for, has been reverted by PR #1201.
+
+1.8rc1 (2021-10-04)
+-------------------
+
+Deprecations:
+
+The almost_exact() method of BaseGeometry has been deprecated. It is confusing
+and will be removed in 2.0.0. The equals_exact() method is to be used instead.
+
+Bug fixes:
+
+- We ensure that the _speedups module is always imported before _vectorized to
+  avoid an unexplained condition on Windows with Python 3.8 and 3.9 (#1184).
+
+1.8a3 (2021-08-24)
+------------------
+
+Deprecations:
+
+The STRtree class deprecation warnings have been removed. The class in 2.0.0
+will be backwards compatible with the class in 1.8.0.
+
+Bug fixes:
+
+- The __array_interface__ raises only AttributeError, all other exceptions are
+  deprecated starting with Numpy 1.21 (#1173).
+- The STRtree class now uses a pair of item, geom sequences internally instead
+  of a dict (#1177).
+
+
+1.8a2 (2021-07-15)
+------------------
+
+Python version support:
+
+Shapely 1.8 will support only Python versions >= 3.6.
+
+New features:
+
+- The STRtree nearest*() methods now take an optional argument that
+  specifies exclusion of the input geometry from results (#1115).
+- A GeometryTypeError has been added to shapely.errors and is consistently
+  raised instead of TypeError or ValueError as in version 1.7. For backwards
+  compatibility, the new exception will derive from TypeError and Value error
+  until version 2.0 (#1099).
+- The STRtree class constructor now takes an optional second argument, a
+  sequence of objects to be stored in the tree. If not provided, the sequence
+  indices of the geometries will be stored, as before (#1112).
+- The STRtree class has new query_geoms(), query_items(), nearest_geom(), and
+  nearest_item() methods (#1112). The query() and nearest() methods remain as
+  aliases for query_geoms() and nearest_geom().
+
+Bug fixes:
+
+- We no longer attempt to load libc to get the free function on Linux, but get
+  it from the global symbol table.
+- GEOS error messages printed when GEOS_getCoordSeq() is passed an empty
+  geometry are avoided by never passing an empty geometry (#1134).
+- Python's builtin super() is now used only as described in PEP 3135 (#1109).
+- Only load conda GEOS dll if it exists (on Windows) (#1108).
+- Add /opt/homebrew/lib to the list of directories to be searched for the GEOS
+  shared library.
+- Added new library search path to assist app creation with cx_Freeze.
+
+1.8a1 (2021-03-03)
+------------------
+
+Shapely 1.8.0 will be a transitional version. There are a few bug fixes and new
+features, but it is mainly about warning of the upcoming changes in 2.0.0.
+Several more pre-releases before 1.8.0 are expected. See the migration guide
+to Shapely 1.8 / 2.0 for more details on how to update your code
+(https://shapely.readthedocs.io/en/latest/migration.html).
+
+Python version support:
+
+Shapely 1.8 will support only Python versions >= 3.5 (#884).
+
+Deprecations:
+
+The following functions and geometry attributes and methods will be removed in
+version 2.0.0.
+
+- ops.cascaded_union
+- geometry .empty()
+- geometry .ctypes and .__array_interface__
+- multi-part geometry .__len__
+- setting custom attributes on geometry objects
+
+Geometry objects will become immutable in version 2.0.0.
+
+The STRtree class will be entirely changed in 2.0.0. The exact future API is
+not yet decided, but will be decided before 1.8.0 is released.
+
+Deprecation warnings will be emitted in 1.8a1 when any of these features are
+used.
+
+The deprecated .to_wkb() and .to_wkt() methods on the geometry objects have
+been removed.
+
+New features:
+
+- Add a normalize() method to geometry classes, exposing the GEOSNormalize
+  algorithm (#1090).
+- Initialize STRtree with a capacity of 10 items per node (#1070).
+- Load libraries relocated to shapely/.libs by auditwheel versions < 3.1 or
+  relocated to Shapely.libs by auditwheel versions >= 3.1.
+- shapely.ops.voronoi_diagram() computes the Voronoi Diagram of a geometry or
+  geometry collection (#833, #851).
+- shapely.validation.make_valid() fixes invalid geometries (#883)
+
+Bug fixes:
+
+- For pyinstaller we now handle the case of more than one GEOS library in the
+  environment, such as when fiona and rasterio wheels are co-installed with
+  shapely (#1071).
+- The ops.split function now splits on touch to eliminate confusing
+  discrepancies between results using multi and single part splitters (#1034).
+- Several issues with duplication and order of vertices in ops.substring have
+  been fixed (#1008).
+
+Packaging:
+
+- The wheels uploaded to PyPI will include GEOS 3.9.1.
+
+1.7.1 (2020-08-20)
+------------------
+
+- ``STRtree`` now safely implements the pickle protocol (#915).
+- Documentation has been added for ``minimum_clearance`` (#875, #874).
+- In ``STRtree.__del__()`` we guard against calling ``GEOSSTRtree_destroy``
+  when the lgeos module has already been torn down on exit (#897, #830).
+- Documentation for the ``overlaps()`` method has been corrected (#920).
+- Correct the test in ``shapely.geometry.base.BaseGeometry.empty()`` to
+  eliminate memory leaks like the one reported in #745.
+- Get free() not from libc but from the processes global symbols (#891),
+  fixing a bug that manifests on OS X 10.15 and 10.16.
+- Extracting substrings from complex lines has been made more correct (#848,
+  #849).
+- Splitting of complex geometries has been sped up by preparing the input
+  geometry (#871).
+- Fix bug in concatenation of function argtypes (#866).
+- Improved documentation of STRtree usage (#857).
+- Improved handling for empty list or list of lists in GeoJSON coordinates
+  (#852).
+- The polylabel algorithm now accounts for polygon holes (#851, #817).
+
+1.7.0 (2020-01-28)
+------------------
+
+This is the final 1.7.0 release. There have been no changes since 1.7b1.
+
+1.7b1 (2020-01-13)
+------------------
+
+First beta release.
+
+1.7a3 (2019-12-31)
+------------------
+
+New features:
+
+- The buffer operation can now be single-sides (#806, #727).
+
+Bug fixes:
+
+- Add /usr/local/lib to the list of directories to be searched for the GEOS
+  shared library (#795).
+- ops.substring now returns a line with coords in end-to-front order when given
+  a start position that is greater than the end position (#628).
+- Implement ``__bool__()`` for geometry base classes so that ``bool(geom)``
+  returns the logical complement of ``geom.is_empty`` (#754).
+- Remove assertion on the number of version-like strings found in the GEOS
+  version string. It could be 2 or 3.
+
+1.7a2 (2019-06-21)
+------------------
+
+- Nearest neighbor search has been added to STRtree (#668).
+- Disallow sequences of MultiPolygons as arguments to the MultiPolygon
+  constructor, resolving #588.
+- Removed vendorized `functools` functions previously used to support
+  Python 2.5.
+
+Bug fixes:
+
+- Avoid reloading the GEOS shared library when using an installed binary wheel
+  on OS X (#735), resolving issue #553.
+- The shapely.ops.orient function can now orient multi polygons and geometry
+  collections as well as polygons (#733).
+- Polygons can now be constructed from sequences of point objects as well as
+  sequences of x, y sequences (#732).
+- The exterior of an empty polygon is now equal to an empty linear ring (#731).
+- The bounds property of an empty point object now returns an empty tuple,
+  consistent with other geometry types (#723).
+- Segmentation faults when non-string values are passed to the WKT loader are
+  avoided by #700.
+- Failure of ops.substring when the sub linestring coincides with the beginning
+  of the linestring has been fixed (#658).
+- Segmentation faults from interpolating on an empty linestring are prevented
+  by #655.
+- A missing special case for rectangular polygons has been added to the
+  polylabel algorithm (#644).
+- LinearRing can be created from a LineString (#638).
+- The prepared geometry validation condition has been tightened in #632 to fix
+  the bug reported in #631.
+- Attempting to interpolate an empty geometry no longer results in a
+  segmentation fault, raising `ValueError` instead (#653).
+
+1.7a1 (2018-07-29)
+------------------
+
+New features:
+
+- A Python version check is made by the package setup script. Shapely 1.7
+  supports only Python versions 2.7 and 3.4+ (#610).
+- Added a new `EmptyGeometry` class to support GeoPandas (#514).
+- Added new `shapely.ops.substring` function (#459).
+- Added new `shapely.ops.clip_by_rect` function (#583).
+- Use DLLs indicated in sys._MEIPASS' to support PyInstaller frozen apps
+  (#523).
+- `shapely.wkb.dumps` now accepts an `srid` integer keyword argument to write
+  WKB data including a spatial reference ID in the output data (#593).
+
+Bug fixes:
+
+- `shapely.geometry.shape` can now marshal empty GeoJSON representations
+  (#573).
+- An exception is raised when an attempt is made to `prepare`
+  a `PreparedGeometry` (#577, #595).
+- Keyword arguments have been removed from a geometry object's `wkt` property
+  getter (#581, #594).
+
+1.6.4.post1 (2018-01-24)
+------------------------
+
+- Fix broken markup in this change log, which restores our nicely formatted
+  readme on PyPI.
+
+1.6.4 (2018-01-24)
+------------------
+
+- Handle a ``TypeError`` that can occur when geometries are torn down (#473,
+  #528).
+
+
+1.6.3 (2017-12-09)
+------------------
+
+- AttributeError is no longer raised when accessing __geo_interface__ of an
+  empty polygon (#450).
+- ``asShape`` now handles empty coordinates in mappings as ``shape`` does
+  (#542). Please note that ``asShape`` is likely to be deprecated in a future
+  version of Shapely.
+- Check for length of LineString coordinates in speed mode, preventing crashes
+  when using LineStrings with only one coordinate (#546).
+
+1.6.2 (2017-10-30)
+------------------
+
+- A 1.6.2.post1 release has been made to fix a problem with macosx wheels
+  uploaded to PyPI.
+
+1.6.2 (2017-10-26)
+------------------
+
+- Splitting a linestring by one of its end points will now succeed instead of
+  failing with a ``ValueError`` (#524, #533).
+- Missing documentation of a geometry's ``overlaps`` predicate has been added
+  (#522).
+
+1.6.1 (2017-09-01)
+------------------
+
+- Avoid ``STRTree`` crashes due to dangling references (#505) by maintaining
+  references to added geometries.
+- Reduce log level to debug when reporting on calls to ctypes ``CDLL()`` that
+  don't succeed and are retried (#515).
+- Clarification: applications like GeoPandas that need an empty geometry object
+  should use ``BaseGeometry()`` instead of ``Point()`` or ``Polygon()``. An
+  ``EmptyGeometry`` class has been added in the master development branch and
+  will be available in the next non-bugfix release.
+
+1.6.0 (2017-08-21)
+------------------
+
+Shapely 1.6.0 adds new attributes to existing geometry classes and new
+functions (``split()`` and ``polylabel()``) to the shapely.ops module.
+Exceptions are consolidated in a shapely.errors module and logging practices
+have been improved. Shapely's optional features depending on Numpy are now
+gathered into a requirements set named "vectorized" and these may be installed
+like ``pip install shapely[vectorized]``.
+
+Much of the work on 1.6.0 was aimed to improve the project's build and
+packaging scripts and to minimize run-time dependencies. Shapely now vendorizes
+packaging to use during builds only and never again invokes the geos-config
+utility at run-time.
+
+In addition to the changes listed under the alpha and beta pre-releases below,
+the following change has been made to the project:
+
+- Project documentation is now hosted at 
+  https://shapely.readthedocs.io/en/latest/.
+
+Thank you all for using, promoting, and contributing to the Shapely project.
+
+1.6b5 (2017-08-18)
+------------------
+
+Bug fixes:
+
+- Passing a single coordinate to ``LineString()`` with speedups disabled now
+  raises a ValueError as happens with speedups enabled. This resolves #509.
+
+1.6b4 (2017-02-15)
+------------------
+
+Bug fixes:
+
+- Isolate vendorized packaging in a _vendor directory, remove obsolete
+  dist-info, and remove packaging from project requirements (resolves #468).
+
+1.6b3 (2016-12-31)
+------------------
+
+Bug fixes:
+
+- Level for log messages originating from the GEOS notice handler reduced from
+  WARNING to INFO (#447).
+- Permit speedups to be imported again without Numpy (#444).
+
+1.6b2 (2016-12-12)
+------------------
+
+New features:
+
+- Add support for GeometryCollection to shape and asShape functions (#422).
+
+1.6b1 (2016-12-12)
+------------------
+
+Bug fixes:
+
+- Implemented __array_interface__ for empty Points and LineStrings (#403).
+
+1.6a3 (2016-12-01)
+------------------
+
+Bug fixes:
+
+- Remove accidental hard requirement of Numpy (#431).
+
+Packaging:
+
+- Put Numpy in an optional requirement set named "vectorized" (#431).
+
+1.6a2 (2016-11-09)
+------------------
+
+Bug fixes:
+
+- Shapely no longer configures logging in ``geos.py`` (#415).
+
+Refactoring:
+
+- Consolidation of exceptions in ``shapely.errors``.
+- ``UnsupportedGEOSVersionError`` is raised when GEOS < 3.3.0 (#407).
+
+Packaging:
+
+- Added new library search paths to assist Anaconda (#413).
+- geos-config will now be bypassed when NO_GEOS_CONFIG env var is set. This
+  allows configuration of Shapely builds on Linux systems that for whatever
+  reasons do not include the geos-config program (#322).
+
+1.6a1 (2016-09-14)
+------------------
+
+New features:
+
+- A new error derived from NotImplementedError, with a more useful message, is
+  raised when the GEOS backend doesn't support a called method (#216).
+- The ``project()`` method of LineString has been extended to LinearRing
+  geometries (#286).
+- A new ``minimum_rotated_rectangle`` attribute has been added to the base
+  geometry class (#354).
+- A new ``shapely.ops.polylabel()`` function has been added. It
+  computes a point suited for labeling concave polygons (#395).
+- A new ``shapely.ops.split()`` function has been added. It splits a
+  geometry by another geometry of lesser dimension: polygon by line, line by
+  point (#293, #371).
+- ``Polygon.from_bounds()`` constructs a Polygon from bounding coordinates
+  (#392).
+- Support for testing with Numpy 1.4.1 has been added (#301).
+- Support creating all kinds of empty geometries from empty lists of Python
+  objects (#397, #404).
+
+Refactoring:
+
+- Switch from ``SingleSidedBuffer()`` to ``OffsetCurve()`` for GEOS >= 3.3
+  (#270).
+- Cython speedups are now enabled by default (#252).
+
+Packaging:
+
+- Packaging 16.7, a setup dependency, is vendorized (#314).
+- Infrastructure for building manylinux1 wheels has been added (#391).
+- The system's ``geos-config`` program is now only checked when ``setup.py``
+  is executed, never during normal use of the module (#244).
+- Added new library search paths to assist PyInstaller (#382) and Windows
+  (#343).
+
+1.5.17 (2016-08-31)
+-------------------
+- Bug fix: eliminate memory leak in geom_factory() (#408).
+- Bug fix: remove mention of negative distances in parallel_offset and note
+  that vertices of right hand offset lines are reversed (#284).
+
+1.5.16 (2016-05-26)
+-------------------
+- Bug fix: eliminate memory leak when unpickling geometry objects (#384, #385).
+- Bug fix: prevent crashes when attempting to pickle a prepared geometry,
+  raising ``PicklingError`` instead (#386).
+- Packaging: extension modules in the OS X wheels uploaded to PyPI link only
+  libgeos_c.dylib now (you can verify and compare to previous releases with
+  ``otool -L shapely/vectorized/_vectorized.so``).
+
+1.5.15 (2016-03-29)
+-------------------
+- Bug fix: use uintptr_t to store pointers instead of long in _geos.pxi,
+  preventing an overflow error (#372, #373). Note that this bug fix was
+  erroneously reported to have been made in 1.5.14, but was not.
+
+1.5.14 (2016-03-27)
+-------------------
+- Bug fix: use ``type()`` instead of ``isinstance()`` when evaluating geometry
+  equality, preventing instances of base and derived classes from 
+  being mistaken for equals (#317).
+- Bug fix: ensure that empty geometries are created when constructors have no
+  args (#332, #333).
+- Bug fix: support app "freezing" better on Windows by not relying on the
+  ``__file__`` attribute (#342, #377).
+- Bug fix: ensure that empty polygons evaluate to be ``==`` (#355).
+- Bug fix: filter out empty geometries that can cause segfaults when creating
+  and loading STRtrees (#345, #348).
+- Bug fix: no longer attempt to reuse GEOS DLLs already loaded by Rasterio
+  or Fiona on OS X (#374, #375).
+
+1.5.13 (2015-10-09)
+-------------------
+- Restore setup and runtime discovery and loading of GEOS shared library to
+  state at version 1.5.9 (#326).
+- On OS X we try to reuse any GEOS shared library that may have been loaded
+  via import of Fiona or Rasterio in order to avoid a bug involving the
+  GEOS AbstractSTRtree (#324, #327).
+
+1.5.12 (2015-08-27)
+-------------------
+- Remove configuration of root logger from libgeos.py (#312).
+- Skip test_fallbacks on Windows (#308).
+- Call setlocale(locale.LC_ALL, "") instead of resetlocale() on Windows when
+  tearing down the locale test (#308).
+- Fix for Sphinx warnings (#309).
+- Addition of .cache, .idea, .pyd, .pdb to .gitignore (#310).
+
+1.5.11 (2015-08-23)
+-------------------
+- Remove packaging module requirement added in 1.5.10 (#305). Distutils can't 
+  parse versions using 'rc', but if we stick to 'a' and 'b' we will be fine.
+
+1.5.10 (2015-08-22)
+-------------------
+- Monkey patch affinity module by absolute reference (#299).
+- Raise TopologicalError in relate() instead of crashing (#294, #295, #303).
+
+1.5.9 (2015-05-27)
+------------------
+- Fix for 64 bit speedups compatibility (#274).
+
+1.5.8 (2015-04-29)
+------------------
+- Setup file encoding bug fix (#254).
+- Support for pyinstaller (#261).
+- Major prepared geometry operation fix for Windows (#268, #269).
+- Major fix for OS X binary wheel (#262).
+
+1.5.7 (2015-03-16)
+------------------
+- Test and fix buggy error and notice handlers (#249).
+
+1.5.6 (2015-02-02)
+------------------
+- Fix setup regression (#232, #234).
+- SVG representation improvements (#233, #237).
+
+1.5.5 (2015-01-20)
+------------------
+- MANIFEST changes to restore _geox.pxi (#231).
+
+1.5.4 (2015-01-19)
+------------------
+- Fixed OS X binary wheel library load path (#224).
+
+1.5.3 (2015-01-12)
+------------------
+- Fixed ownership and potential memory leak in polygonize (#223).
+- Wider release of binary wheels for OS X.
+
+1.5.2 (2015-01-04)
+------------------
+- Fail installation if GEOS dependency is not met, preventing update breakage
+  (#218, #219).
+
+1.5.1 (2014-12-04)
+------------------
+- Restore geometry hashing (#209).
+
+1.5.0 (2014-12-02)
+------------------
+- Affine transformation speedups (#197).
+- New `==` rich comparison (#195).
+- Geometry collection constructor (#200).
+- ops.snap() backed by GEOSSnap (#201).
+- Clearer exceptions in cases of topological invalidity (#203).
+
+1.4.4 (2014-11-02)
+------------------
+- Proper conversion of numpy float32 vals to coords (#186).
+
+1.4.3 (2014-10-01)
+------------------
+- Fix for endianness bug in WKB writer (#174).
+
+1.4.2 (2014-09-29)
+------------------
+- Fix bungled 1.4.1 release (#176).
+
+1.4.1 (2014-09-23)
+------------------
+- Return of support for GEOS 3.2 (#176, #178).
+
+1.4.0 (2014-09-08)
+------------------
+- SVG representations for IPython's inline image protocol.
+- Efficient and fast vectorized contains().
+- Change mitre_limit default to 5.0; raise ValueError with 0.0 (#139).
+- Allow mix of tuples and Points in sped-up LineString ctor (#152).
+- New STRtree class (#73).
+- Add ops.nearest_points() (#147).
+- Faster creation of geometric objects from others (cloning) (#165).
+- Removal of tests from package.
+
+1.3.3 (2014-07-23)
+------------------
+- Allow single-part geometries as argument to ops.cacaded_union() (#135).
+- Support affine transformations of LinearRings (#112).
+
+1.3.2 (2014-05-13)
+------------------
+- Let LineString() take a sequence of Points (#130).
+
+1.3.1 (2014-04-22)
+------------------
+- More reliable proxy cleanup on exit (#106).
+- More robust DLL loading on all platforms (#114).
+
+1.3.0 (2013-12-31)
+------------------
+- Include support for Python 3.2 and 3.3 (#56), minimum version is now 2.6.
+- Switch to GEOS WKT/WKB Reader/Writer API, with defaults changed to enable 3D
+  output dimensions, and to 'trim' WKT output for GEOS >=3.3.0.
+- Use GEOS version instead of GEOS C API version to determine library
+  capabilities (#65).
+
+1.2.19 (2013-12-30)
+-------------------
+- Add buffering style options (#55).
+
+1.2.18 (2013-07-23)
+--------------------
+- Add shapely.ops.transform.
+- Permit empty sequences in collection constructors (#49, #50).
+- Individual polygons in MultiPolygon.__geo_interface__ are changed to tuples
+  to match Polygon.__geo_interface__ (#51).
+- Add shapely.ops.polygonize_full (#57).
+
+1.2.17 (2013-01-27)
+-------------------
+- Avoid circular import between wkt/wkb and geometry.base by moving calls
+  to GEOS serializers to the latter module.
+- Set _ndim when unpickling (issue #6).
+- Don't install DLLs to Python's DLL directory (#37).
+- Add affinity module of affine transformation (#31).
+- Fix NameError that blocked installation with PyPy (#40, #41).
+
+1.2.16 (2012-09-18)
+-------------------
+- Add ops.unary_union function.
+- Alias ops.cascaded_union to ops.unary_union when GEOS CAPI >= (1,7,0).
+- Add geos_version_string attribute to shapely.geos.
+- Ensure parent is set when child geometry is accessed.
+- Generate _speedups.c using Cython when building from repo when missing,
+  stale, or the build target is "sdist".
+- The is_simple predicate of invalid, self-intersecting linear rings now
+  returns ``False``.
+- Remove VERSION.txt from repo, it's now written by the distutils setup script
+  with value of shapely.__version__.
+
+1.2.15 (2012-06-27)
+-------------------
+- Eliminate numerical sensitivity in a method chaining test (Debian bug
+  #663210).
+- Account for cascaded union of random buffered test points being a polygon
+  or multipolygon (Debian bug #666655).
+- Use Cython to build speedups if it is installed.
+- Avoid stumbling over SVN revision numbers in GEOS C API version strings.
+
+1.2.14 (2012-01-23)
+-------------------
+- A geometry's coords property is now sliceable, yielding a list of coordinate
+  values.
+- Homogeneous collections are now sliceable, yielding a new collection of the
+  same type.
+
+1.2.13 (2011-09-16)
+-------------------
+- Fixed errors in speedups on 32bit systems when GEOS references memory above
+  2GB.
+- Add shapely.__version__ attribute.
+- Update the manual.
+
+1.2.12 (2011-08-15)
+-------------------
+- Build Windows distributions with VC7 or VC9 as appropriate.
+- More verbose report on failure to speed up.
+- Fix for prepared geometries broken in 1.2.11.
+- DO NOT INSTALL 1.2.11
+
+1.2.11 (2011-08-04)
+-------------------
+- Ignore AttributeError during exit.
+- PyPy 1.5 support.
+- Prevent operation on prepared geometry crasher (#12).
+- Optional Cython speedups for Windows.
+- Linux 3 platform support.
+
+1.2.10 (2011-05-09)
+-------------------
+- Add optional Cython speedups.
+- Add is_cww predicate to LinearRing.
+- Add function that forces orientation of Polygons.
+- Disable build of speedups on Windows pending packaging work.
+
+1.2.9 (2011-03-31)
+------------------
+- Remove extra glob import.
+- Move examples to shapely.examples.
+- Add box() constructor for rectangular polygons.
+- Fix extraneous imports.
+
+1.2.8 (2011-12-03)
+------------------
+- New parallel_offset method (#6).
+- Support for Python 2.4.
+
+1.2.7 (2010-11-05)
+------------------
+- Support for Windows eggs.
+
+1.2.6 (2010-10-21)
+------------------
+- The geoms property of an empty collection yields [] instead of a ValueError
+  (#3).
+- The coords and geometry type sproperties have the same behavior as above.
+- Ensure that z values carry through into products of operations (#4).
+
+1.2.5 (2010-09-19)
+------------------
+- Stop distributing docs/_build.
+- Include library fallbacks in test_dlls.py for linux platform.
+
+1.2.4 (2010-09-09)
+------------------
+- Raise AttributeError when there's no backend support for a method.
+- Raise OSError if libgeos_c.so (or variants) can't be found and loaded.
+- Add geos_c DLL loading support for linux platforms where find_library doesn't
+  work.
+
+1.2.3 (2010-08-17)
+------------------
+- Add mapping function.
+- Fix problem with GEOSisValidReason symbol for GEOS < 3.1.
+
+1.2.2 (2010-07-23)
+------------------
+- Add representative_point method.
+
+1.2.1 (2010-06-23)
+------------------
+- Fixed bounds of singular polygons.
+- Added shapely.validation.explain_validity function (#226).
+
+1.2 (2010-05-27)
+----------------
+- Final release.
+
+1.2rc2 (2010-05-26)
+-------------------
+- Add examples and tests to MANIFEST.in.
+- Release candidate 2.
+
+1.2rc1 (2010-05-25)
+-------------------
+- Release candidate.
+
+1.2b7 (2010-04-22)
+------------------
+- Memory leak associated with new empty geometry state fixed.
+
+1.2b6 (2010-04-13)
+------------------
+- Broken GeometryCollection fixed.
+
+1.2b5 (2010-04-09)
+------------------
+- Objects can be constructed from others of the same type, thereby making
+  copies. Collections can be constructed from sequences of objects, also making
+  copies.
+- Collections are now iterators over their component objects.
+- New code for manual figures, using the descartes package.
+
+1.2b4 (2010-03-19)
+------------------
+- Adds support for the "sunos5" platform.
+
+1.2b3 (2010-02-28)
+------------------
+- Only provide simplification implementations for GEOS C API >= 1.5.
+
+1.2b2 (2010-02-19)
+------------------
+- Fix cascaded_union bug introduced in 1.2b1 (#212).
+
+1.2b1 (2010-02-18)
+------------------
+- Update the README. Remove cruft from setup.py. Add some version 1.2 metadata
+  regarding required Python version (>=2.5,<3) and external dependency
+  (libgeos_c >= 3.1).
+
+1.2a6 (2010-02-09)
+------------------
+- Add accessor for separate arrays of X and Y values (#210).
+
+TODO: fill gap here
+
+1.2a1 (2010-01-20)
+------------------
+- Proper prototyping of WKB writer, and avoidance of errors on 64-bit systems
+  (#191).
+- Prototype libgeos_c functions in a way that lets py2exe apps import shapely
+  (#189).
+
+1.2 Branched (2009-09-19)
+
+1.0.12 (2009-04-09)
+-------------------
+- Fix for references held by topology and predicate descriptors.
+
+1.0.11 (2008-11-20)
+-------------------
+- Work around bug in GEOS 2.2.3, GEOSCoordSeq_getOrdinate not exported properly
+  (#178).
+
+1.0.10 (2008-11-17)
+-------------------
+- Fixed compatibility with GEOS 2.2.3 that was broken in 1.0.8 release (#176).
+
+1.0.9 (2008-11-16)
+------------------
+- Find and load MacPorts libgeos.
+
+1.0.8 (2008-11-01)
+------------------
+- Fill out GEOS function result and argument types to prevent faults on a
+  64-bit arch.
+
+1.0.7 (2008-08-22)
+------------------
+- Polygon rings now have the same dimensions as parent (#168).
+- Eliminated reference cycles in polygons (#169).
+
+1.0.6 (2008-07-10)
+------------------
+- Fixed adaptation of multi polygon data.
+- Raise exceptions earlier from binary predicates.
+- Beginning distributing new windows DLLs (#166).
+
+1.0.5 (2008-05-20)
+------------------
+- Added access to GEOS polygonizer function.
+- Raise exception when insufficient coordinate tuples are passed to LinearRing
+  constructor (#164).
+
+1.0.4 (2008-05-01)
+------------------
+- Disentangle Python and topological equality (#163).
+- Add shape(), a factory that copies coordinates from a geo interface provider.
+  To be used instead of asShape() unless you really need to store coordinates
+  outside shapely for efficient use in other code.
+- Cache GEOS geometries in adapters (#163).
+
+1.0.3 (2008-04-09)
+------------------
+- Do not release GIL when calling GEOS functions (#158).
+- Prevent faults when chaining multiple GEOS operators (#159).
+
+1.0.2 (2008-02-26)
+------------------
+- Fix loss of dimensionality in polygon rings (#155).
+
+1.0.1 (2008-02-08)
+------------------
+- Allow chaining expressions involving coordinate sequences and geometry parts
+  (#151).
+- Protect against abnormal use of coordinate accessors (#152).
+- Coordinate sequences now implement the numpy array protocol (#153).
+
+1.0 (2008-01-18)
+----------------
+- Final release.
+
+1.0 RC2 (2008-01-16)
+--------------------
+- Added temporary solution for #149.
+
+1.0 RC1 (2008-01-14)
+--------------------
+- First release candidate


### PR DESCRIPTION
This implements the suggestion from https://github.com/shapely/shapely/pull/1442#issuecomment-1223326351, following up on the changelog PR:

- Include the content of CHANGES.txt verbatim into the docs (`docs/release/1.x.rst`), instead of using the include directive
- Remove the old releases (before 1.8) from CHANGEST.txt, and refer to the docs instead (this keeps that file shorter, plus reduces the duplication from the previous point)
- Include the changes from recent 1.8.x releases that were currently only present on the maint-1.8 branch
- For 2.0, only add a summary to CHANGES.txt, referring to the docs for the full changelog. This way, we can at least include the dates of the releases, and also include the changes in consecutive alpha/beta/rc releases that are not relevant for the final release notes in the docs.