### PR TITLE
1.8 backport: release CI: Update used actions to latest versions, add upload to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,14 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Build a source tarball
         env:
@@ -40,7 +42,7 @@ jobs:
           python -m pip install cython==0.29.28 oldest-supported-numpy
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*.tar.gz
           retention-days: 30
@@ -76,10 +78,13 @@ jobs:
           cmake_osx_architectures: "x86_64;arm64"
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Cache GEOS build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}
           key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.GEOS_VERSION }}-${{ hashFiles('ci/*') }}
@@ -114,7 +119,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.10.2
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: pp* *musllinux* cp310-manylinux_i686
@@ -144,7 +149,7 @@ jobs:
           CIBW_TEST_COMMAND_WINDOWS: xcopy /y /i {project}\tests ${{ runner.temp }}\tests && chdir /d ${{ runner.temp }} && dir && python -m pytest -vv -k "not test_fallbacks and not test_minimum_clearance" tests
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
           retention-days: 5
@@ -155,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -187,3 +192,11 @@ jobs:
           asset_path: dist/${{ env.name }}
           asset_name: ${{ env.name }}
           asset_content_type: application/zip
+
+      - name: Upload Release Assets to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          skip_existing: true
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This is backport of #1561 to the 1.8 maintenance branch, brining maintenance to the release CI to the 1.8 branch.

It updates the used actions in the release CI to their latest version, and also adds the _Upload Release Assets to PyPI_ part which was added in https://github.com/shapely/shapely/commit/a66a623cd63b674d7aa12c259ff56a58348e08d5.

The main improvement is on the cibuildwheel side, which include Python 3.11 support, better Apple Silicon support and many bugfixes. It also expands the API, see https://cibuildwheel.readthedocs.io/en/stable/changelog/ for details.

With this PR, the only thing that's needed to release Python 3.11 wheels to PyPI is tagging a new patch release on the 1.8 branch, on which this CI configuration is triggered and does the rest.