### PR TITLE
Specify build-backend for PEP 517/518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "oldest-supported-numpy",
     "setuptools<64",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 # 1) Installing from a source distribution, whether via
 #
-#      ``python setup.py install``
+#      ``pip install .``
 #
 #    after downloading a source distribution, or
 #
@@ -67,6 +67,9 @@ from setuptools.command.build_ext import build_ext as distutils_build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 
+# ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+sys.path.append(os.path.dirname(__file__))
 from _vendor.packaging.version import Version
 
 logging.basicConfig()


### PR DESCRIPTION
It seems that maint-1.8's PEP 517/518 was incomplete, as a build-backend was not specified. <s>Also, unpin setuptools version, as newer versions should work too.</s> A "wheel" requirement was not added, as this should automatically be included.

Closes #1568