### PR TITLE
Make Geometry objects weakref-able

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -63,7 +63,7 @@ class BaseGeometry(shapely.Geometry):
 
     """
 
-    __slots__ = []
+    __slots__ = ["__weakref__"]
 
     def __new__(self):
         warn(

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -1,3 +1,5 @@
+import weakref
+
 import numpy as np
 import pytest
 
@@ -47,6 +49,11 @@ geometries_all_types = [
 def test_setattr_disallowed(geom):
     with pytest.raises(AttributeError):
         geom.name = "test"
+
+
+@pytest.mark.parametrize("geom", geometries_all_types)
+def test_weakrefable(geom):
+    _ = weakref.ref(geom)
 
 
 @pytest.mark.parametrize("geom", geometries_all_types)


### PR DESCRIPTION
For context, see https://github.com/SciTools/cartopy/issues/2076#issuecomment-1243294605. 

While trying to make cartopy run with Shapely 2.0, I discovered that they relied on geometry objects being weakref-able. And in Shapely 2.0 we broke that (first by making it an extension type in C (in pygeos), and then afterwards by adding `__slots__` to the python subclasses, https://github.com/shapely/shapely/pull/1181)

This PR makes the geometry objects again weakref-able. 

There is the question whether we want to do this, with the main tradeoff being that this adds 8 bytes of memory to each geometry object (although, given that each coordinate is also 8 bytes, this is only somewhat significant for Point objects)