### PR TITLE
Document Point(..) constructor change no longer allowing coordinate sequence of len > 1

### DIFF
--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -158,6 +158,9 @@ Some additional backwards incompatible API changes were included in Shapely
 * A ``GeometryCollection`` that consists of all empty sub-geometries now
   returns those empty geometries from its ``.geoms`` attribute instead of
   returning an empty list (#1420).
+* The ``Point(..)`` constructor no longer accepts a sequence of coordinates
+  consisting of more than one coordinate pair (previously, subsequent
+  coordinates would be ignored) (#1600).
 * The unused ``shape_factory()`` method and ``HeterogeneousGeometrySequence``
   class are removed (#1421).
 * The undocumented ``__geom__`` attribute has been removed. If necessary

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -160,7 +160,7 @@ Some additional backwards incompatible API changes were included in Shapely
   returning an empty list (#1420).
 * The ``Point(..)`` constructor no longer accepts a sequence of coordinates
   consisting of more than one coordinate pair (previously, subsequent
-  coordinates would be ignored) (#1600).
+  coordinates were ignored) (#1600).
 * The unused ``shape_factory()`` method and ``HeterogeneousGeometrySequence``
   class are removed (#1421).
 * The undocumented ``__geom__`` attribute has been removed. If necessary

--- a/shapely/tests/geometry/test_point.py
+++ b/shapely/tests/geometry/test_point.py
@@ -88,6 +88,10 @@ def test_from_invalid():
     with pytest.raises(TypeError, match="takes at most 3 arguments"):
         Point(1, 2, 3, 4)
 
+    # this worked in shapely 1.x, just ignoring the other coords
+    with pytest.raises(ValueError, match="Invalid values passed"):
+        Point([(2, 3), (11, 4)])
+
 
 class TestPoint:
     def test_point(self):


### PR DESCRIPTION
See https://github.com/shapely/shapely/pull/1590#issuecomment-1295823911 for context

With shapely 1.8:

```
In [1]: from shapely.geometry import Point

In [2]: Point([(1, 2), (3, 4), (5, 6)]).wkt
Out[2]: 'POINT (1 2)'
```

One 2.x, this raises an error instead of ignoring the other coordinates. This PR adds an explicit test for this and a note in the release notes.