### PR TITLE
BUG: move weakref-able implementation to base C extension type (fix PyPy)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,11 @@ jobs:
             python: 3.9
             geos: 3.10.3
             numpy: 1.19.5
+          # pypy
+          - os: ubuntu-latest
+            python: "pypy3.9"
+            geos: 3.11.0
+            numpy: 1.23.3
 
     env:
       GEOS_VERSION: ${{ matrix.geos }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
             numpy: 1.19.5
           # pypy
           - os: ubuntu-latest
-            python: "pypy3.9"
+            python: "pypy3.8"
             geos: 3.11.0
             numpy: 1.23.3
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -81,7 +81,7 @@ class BaseGeometry(shapely.Geometry):
 
     """
 
-    __slots__ = ["__weakref__"]
+    __slots__ = []
 
     def __new__(self):
         warn(

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -1,3 +1,4 @@
+import platform
 import weakref
 
 import numpy as np
@@ -45,6 +46,10 @@ geometries_all_types = [
 ]
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="Setting custom attributes doesn't fail on PyPy",
+)
 @pytest.mark.parametrize("geom", geometries_all_types)
 def test_setattr_disallowed(geom):
     with pytest.raises(AttributeError):

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -38,11 +38,15 @@ PyObject* GeometryObject_FromGEOS(GEOSGeometry* ptr, GEOSContextHandle_t ctx) {
   } else {
     self->ptr = ptr;
     self->ptr_prepared = NULL;
+    self->weakreflist = (PyObject *)NULL;
     return (PyObject*)self;
   }
 }
 
 static void GeometryObject_dealloc(GeometryObject* self) {
+  if (self->weakreflist != NULL) {
+    PyObject_ClearWeakRefs((PyObject *)self);
+  }
   if (self->ptr != NULL) {
     // not using GEOS_INIT, but using global context instead
     GEOSContextHandle_t ctx = geos_context[0];
@@ -396,6 +400,7 @@ PyTypeObject GeometryType = {
     .tp_repr = (reprfunc)GeometryObject_repr,
     .tp_hash = (hashfunc)GeometryObject_hash,
     .tp_richcompare = (richcmpfunc)GeometryObject_richcompare,
+    .tp_weaklistoffset = offsetof(GeometryObject, weakreflist),
     .tp_str = (reprfunc)GeometryObject_str,
 };
 

--- a/src/pygeom.h
+++ b/src/pygeom.h
@@ -6,8 +6,11 @@
 #include "geos.h"
 
 typedef struct {
-  PyObject_HEAD void* ptr;
+  PyObject_HEAD
+  void* ptr;
   void* ptr_prepared;
+  /* For weak references */
+  PyObject *weakreflist;
 } GeometryObject;
 
 extern PyTypeObject GeometryType;


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/1575

I haven't yet checked if this actually fixes it on PyPy, but it's a potential fix for the issue. My understanding is that on PyPy also extension types defined in C support weakref by default, so therefore adding this manually in the subclasses as we did here is failing (https://foss.heptapod.net/pypy/pypy/-/issues/2670#note_45293)

The implementation of adding a  `weakreflist` slot is mimicked from numpy (how they do that for the ndarray extension type)