### PR TITLE
Refactor reducing set operations as gufuncs + return emtpy collection for empty/all-None input

### DIFF
--- a/docs/migration_pygeos.rst
+++ b/docs/migration_pygeos.rst
@@ -84,6 +84,6 @@ Other differences
   functions was renamed to ``quad_segs``.
 - The ``preserve_topology`` keyword of ``simplify()`` now defaults to
   ``True`` instead of ``False``.
-- The behaviour of ``union_all()`` was changed to return an empty
-  GeometryCollection for an empty or all-None sequence as input (instead of
-  returning None).
+- The behaviour of ``union_all()`` / ``intersection_all()`` / ``symmetric_difference_all``
+  was changed to return an empty GeometryCollection for an empty or all-None
+  sequence as input (instead of returning None).

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -172,7 +172,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     else:
         geometries = np.rollaxis(geometries, axis=axis, start=geometries.ndim)
 
-    return lib.intersection_all2(geometries, **kwargs)
+    return lib.intersection_all(geometries, **kwargs)
 
 
 @multithreading_enabled
@@ -265,7 +265,13 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     >>> symmetric_difference_all([[line1, line2, None]], axis=1).tolist()
     [<MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>]
     """
-    return lib.symmetric_difference.reduce(geometries, axis=axis, **kwargs)
+    geometries = np.asarray(geometries)
+    if axis is None:
+        geometries = geometries.ravel()
+    else:
+        geometries = np.rollaxis(geometries, axis=axis, start=geometries.ndim)
+
+    return lib.symmetric_difference_all(geometries, **kwargs)
 
 
 @multithreading_enabled

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -138,7 +138,8 @@ def intersection_all(geometries, axis=None, **kwargs):
     """Returns the intersection of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
-    If all elements of the given axis are None, None is returned.
+    If all elements of the given axis are None, an empty GeometryCollection is
+    returned.
 
     Parameters
     ----------
@@ -165,6 +166,8 @@ def intersection_all(geometries, axis=None, **kwargs):
     <LINESTRING (1 1, 2 2)>
     >>> intersection_all([[line1, line2, None]], axis=1).tolist()
     [<LINESTRING (1 1, 2 2)>]
+    >>> intersection_all([line1, None])
+    <LINESTRING (0 0, 2 2)>
     """
     geometries = np.asarray(geometries)
     if axis is None:
@@ -237,7 +240,8 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     """Returns the symmetric difference of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
-    If all elements of the given axis are None, None is returned.
+    If all elements of the given axis are None an empty GeometryCollection is
+    returned.
 
     Parameters
     ----------
@@ -264,6 +268,10 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     <MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>
     >>> symmetric_difference_all([[line1, line2, None]], axis=1).tolist()
     [<MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>]
+    >>> symmetric_difference_all([line1, None])
+    <LINESTRING (0 0, 2 2)>
+    >>> symmetric_difference_all([None, None])
+    <GEOMETRYCOLLECTION EMPTY>
     """
     geometries = np.asarray(geometries)
     if axis is None:
@@ -460,6 +468,10 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     This is an optimized version of union which assumes the polygons
     to be non-overlapping.
 
+    This function ignores None values when other Geometry elements are present.
+    If all elements of the given axis are None, an empty MultiPolygon is
+    returned.
+
     Parameters
     ----------
     geometries : array_like
@@ -483,6 +495,10 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     >>> polygon_2 = Polygon([(1, 0), (1, 1), (2, 1), (2, 0), (1, 0)])
     >>> normalize(coverage_union_all([polygon_1, polygon_2]))
     <POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))>
+    >>> normalize(coverage_union_all([polygon_1, None]))
+    <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
+    >>> normalize(coverage_union_all([None, None]))
+    <MULTIPOLYGON EMPTY>
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -166,7 +166,13 @@ def intersection_all(geometries, axis=None, **kwargs):
     >>> intersection_all([[line1, line2, None]], axis=1).tolist()
     [<LINESTRING (1 1, 2 2)>]
     """
-    return lib.intersection.reduce(geometries, axis=axis, **kwargs)
+    geometries = np.asarray(geometries)
+    if axis is None:
+        geometries = geometries.ravel()
+    else:
+        geometries = np.rollaxis(geometries, axis=axis, start=geometries.ndim)
+
+    return lib.intersection_all2(geometries, **kwargs)
 
 
 @multithreading_enabled

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -147,22 +147,16 @@ def test_set_operation_reduce_two_none(func, related_func, none_position):
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none(n, func, related_func):
-    if func is shapely.union_all:
-        assert_geometries_equal(func([None] * n), GeometryCollection([]))
-    else:
-        assert func([None] * n) is None
+    assert_geometries_equal(func([None] * n), GeometryCollection([]))
 
 
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none_arr(n, func, related_func):
-    if func is shapely.union_all:
-        assert func([[None] * n] * 2, axis=1).tolist() == [
-            GeometryCollection([]),
-            GeometryCollection([]),
-        ]
-    else:
-        assert func([[None] * n] * 2, axis=1).tolist() == [None, None]
+    assert func([[None] * n] * 2, axis=1).tolist() == [
+        GeometryCollection([]),
+        GeometryCollection([]),
+    ]
 
 
 @pytest.mark.skipif(shapely.geos_version >= (3, 9, 0), reason="GEOS >= 3.9")

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -6,7 +6,7 @@ from shapely import Geometry, GeometryCollection, Polygon
 from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 
