### PR TITLE
API: restore unary_union behaviour on empty list to return empty GeometryCollection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ Relevant changes compared to 2.0a1:
   class ``buffer`` and ``offset_curve`` methods all to ``quad_segs``.
 - Added use of ``GEOSGeom_getExtent`` to speed up bounds calculations for
   GEOS >= 3.11.
+- Restored the behaviour of ``unary_union`` to return an empty GeometryCollection
+  for an empty sequence as input.
 
 Wheels for 2.0b1 published on PyPI include GEOS 3.11.0.
 

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -325,7 +325,8 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     """Returns the union of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
-    If all elements of the given axis are None, None is returned.
+    If all elements of the given axis are None an empty GeometryCollection is
+    returned.
 
     If grid_size is nonzero, input coordinates will be snapped to a precision
     grid of that size and resulting coordinates will be snapped to that same
@@ -358,7 +359,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
 
     Examples
     --------
-    >>> from shapely import box, LineString, normalize
+    >>> from shapely import box, LineString, normalize, Point
     >>> line1 = LineString([(0, 0), (2, 2)])
     >>> line2 = LineString([(2, 2), (3, 3)])
     >>> union_all([line1, line2])
@@ -372,7 +373,12 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     >>> box1 = box(0.1, 0.2, 2.1, 2.1)
     >>> union_all([box1, box2], grid_size=1)
     <POLYGON ((2 0, 0 0, 0 2, 1 2, 1 3, 3 3, 3 1, 2 1, 2 0))>
-
+    >>> union_all([None, Point(0, 1)])
+    <POINT (0 1)>
+    >>> union_all([None, None])
+    <GEOMETRYCOLLECTION EMPTY>
+    >>> union_all([])
+    <GEOMETRYCOLLECTION EMPTY>
     """
     # for union_all, GEOS provides an efficient route through first creating
     # GeometryCollections
@@ -381,9 +387,8 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     if axis is None:
         geometries = geometries.ravel()
     else:
-        geometries = np.rollaxis(
-            np.asarray(geometries), axis=axis, start=geometries.ndim
-        )
+        geometries = np.rollaxis(geometries, axis=axis, start=geometries.ndim)
+
     # create_collection acts on the inner axis
     collections = lib.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)
 
@@ -396,18 +401,9 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 
-        result = lib.unary_union_prec(collections, grid_size, **kwargs)
+        return lib.unary_union_prec(collections, grid_size, **kwargs)
 
-    else:
-        result = lib.unary_union(collections, **kwargs)
-    # for consistency with other _all functions, we replace GEOMETRY COLLECTION EMPTY
-    # if the original collection had no geometries
-    only_none = lib.get_num_geometries(collections) == 0
-    if np.isscalar(only_none):
-        return result if not only_none else None
-    else:
-        result[only_none] = None
-        return result
+    return lib.unary_union(collections, **kwargs)
 
 
 unary_union = union_all

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import shapely
-from shapely import Geometry, Polygon
+from shapely import Geometry, GeometryCollection, Polygon
 from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 
@@ -147,17 +147,22 @@ def test_set_operation_reduce_two_none(func, related_func, none_position):
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none(n, func, related_func):
-    # API change: before, union_all([None]) yielded EMPTY GEOMETRYCOLLECTION
-    # The new behaviour is that it returns None if all inputs are None.
-    assert func([None] * n) is None
+    if func is shapely.union_all:
+        assert_geometries_equal(func([None] * n), GeometryCollection([]))
+    else:
+        assert func([None] * n) is None
 
 
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none_arr(n, func, related_func):
-    # API change: before, union_all([None]) yielded EMPTY GEOMETRYCOLLECTION
-    # The new behaviour is that it returns None if all inputs are None.
-    assert func([[None] * n] * 2, axis=1).tolist() == [None, None]
+    if func is shapely.union_all:
+        assert func([[None] * n] * 2, axis=1).tolist() == [
+            GeometryCollection([]),
+            GeometryCollection([]),
+        ]
+    else:
+        assert func([[None] * n] * 2, axis=1).tolist() == [None, None]
 
 
 @pytest.mark.skipif(shapely.geos_version >= (3, 9, 0), reason="GEOS >= 3.9")
@@ -241,9 +246,7 @@ def test_set_operation_prec_reduce_two_none(func, related_func, none_position):
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_all_none(n, func, related_func):
-    # API change: before, union_all([None]) yielded EMPTY GEOMETRYCOLLECTION
-    # The new behaviour is that it returns None if all inputs are None.
-    assert func([None] * n, grid_size=1) is None
+    assert_geometries_equal(func([None] * n, grid_size=1), GeometryCollection([]))
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 8, 0), reason="GEOS < 3.8")


### PR DESCRIPTION
Targeted fix for https://github.com/shapely/shapely/issues/1332, in case this might be merged quicker for a beta release than a more general solution for all reducers (https://github.com/shapely/shapely/pull/1501, https://github.com/shapely/shapely/pull/1540). unary_union is the only one that already existed in 1.8, and so the only one that people might run into when upgrading from 1.8->2.0 (as people already reported in https://github.com/shapely/shapely/issues/1332 and https://github.com/shapely/shapely/issues/1545)

@brendan-ward I basically extracted those parts from your PR that related to unary_union.