### PR TITLE
COMPAT: keep old exception sublcasses as (deprecated) ShapelyError aliases

### DIFF
--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -35,6 +35,7 @@ class GeometryTypeError(ShapelyError):
 def __getattr__(name):
     import warnings
 
+    # Alias Shapely 1.8 error classes to ShapelyError with deprecation warning
     if name in [
         "ReadingError",
         "WKBReadingError",

--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -30,3 +30,25 @@ class GeometryTypeError(ShapelyError):
     An error raised when the type of the geometry in question is
     unrecognized or inappropriate.
     """
+
+
+def __getattr__(name):
+    import warnings
+
+    if name in [
+        "ReadingError",
+        "WKBReadingError",
+        "WKTReadingError",
+        "PredicateError",
+        "InvalidGeometryError",
+    ]:
+        warnings.warn(
+            f"{name} is deprecated and will be removed in a future version. "
+            "Use ShapelyError instead (functions previously raising {name} "
+            "will now raise a ShapelyError instead).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ShapelyError
+
+    raise AttributeError(f"module 'shapely.errors' has no attribute '{name}'")


### PR DESCRIPTION
I didn't really think about the backwards compatibility story when cleaning up those exception subclasses we no longer use ourselves (-> https://github.com/shapely/shapely/pull/1306), but since we didn't explicitly deprecate those, we can actually still do that now in 2.0

Triggered by seeing `pycsw` importing one of those errors: https://github.com/geopython/pycsw/blob/de3278523af546b3cdf5dc5a23cc5d61b4efab8e/pycsw/core/repository.py#L40-L43