### PR TITLE
Move dev requirements to pyproject.toml 

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,8 +79,7 @@ using ``venv``:
 
     $ python3 -m venv .
     $ source bin/activate
-    (env) $ pip install -r requirements-dev.txt
-    (env) $ pip install -e .
+    (env) $ pip install -e .[dev]
 
 Or using ``conda``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "cython",
+    "cython>=0.29.32",
     "oldest-supported-numpy",
-    "setuptools>=61.0.0",
+    "setuptools>=63",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -42,6 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 docs = ["sphinx", "numpydoc"]
+dev = ["descartes>=1.0.1", "matplotlib", "pytest", "pytest-cov", "wheel"]
 
 [project.urls]
 Documentation = "https://shapely.readthedocs.io/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-cython==0.29.21
-descartes==1.0.1
+cython>=0.29.32
+descartes>=1.0.1
 matplotlib
 numpy>=1.4.1
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,0 @@
-cython>=0.29.32
-descartes>=1.0.1
-matplotlib
-numpy>=1.4.1
-pytest
-pytest-cov
-setuptools
-wheel


### PR DESCRIPTION
Removes `requirements-dev.txt` file and consolidates those requirements as optional dependencies in `pyproject.toml` with the [dev] extra.

Also requires a newer version of Cython for Python 3.11, and specify minimum instead of specific versions for Cython and Descartes.