### PR TITLE
PERF: improve performance of Point(x, y) constructor

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -53,6 +53,12 @@ class IOSuite:
         shapely.from_wkb(self.to_read_wkb)
 
 
+class ConstructorsSuite:
+    """Microbenchmarks for the Geometry class constructors"""
+    
+    def time_point(self):
+        shapely.Point(1.0, 2.0)
+
 class ConstructiveSuite:
     """Benchmarks constructive functions on a set of 10,000 points"""
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -1,5 +1,6 @@
 """Points and related utilities
 """
+import numpy as np
 
 import shapely
 from shapely.errors import DimensionError
@@ -70,7 +71,7 @@ class Point(BaseGeometry):
             geom = shapely.points(coords)
         else:
             # 2 or 3 args
-            geom = shapely.points(*args)
+            geom = shapely.points(np.array(args))
 
         if not isinstance(geom, Point):
             raise ValueError("Invalid values passed to Point constructor")


### PR DESCRIPTION
This avoids creating a separate array for the x and y argument, and then stacking both arrays (this is what happens in the `points(..)` under the hood, as that can both accept a single 2D array of separate x/y arrays):

```
In [2]: %timeit Point(1, 1)
12.6 µs ± 442 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)    # <-- main
4.34 µs ± 60.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)   # <-- PR
```