-from .common import all_types, multi_polygon, point, polygon
+from .common import all_types, empty, multi_polygon, point, polygon
 
 # fixed-precision operations raise GEOS exceptions on mixed dimension geometry collections
 all_single_types = [g for g in all_types if not shapely.get_type_id(g) == 7]
@@ -120,6 +120,15 @@ def test_set_operation_reduce_axis(func, related_func):
     assert actual.shape == (3,)
 
 
+@pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
+def test_set_operation_reduce_empty(func, related_func):
+    assert func(np.empty((0,), dtype=object)) == empty
+    arr_empty_2D = np.empty((0, 2), dtype=object)
+    assert func(arr_empty_2D) == empty
+    assert func(arr_empty_2D, axis=0).tolist() == [empty] * 2
+    assert func(arr_empty_2D, axis=1).tolist() == []
+
+
 @pytest.mark.parametrize("none_position", range(3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_one_none(func, related_func, none_position):
@@ -144,6 +153,13 @@ def test_set_operation_reduce_two_none(func, related_func, none_position):
     assert_geometries_equal(actual, expected)
 
 
+@pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
+def test_set_operation_reduce_some_none_len2(func, related_func):
+    # in a previous implementation, this would take a different code path
+    # and return wrong result
+    assert func([empty, None]) == empty
+
+
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none(n, func, related_func):
@@ -153,10 +169,8 @@ def test_set_operation_reduce_all_none(n, func, related_func):
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_all_none_arr(n, func, related_func):
-    assert func([[None] * n] * 2, axis=1).tolist() == [
-        GeometryCollection([]),
-        GeometryCollection([]),
-    ]
+    assert func([[None] * n] * 2, axis=1).tolist() == [empty, empty]
+    assert func([[None] * 2] * n, axis=0).tolist() == [empty, empty]
 
 
 @pytest.mark.skipif(shapely.geos_version >= (3, 9, 0), reason="GEOS >= 3.9")

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3424,11 +3424,6 @@ TODO relate functions
                                   PyUFunc_None, #NAME, "", 0);                   \
   PyDict_SetItemString(d, #NAME, ufunc)
 
-#define DEFINE_YY_Y_REORDERABLE(NAME)                                            \
-  ufunc = PyUFunc_FromFuncAndData(YY_Y_funcs, NAME##_data, YY_Y_dtypes, 1, 2, 1, \
-                                  PyUFunc_ReorderableNone, #NAME, "", 0);        \
-  PyDict_SetItemString(d, #NAME, ufunc)
-
 #define DEFINE_Y_Y_reduce(NAME)                                               \
   ufunc = PyUFunc_FromFuncAndDataAndSignature(Y_Y_reduce_funcs, NAME##_data,  \
                                               Y_Y_reduce_dtypes, 1, 1, 1,     \
@@ -3537,13 +3532,10 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_Yd_Y(simplify_preserve_topology);
   DEFINE_Yd_Y(force_3d);
 
-  // 'REORDERABLE' sets PyUFunc_ReorderableNone instead of PyUFunc_None as 'identity',
-  // meaning that the order of arguments does not matter. This enables reduction over
-  // multiple (or all) axes.
-  DEFINE_YY_Y_REORDERABLE(intersection);
+  DEFINE_YY_Y(intersection);
   DEFINE_YY_Y(difference);
-  DEFINE_YY_Y_REORDERABLE(symmetric_difference);
-  DEFINE_YY_Y_REORDERABLE(union);
+  DEFINE_YY_Y(symmetric_difference);
+  DEFINE_YY_Y(union);
   DEFINE_YY_Y(shared_paths);
 
   DEFINE_Y_Y_reduce(intersection_all);


### PR DESCRIPTION
Next iteration on https://github.com/shapely/shapely/pull/1540 and https://github.com/shapely/shapely/pull/1501 
Addresses https://github.com/shapely/shapely/issues/1332

See https://github.com/shapely/shapely/pull/1540#discussion_r990693467 for details. This PR implements `intersection_all` and `symmetric_difference_all` as a generalized ufunc with the last dimension of the array that gets reduced. This way we can implement the reducing set operations without relying on the `.reduce` mode of standard ufuncs. 
To achieve the same functionality from before, we only have to reshape the input array to move the axis to be reduced (based on the `axis` keyword) to the last dimension.

I still need to add some more tests for the cases brought up in the various issues and PRs (and copy from https://github.com/shapely/shapely/pull/1540). 
I also didn't yet add a keyword to control the behaviour of skipping None or not, but that should be straightforward to add on top of the current changes (also a keyword to control the "initial" value (in case of empty or all None) that is returned could be added)