### PR TITLE
CI: ensure doctests are running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
             geos: 3.10.3
             numpy: 1.21.3
           # 2022
-          - python: "3.11-dev" # switch to "3.11" when released (PEP 664)
+          - python: "3.11"
             geos: 3.11.0
             numpy: 1.23.3
             matplotlib: true
@@ -169,12 +169,12 @@ jobs:
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' }}
         run: |
           python -m pytest --doctest-modules docs/manual.rst
 
       - name: Run doctests (part 2)
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.10' && matrix.geos == '3.11.0'}}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && matrix.geos == '3.11.0'}}
         run: |
           pytest --doctest-modules shapely --ignore=shapely/tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
             geos: 3.11.0
             numpy: 1.23.3
             matplotlib: true
+            doctest: true
             # TODO(shapely-2.0) temporary allow warnings
             # extra_pytest_args: "-W error"  # error on warnings
           # dev
@@ -169,12 +170,12 @@ jobs:
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.doctest }}
         run: |
           python -m pytest --doctest-modules docs/manual.rst
 
       - name: Run doctests (part 2)
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && matrix.geos == '3.11.0'}}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.doctest }}
         run: |
           pytest --doctest-modules shapely --ignore=shapely/tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
             python: 3.9
             geos: 3.10.3
             numpy: 1.19.5
-          # pypy (don't use ubuntu-latest to not overwrite existing geos 3.11.0 build)
+          # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-20.04
             python: "pypy3.8"
             geos: 3.11.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,8 @@ jobs:
             python: 3.9
             geos: 3.10.3
             numpy: 1.19.5
-          # pypy
-          - os: ubuntu-latest
+          # pypy (don't use ubuntu-latest to not overwrite existing geos 3.11.0 build)
+          - os: ubuntu-20.04
             python: "pypy3.8"
             geos: 3.11.0
             numpy: 1.23.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           echo "${{ env.GEOS_INSTALL }}/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Set environment variables (OSX)
         run: |


### PR DESCRIPTION
Because we limit the doctests to a single python/GEOS version combo, we need to remember updating the check if the python or GEOS version gets updated. 