### PR TITLE
MAINT: Remove descartes from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 cython==0.29.21
-descartes==1.0.1
 matplotlib
 numpy>=1.4.1
 pytest


### PR DESCRIPTION
It is no longer needed since the `shapely.plotting` module was added in cbf28cc.

Fixes #1145.