### PR TITLE
Raise ValueError for non-finite distance to buffer/offset_curve

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -464,6 +464,8 @@ class BaseGeometry(shapely.Geometry):
 
         if mitre_limit == 0.0:
             raise ValueError("Cannot compute offset from zero-length line segment")
+        elif not np.isfinite(distance):
+            raise ValueError("buffer distance must be finite")
 
         return shapely.buffer(
             self,

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -1,5 +1,6 @@
 """Line strings and related utilities
 """
+import numpy as np
 
 import shapely
 from shapely.geometry.base import BaseGeometry, JOIN_STYLE
@@ -146,6 +147,8 @@ class LineString(BaseGeometry):
         """
         if mitre_limit == 0.0:
             raise ValueError("Cannot compute offset from zero-length line segment")
+        elif not np.isfinite(distance):
+            raise ValueError("offset_curve distance must be finite")
         return shapely.offset_curve(self, distance, quad_segs, join_style, mitre_limit)
 
     def parallel_offset(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -6,6 +6,13 @@ from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 from shapely.constructive import BufferCapStyle, BufferJoinStyle
 
 
+@pytest.mark.parametrize("distance", [float("nan"), float("inf")])
+def test_non_finite_distance(distance):
+    g = geometry.Point(0, 0)
+    with pytest.raises(ValueError, match="distance must be finite"):
+        g.buffer(distance)
+
+
 class BufferTests(unittest.TestCase):
     """Test Buffer Point/Line/Polygon with and without single_sided params"""
 

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -1,6 +1,15 @@
+import pytest
+
 from . import unittest
 from shapely.geometry import LineString, LinearRing
 from shapely.testing import assert_geometries_equal
+
+
+@pytest.mark.parametrize("distance", [float("nan"), float("inf")])
+def test_non_finite_distance(distance):
+    g = LineString([(0, 0), (10, 0)])
+    with pytest.raises(ValueError, match="distance must be finite"):
+        g.parallel_offset(distance)
 
 
 class OperationsTestCase(unittest.TestCase):


### PR DESCRIPTION
Similar to #1516 for `maint-1.8`, raise ValueError for non-finite distance values passed to buffer or offset_curve (aka parallel_offset) functions.

Previous behavior for shapely-2.0 did not crash (as it did for 1.8), but would be inconsistent:

- distance float('inf') would raise "GEOSException: IllegalArgumentException: CGAlgorithmsDD::orientationIndex encountered NaN/Inf numbers"
- distance float("nan") would not raise or warn, but would return None