### PR TITLE
DEP: change `almost_equals()` to be removed from version 2.0 to 2.1

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1097,10 +1097,9 @@ differently.
   >>> b == c
   False
 
-.. method:: object.almost_equals(other[, decimal=6])
+.. method:: object.equals_exact(other, tolerance)
 
-  Returns ``True`` if the object is approximately equal to the `other` at all
-  points to specified `decimal` place precision.
+  Returns ``True`` if the object is within a specified `tolerance`.
 
 .. method:: object.contains(other)
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -757,8 +757,9 @@ class BaseGeometry(shapely.Geometry):
         """True if geometries are equal at all coordinates to a
         specified decimal place.
 
-        .. deprecated:: 1.8.0 The 'almost_equals()' method is deprecated
-            and will be removed in Shapely 2.0 because the name is
+        .. deprecated:: 1.8.0
+            The 'almost_equals()' method is deprecated
+            and will be removed in Shapely 2.1 because the name is
             confusing. The 'equals_exact()' method should be used
             instead.
 
@@ -785,7 +786,8 @@ class BaseGeometry(shapely.Geometry):
 
         """
         warn(
-            "The 'almost_equals()' method is deprecated and will be removed in Shapely 2.0",
+            "The 'almost_equals()' method is deprecated and will be "
+            "removed in Shapely 2.1; use 'equals_exact()' instead",
             ShapelyDeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,33 +1,32 @@
-from . import unittest
-
 import pytest
 
-from shapely import geometry
+from shapely import Point
 from shapely.errors import ShapelyDeprecationWarning
 
 
-class PointEqualityTestCase(unittest.TestCase):
+def test_equals_exact():
+    p1 = Point(1.0, 1.0)
+    p2 = Point(2.0, 2.0)
+    assert not p1.equals(p2)
+    assert not p1.equals_exact(p2, 0.001)
+    assert p1.equals_exact(p2, 1.42)
 
-    def test_equals_exact(self):
-        p1 = geometry.Point(1.0, 1.0)
-        p2 = geometry.Point(2.0, 2.0)
-        assert not p1.equals(p2)
-        assert not p1.equals_exact(p2, 0.001)
 
-    def test_almost_equals_default(self):
-        p1 = geometry.Point(1.0, 1.0)
-        p2 = geometry.Point(1.0+1e-7, 1.0+1e-7)  # almost equal to 6 places
-        p3 = geometry.Point(1.0+1e-6, 1.0+1e-6)  # not almost equal
-        with pytest.warns(ShapelyDeprecationWarning):
-            assert p1.almost_equals(p2)
-        with pytest.warns(ShapelyDeprecationWarning):
-            assert not p1.almost_equals(p3)
+def test_almost_equals_default():
+    p1 = Point(1.0, 1.0)
+    p2 = Point(1.0 + 1e-7, 1.0 + 1e-7)  # almost equal to 6 places
+    p3 = Point(1.0 + 1e-6, 1.0 + 1e-6)  # not almost equal
+    with pytest.warns(ShapelyDeprecationWarning):
+        assert p1.almost_equals(p2)
+    with pytest.warns(ShapelyDeprecationWarning):
+        assert not p1.almost_equals(p3)
 
-    def test_almost_equals(self):
-        p1 = geometry.Point(1.0, 1.0)
-        p2 = geometry.Point(1.1, 1.1)
-        assert not p1.equals(p2)
-        with pytest.warns(ShapelyDeprecationWarning):
-            assert p1.almost_equals(p2, 0)
-        with pytest.warns(ShapelyDeprecationWarning):
-            assert not p1.almost_equals(p2, 1)
+
+def test_almost_equals():
+    p1 = Point(1.0, 1.0)
+    p2 = Point(1.1, 1.1)
+    assert not p1.equals(p2)
+    with pytest.warns(ShapelyDeprecationWarning):
+        assert p1.almost_equals(p2, 0)
+    with pytest.warns(ShapelyDeprecationWarning):
+        assert not p1.almost_equals(p2, 1)


### PR DESCRIPTION
Xref to #889 and 26cafd027ab26a6b728ce8a3d26f0b9c8b114bf1

This function was deprecated for 1.8 and planned to be removed for 2.0. But willing to hold off for another release if there is any compelling reason.

---

On a related topic, these signatures have different `tolerance` defaults:

- [`shapely.geometry.base.BaseGeometry.equals_exact(self, other, tolerance)`](https://github.com/shapely/shapely/blob/bc7fa916fc680b43cf58fc206b039e2563ef7a7f/shapely/geometry/base.py#L703)
- [`shapely.predicates.equals_exact(a, b, tolerance=0.0, **kwargs)`](https://github.com/shapely/shapely/blob/bc7fa916fc680b43cf58fc206b039e2563ef7a7f/shapely/predicates.py#L944)

It was noted in https://github.com/shapely/shapely/issues/889#issuecomment-609093066 that tolerance should have a default of 0. Should it?