### PR TITLE
API: rename 'radius' -> 'distance' keyword in shapely.buffer() for consistency

### DIFF
--- a/docs/migration_pygeos.rst
+++ b/docs/migration_pygeos.rst
@@ -87,3 +87,4 @@ Other differences
 - The behaviour of ``union_all()`` / ``intersection_all()`` / ``symmetric_difference_all``
   was changed to return an empty GeometryCollection for an empty or all-None
   sequence as input (instead of returning None).
+- The ``radius`` keyword of the ``buffer()`` funtion was renamed to ``distance``.

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -83,7 +83,7 @@ MultiLineString, MultiPoint, Point, Polygon
 @multithreading_enabled
 def buffer(
     geometry,
-    radius,
+    distance,
     quad_segs=8,
     cap_style="round",
     join_style="round",
@@ -95,8 +95,8 @@ def buffer(
     Computes the buffer of a geometry for positive and negative buffer radius.
 
     The buffer of a geometry is defined as the Minkowski sum (or difference,
-    for negative width) of the geometry with a circle with radius equal to the
-    absolute value of the buffer radius.
+    for negative distance) of the geometry with a circle with radius equal
+    to the absolute value of the buffer distance.
 
     The buffer operation always returns a polygonal result. The negative
     or zero-distance buffer of lines and points is always empty.
@@ -104,7 +104,7 @@ def buffer(
     Parameters
     ----------
     geometry : Geometry or array_like
-    width : float or array_like
+    distance : float or array_like
         Specifies the circle radius in the Minkowski sum (or difference).
     quad_segs : int, default 8
         Specifies the number of linear segments in a quarter circle in the
@@ -178,7 +178,7 @@ def buffer(
         raise TypeError("single_sided only accepts scalar values")
     return lib.buffer(
         geometry,
-        radius,
+        distance,
         np.intc(quad_segs),
         np.intc(cap_style),
         np.intc(join_style),

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -92,7 +92,7 @@ def buffer(
     **kwargs
 ):
     """
-    Computes the buffer of a geometry for positive and negative buffer radius.
+    Computes the buffer of a geometry for positive and negative buffer distance.
 
     The buffer of a geometry is defined as the Minkowski sum (or difference,
     for negative distance) of the geometry with a circle with radius equal


### PR DESCRIPTION
See https://github.com/shapely/shapely/issues/1276#issuecomment-1295427157 for context