### PR TITLE
MAINT: Add Python 3.11 classifier and upgrade to GEOS 3.11.1; other CI upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.11.0"
+      GEOS_VERSION: "3.11.1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,13 +39,13 @@ jobs:
           # 2022
           - python: "3.11"
             geos: 3.11.0
-            numpy: 1.23.3
+            numpy: 1.23.4
             matplotlib: true
             doctest: true
             # TODO(shapely-2.0) temporary allow warnings
             # extra_pytest_args: "-W error"  # error on warnings
           # dev
-          - python: "3.10"
+          - python: "3.11"
             geos: main
             extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
@@ -63,7 +63,7 @@ jobs:
           - os: ubuntu-20.04
             python: "pypy3.8"
             geos: 3.11.0
-            numpy: 1.23.3
+            numpy: 1.23.4
 
     env:
       GEOS_VERSION: ${{ matrix.geos }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, 3.11.0, main]
+        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, 3.11.1, main]
         include:
           # 2017
           - python: 3.7  # 3.6 is dropped
@@ -38,7 +38,7 @@ jobs:
             numpy: 1.21.3
           # 2022
           - python: "3.11"
-            geos: 3.11.0
+            geos: 3.11.1
             numpy: 1.23.4
             matplotlib: true
             doctest: true
@@ -62,7 +62,7 @@ jobs:
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-20.04
             python: "pypy3.8"
-            geos: 3.11.0
+            geos: 3.11.1
             numpy: 1.23.4
 
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ if: (branch = main OR tag IS present) AND (type = push)
 
 env:
   global:
-  - GEOS_VERSION=3.11.0
+  - GEOS_VERSION=3.11.1
 
 cache:
   directories:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.7"

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -36,9 +36,10 @@ def setUpModule():
 
 
 def tearDownModule():
-    if sys.platform == 'win32':
+    if sys.platform == 'win32' or sys.version_info[0:2] >= (3, 11):
         locale.setlocale(locale.LC_ALL, "")
     else:
+        # Deprecated since version 3.11, will be removed in version 3.13
         locale.resetlocale()
 
 


### PR DESCRIPTION
Add a Python 3.11 classifier.

This follows on from #1596 to test Python 3.11 for the "dev" builds (although presumably 3.12-dev could be considered), and also bump NumPy to 1.23.4.