### PR TITLE
Resolve pytest warnings (maint-1.8)

### DIFF
--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,36 +1,19 @@
 import os
 import doctest
-from . import unittest
-from glob import glob
+from pathlib import Path
+
+import pytest
 
 optionflags = (doctest.REPORT_ONLY_FIRST_FAILURE |
                doctest.NORMALIZE_WHITESPACE |
                doctest.ELLIPSIS)
 
 
-def list_doctests():
-    print(__file__)
-    source_files = glob(os.path.join(os.path.dirname(__file__), '*.txt'))
-    return [filename for filename in source_files]
-
-
-def open_file(filename, mode='r'):
-    """Helper function to open files from within the tests package."""
-    return open(os.path.join(os.path.dirname(__file__), filename), mode)
-
-
-def setUp(test):
-    test.globs.update(dict(open_file=open_file,))
-
-
-def test_suite():
-    return unittest.TestSuite(
-        [doctest.DocFileSuite(os.path.basename(filename),
-                              optionflags=optionflags,
-                              setUp=setUp)
-         for filename
-         in list_doctests()])
-
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=1)
-    runner.run(test_suite())
+@pytest.mark.parametrize(
+    "filename",
+    list(Path(__file__).parent.glob('*.txt')),
+)
+def test_doctest(filename):
+    ret = doctest.testfile(filename.name, optionflags=optionflags)
+    assert ret.attempted > 0
+    assert ret.failed == 0

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,37 +1,25 @@
-from shapely.geometry import Point, MultiPoint, Polygon, GeometryCollection
+import pytest
+
+from shapely.geometry import GeometryCollection, LineString, MultiPoint, Point
 
 
-def test_point():
-    g = Point(0, 0)
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
-
-
-def test_multipoint():
-    g = MultiPoint([(0, 0)])
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
-
-
-def test_polygon():
-    g = Point(0, 0).buffer(1.0)
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
-
-
-def test_collection():
-    g = GeometryCollection([Point(0, 0)])
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
+@pytest.mark.parametrize(
+    "geom",
+    [
+        Point(1, 2),
+        MultiPoint([(1, 2), (3, 4)]),
+        LineString([(1, 2), (3, 4)]),
+        Point(0, 0).buffer(1.0),
+        GeometryCollection([Point(1, 2), LineString([(1, 2), (3, 4)])]),
+    ],
+    ids=[
+        "Point",
+        "MultiPoint",
+        "LineString",
+        "Polygon",
+        "GeometryCollection",
+    ],
+)
+def test_hash(geom):
+    with pytest.raises(TypeError, match="unhashable type"):
+        hash(geom)


### PR DESCRIPTION
Two files (`tests/test_doctests.py` and `tests/test_hash.py`) are refactored from older testing paradigms into pytests to resolve a few warnings from tests that returned non-None objects.

```
=============================== warnings summary ===============================
tests/test_doctests.py::test_suite
  $PREFIX/lib/pypy3.8/site-packages/_pytest/python.py:201: PytestReturnNotNoneWarning: Expected None, but tests/test_doctests.py::test_suite returned <unittest.suite.TestSuite tests=[<doctest._DocTestSuite tests=[$SRC_DIR/tests/test_binascii_hex.txt]>]>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "

tests/test_hash.py::test_point
  $PREFIX/lib/pypy3.8/site-packages/_pytest/python.py:201: PytestReturnNotNoneWarning: Expected None, but tests/test_hash.py::test_point returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "

tests/test_hash.py::test_multipoint
  $PREFIX/lib/pypy3.8/site-packages/_pytest/python.py:201: PytestReturnNotNoneWarning: Expected None, but tests/test_hash.py::test_multipoint returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "

tests/test_hash.py::test_polygon
  $PREFIX/lib/pypy3.8/site-packages/_pytest/python.py:201: PytestReturnNotNoneWarning: Expected None, but tests/test_hash.py::test_polygon returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "

tests/test_hash.py::test_collection
  $PREFIX/lib/pypy3.8/site-packages/_pytest/python.py:201: PytestReturnNotNoneWarning: Expected None, but tests/test_hash.py::test_collection returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "
```