### PR TITLE
Add unary_union alias for top-level union_all

### DIFF
--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -10,6 +10,7 @@ __all__ = [
     "intersection_all",
     "symmetric_difference",
     "symmetric_difference_all",
+    "unary_union",
     "union",
     "union_all",
     "coverage_union",
@@ -333,6 +334,8 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     set using set_precision.  Note: returned geometry does not have precision
     set unless specified previously by set_precision.
 
+    `unary_union` is an alias of `union_all`.
+
     Parameters
     ----------
     geometries : array_like
@@ -405,6 +408,9 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     else:
         result[only_none] = None
         return result
+
+
+unary_union = union_all
 
 
 @requires_geos("3.8.0")

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -379,3 +379,10 @@ def test_coverage_union_non_polygon_inputs(geom_1, geom_2):
 def test_union_all_prec(geom, grid_size, expected):
     actual = shapely.union_all(geom, grid_size=grid_size)
     assert shapely.equals(actual, expected)
+
+
+def test_uary_union_alias():
+    geoms = [shapely.box(0.1, 0.1, 5, 5), shapely.box(0, 0.2, 5.1, 10)]
+    actual = shapely.unary_union(geoms, grid_size=1)
+    expected = shapely.union_all(geoms, grid_size=1)
+    assert shapely.equals(actual, expected)

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -381,6 +381,7 @@ def test_union_all_prec(geom, grid_size, expected):
     assert shapely.equals(actual, expected)
 
 
+@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 def test_uary_union_alias():
     geoms = [shapely.box(0.1, 0.1, 5, 5), shapely.box(0, 0.2, 5.1, 10)]
     actual = shapely.unary_union(geoms, grid_size=1)


### PR DESCRIPTION
xref https://github.com/shapely/shapely/issues/1276

Since we already have `unary_union`, and this is also used in GeoPandas (and PostGIS also uses this), we thought it best to keep that name. But also keeping `union_all` because this is consistent with `intersection_all` etc (and we don't want to rename the `_all` functions to `unary_`, since that is also not a super clear name if you are not familiar with it)