### PR TITLE
CI: add PyPI token for travis wheel uploads (splitted secret)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ if: (branch = main OR tag IS present) AND (type = push)
 env:
   global:
   - GEOS_VERSION=3.11.0
+  - secure: Rg+fFrK8N8+jYqno6mfa/MfeUDV9mnUdJtsC02A6A1Umdcs3gwyyEfeEdDlJvJ94Sr04jwN/9WkTj5i7EyW6/ESq1mFaaSLqL456nyriJBHn7o/dJgKavl6E0EyXMbpfLXR4V+5cHfI/48PuX4BuDwlEZa+dLTjpDbvXIwb98sY=
+  - secure: bJ5kz6dk3E9bYoBe//XF5d0xP1ksbc/uGVhZVgB6jRGYpkO/lpU7rIltiG//8LMH+heKK2vEUAo6lLGBPN3FMBx7Ti/UBlbQhw4NKdTW52Tzb8XY15MwcYjCC4PbYf9pGvO5VgRXiTfRjR6yac85ndV7SpYCDKCudf4wJ9M6tro=
+  - secure: MPQZA8QcTJtJrLhHA7hGmrGE5Shr71gxOjjyVcX+KUHmLefWTX/wkz2AXntTq9sBHwBskKc0k7wqM/HRmC2JFgrhe+7zFqs6etILhISdZUizM3TKd7y2Dnm4U3KLBvtuoty3o9N2YsETmXhDsOZ4po8zyxLBuUmo2obIqk+TAyY=
 
 cache:
   directories:
@@ -57,9 +60,8 @@ script:
 deploy:
   provider: pypi
   username: __token__
+  password: $PYPI_TOKEN1$PYPI_TOKEN2$PYPI_TOKEN3
   skip_cleanup: true
   skip_existing: true
   on:
     tags: true
-  password:
-    secure: ""  # TODO

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ if: (branch = main OR tag IS present) AND (type = push)
 env:
   global:
   - GEOS_VERSION=3.11.0
-  - secure: Rg+fFrK8N8+jYqno6mfa/MfeUDV9mnUdJtsC02A6A1Umdcs3gwyyEfeEdDlJvJ94Sr04jwN/9WkTj5i7EyW6/ESq1mFaaSLqL456nyriJBHn7o/dJgKavl6E0EyXMbpfLXR4V+5cHfI/48PuX4BuDwlEZa+dLTjpDbvXIwb98sY=
-  - secure: bJ5kz6dk3E9bYoBe//XF5d0xP1ksbc/uGVhZVgB6jRGYpkO/lpU7rIltiG//8LMH+heKK2vEUAo6lLGBPN3FMBx7Ti/UBlbQhw4NKdTW52Tzb8XY15MwcYjCC4PbYf9pGvO5VgRXiTfRjR6yac85ndV7SpYCDKCudf4wJ9M6tro=
-  - secure: MPQZA8QcTJtJrLhHA7hGmrGE5Shr71gxOjjyVcX+KUHmLefWTX/wkz2AXntTq9sBHwBskKc0k7wqM/HRmC2JFgrhe+7zFqs6etILhISdZUizM3TKd7y2Dnm4U3KLBvtuoty3o9N2YsETmXhDsOZ4po8zyxLBuUmo2obIqk+TAyY=
 
 cache:
   directories:
@@ -59,8 +56,9 @@ script:
 
 deploy:
   provider: pypi
-  username: __token__
-  password: $PYPI_TOKEN1$PYPI_TOKEN2$PYPI_TOKEN3
+  username: "__token__"
+  password:
+    secure: "hU7JzC2F1GomDVpSOw9L3WHV/qwVWkc3NI6YCkkqUArMyYnJPSMBJck9ugeZIJ6OrIKORs50vIAdGrYQnjbhcntQzwc384mfnNO3FNPMnkBaxi4y0ofERy/ygqysM+tEOXINzJpFcYyylpknQdSnuzLSgYhdm+OXfob5Sqy/ABX+dXEuz1pb7UWvK0oYcLC1PYkfneFK4IcUIHYuMhia48y0jfxlez9gFZMAos3PKtn6m9CRN4xU370RgNjvy7Ey/hXwiTlm4rrX4KbEFj1q/SoaXvgK+mQqofM7n/4MakA8VFzKtz5a/L64f4iiJy0V2WgO/DiO2fLFwfEFmr+23WY8TTkMV/p7IAjZzeMY9ZmODymzXRKaJxIVt0MerLiwdul7nVCmXbJ/HkQwW2p32IUxzL37XaEk6ZN4lTb+5BhPA9e6jCZdgRY8sfJrrOzFxNNVm0wuf9nbve662PYhmgq9sETk4sdvqK8ODem/TSqMZzsq6FPRf2JCeFGZn+2TAKp+nwAFTByoJ/mMNsTc3TjtAzFhhtd2DUQriGadD+aNPZexA+yKCVSY/EGDYxpbnyS1h1fJv17kgyLxQfUi5FDBwrcGX0Ld01IyqcQbaw57DLDTQYYK4yvrfsYaQJDIQlySe8BkwgtJ5Dz9WP13MUZJ7VrISYMdTRU805eTvRE="
   skip_cleanup: true
   skip_existing: true
   on:


### PR DESCRIPTION
The linux aarch64 wheels were not yet uploaded for the previous alpha (see https://github.com/shapely/shapely/issues/962#issuecomment-1203723128), because the PyPI authentication wasn't yet set up in travis.yml

However I ran into the issue that the token is "too large" for travis to encrypt (apparently something for older repos ..), see https://travis-ci.community/t/travis-encrypt-data-too-large-for-pypi-tokens-with-older-repos/5792/10 or https://github.com/travis-ci/travis.rb/issues/687 for context.

I followed a workaround mentioned in those threads (and similarly as done in eg https://github.com/rafguns/linkpred/commit/f0a4ebdfa4532f519e5e5c74d17b98d12e58cdc3) to split the secret. No idea if I did it correctly, I suppose we will only see with the next time we try to upload .. 

Basically what I did was creating a token on PyPI to use for uploading from Travis, and then encrypting this using Travis' cli tool, but cut the token into three pieces: `travis encrypt PYPI_TOKEN1=<part of the token> --com`

(I also sent Travis a support request to fix this)