### PR TITLE
Move project metadata to setup.cfg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - "ci/*"
       - "MANIFEST.in"
       - "pyproject.toml"
-      - "setup.py"
+      - "setup.*"
 
 jobs:
   build_sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,56 +2,11 @@
 requires = [
     "cython",
     "oldest-supported-numpy",
-    "setuptools>=61.0.0",
+    "setuptools",
 ]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "shapely"
-dynamic = ["version"]
-authors = [
-    {name = "Sean Gillies"},
-]
-maintainers = [
-    {name = "Shapely contributors"},
-]
-description = "Manipulation and analysis of geometric objects"
-readme = "README.rst"
-keywords = ["geometry", "topology", "gis"]
-license = {text = "BSD 3-Clause"}
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: Unix",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering :: GIS",
-]
-requires-python = ">=3.7"
-dependencies = [
-    "numpy>=1.14",
-]
-
-[project.optional-dependencies]
-test = ["pytest"]
-docs = ["sphinx", "numpydoc"]
-
-[project.urls]
-Documentation = "https://shapely.readthedocs.io/"
-Repository = "https://github.com/shapely/shapely"
-
-[tool.setuptools.packages.find]
-include = [
-    "shapely",
-    "shapely.*",
-]
+# [project] -- see setup.cfg for project metadata
 
 [tool.coverage.run]
 source = ["shapely"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,52 @@
+[metadata]
+name = shapely
+author = Sean Gillies
+maintainer = Shapely contributors
+description = Manipulation and analysis of geometric objects
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+keywords = geometry, topology, gis
+license = BSD 3-Clause
+url = https://github.com/shapely/shapely
+project_urls =
+    Documentation = https://shapely.readthedocs.io/
+    Repository = https://github.com/shapely/shapely
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: Unix
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Scientific/Engineering :: GIS
+
+[options]
+include_package_data = True
+packages = find:
+python_requires = >=3.7
+install_requires =
+    numpy>=1.14
+
+[options.extras_require]
+test =
+    pytest
+docs =
+    matplotlib
+    numpydoc
+    sphinx
+    sphinx-book-theme
+
+[options.packages.find]
+include =
+    shapely
+    shapely.*
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ cmdclass = versioneer.get_cmdclass()
 cmdclass["build_ext"] = build_ext
 
 
-# see pyproject.toml for static project metadata
+# see setup.cfg for static project metadata
 setup(
     version=versioneer.get_version(),
     ext_modules=ext_modules,


### PR DESCRIPTION
This PR is for @sebastic to endorse or say it is not needed, following a recent discussion https://github.com/pyproj4/pyproj/discussions/1134#discussioncomment-3592703 . This applies only to shapely-2.0, which has been under development for a few years, but will hopefully reach a final release perhaps this year (although no fixed deadline has been formally discussed). Is there an approximate date when setuptools>=61 will be in debian stable?

While modernizing project metadata, I had picked #1426 instead of #1430 considering recent PyPA developments, but forgetting the constraints for binary packaging (i.e. fixed package versions, no pip/network abilities). It is a bit annoying, as I had thought that `pyproject.toml` was the final spot to put project metadata.