### PR TITLE
DOC/CI: fix doc build for latex + re-enable epub and htmlzip

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,7 @@ sphinx:
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - pdf
+formats: all
 
 conda:
   environment: docs/environment.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,8 @@ def rstjinja(app, docname, source):
     """
     # https://www.ericholscher.com/blog/2016/jul/25/integrating-jinja-rst-sphinx/
     # Make sure we're outputting HTML
+    if app.builder.format != 'html':
+        return
     source[0] = app.builder.templates.render_string(source[0], app.config.html_context)
 
 


### PR DESCRIPTION
After https://github.com/shapely/shapely/pull/1529, the doc build on readthedocs was failing for latex (pdf). Although if this rendering can't be done for pdf, then I am not sure that the approach of https://github.com/shapely/shapely/pull/1529 will actually result in proper pdf docs .. (I am also not sure how important this is)