### PR TITLE
MAINT: remove requirements-dev.txt; expand optional dependencies in pyproject.toml

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,8 +79,7 @@ using ``venv``:
 
     $ python3 -m venv .
     $ source bin/activate
-    (env) $ pip install -r requirements-dev.txt
-    (env) $ pip install -e .
+    (env) $ pip install -e .[test]
 
 Or using ``conda``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
-docs = ["sphinx", "numpydoc"]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+docs = [
+    "numpydoc==1.1.*",
+    "matplotlib",
+    "sphinx",
+    "sphinx-book-theme",
+    "sphinx-remove-toctrees",
+]
 
 [project.urls]
 Documentation = "https://shapely.readthedocs.io/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-cython==0.29.21
-matplotlib
-numpy>=1.4.1
-pytest
-pytest-cov
-setuptools
-wheel


### PR DESCRIPTION
This PR has a few related aims:

- Remove requirements-dev.txt
- Expand the optional dependencies (in pyproject.toml) for "test" and "docs"