### PR TITLE
COMPAT: keep (deprecated) geom_factory for downstream packages (cartopy)

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -3,6 +3,7 @@
 cimport cython
 from cpython cimport PyObject
 from cython cimport view
+from libc.stdint cimport uintptr_t
 
 import numpy as np
 
@@ -384,3 +385,11 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
             geom_idx_1 += collection_size[coll_idx]
 
     return out
+
+
+def _geom_factory(uintptr_t g):
+
+    with get_geos_handle() as geos_handle:
+        geom = PyGEOS_CreateGeometry(<GEOSGeometry *>g, geos_handle)
+
+    return geom

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -12,6 +12,7 @@ from warnings import warn
 import numpy as np
 
 import shapely
+from shapely._geometry_helpers import _geom_factory
 from shapely.affinity import affine_transform
 from shapely.coords import CoordinateSequence
 from shapely.errors import GeometryTypeError, GEOSException, ShapelyDeprecationWarning
@@ -26,6 +27,16 @@ GEOMETRY_TYPES = [
     "MultiPolygon",
     "GeometryCollection",
 ]
+
+
+def geom_factory(g, parent=None):
+    warn(
+        "The 'geom_factory' function is deprecated in Shapely 2.0, and will be "
+        "removed in a future version",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _geom_factory(g)
 
 
 def dump_coords(geom):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -30,6 +30,15 @@ GEOMETRY_TYPES = [
 
 
 def geom_factory(g, parent=None):
+    """
+    Creates a Shapely geometry instance from a pointer to a GEOS geometry.
+
+    WARNING: the GEOS library used to create the the GEOS geometry pointer
+    and the GEOS library used by Shapely must be exactly the same, or
+    unexpected results or segfaults may occur.
+
+    Deprecated in Shapely 2.0, and will be removed in a future version.
+    """
     warn(
         "The 'geom_factory' function is deprecated in Shapely 2.0, and will be "
         "removed in a future version",


### PR DESCRIPTION
For context, see https://github.com/SciTools/cartopy/issues/2076#issuecomment-1243294605. Cartopy is using `geom_factory` in their cython code to create a shapely geometry from a GEOS geometry object pointer they create in cython. This PR adds back a (deprecated) `geom_factory` function that did this before in <=1.8. 
Of course this is not really safe to use (it requires that you are using the exact same GEOS version and build), but this caveat already applies to cartopy+shapely now as well, so this just keeps that situation a bit longer. Longer term, cartopy will ideally stop passing pointers to shapely, for example by using shapely more instead of interfacing directly with GEOS (cfr https://github.com/SciTools/cartopy/issues/805)

Also related to https://github.com/shapely/shapely/issues/1443
