### PR TITLE
Add svg path ElementTree.Element export to BaseGeometry 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 cython==0.29.21
 matplotlib
 numpy>=1.4.1
+pre-commit
 pytest
 pytest-cov
 setuptools

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -7,6 +7,7 @@ different z values may intersect or be equal.
 """
 import re
 from warnings import warn
+from xml.etree import ElementTree as ET
 
 import numpy as np
 
@@ -26,6 +27,11 @@ GEOMETRY_TYPES = [
     "MultiPolygon",
     "GeometryCollection",
 ]
+
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+SVG_XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+ET.register_namespace("", SVG_NAMESPACE)
+ET.register_namespace("xlink", SVG_XLINK_NAMESPACE)
 
 
 def geom_factory(g, parent=None):
@@ -249,15 +255,40 @@ class BaseGeometry(shapely.Geometry):
         """Raises NotImplementedError"""
         raise NotImplementedError
 
+    def svg_path_element(self, yflip="transform", **kwargs):
+        """Returns SVG XML Element for the geometry.
+
+        The y-axis of SVG is flipped compared to a Shapely geometry: SVG is
+        y-down while Shapely is y-up. The 'yflip' parameter specifies how to
+        handle the y-axis flip. If yflip is 'transform', then the y-axis flip
+        is encoded in a transform matrix in the SVG. If yflip is None, then
+        the y-axis flip is not handled (aka no transform matrix is included).
+
+        Parameters
+        ==========
+        yflip : string
+            How to address the y-axis flip of SVG compared to Shapely
+            geometry. Options are 'transform' (default) and None.
+        kwargs: Keyword arguments to pass on to the class 'svg' method. See
+            svg() for the given class for valid arguments.
+        """
+        # manage y-flip: svg is y-down, shapely is y-up
+        if self.is_empty or not yflip:
+            path = ET.fromstring(self.svg(**kwargs))
+        elif yflip == "transform":
+            path = ET.fromstring(self.svg(**kwargs))
+            _, ymin, _, ymax = self.bounds
+            path.set("transform", f"matrix(1,0,0,-1,0,{ymax + ymin})")
+        else:
+            raise ValueError("yflip parameter must be 'transform', 'scale', or None.")
+        return path
+
     def _repr_svg_(self):
         """SVG representation for iPython notebook"""
-        svg_top = (
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-        )
-        if self.is_empty:
-            return svg_top + "/>"
-        else:
+        doc = ET.Element("svg", xmlns=SVG_NAMESPACE)
+        doc.set("xmlns:xlink", SVG_XLINK_NAMESPACE)
+
+        if not self.is_empty:
             # Establish SVG canvas that will fit all the data + small space
             xmin, ymin, xmax, ymax = self.bounds
             if xmin == xmax and ymin == ymax:
@@ -280,13 +311,18 @@ class BaseGeometry(shapely.Geometry):
                 scale_factor = max([dx, dy]) / max([width, height])
             except ZeroDivisionError:
                 scale_factor = 1.0
-            view_box = f"{xmin} {ymin} {dx} {dy}"
-            transform = f"matrix(1,0,0,-1,0,{ymax + ymin})"
-            return svg_top + (
-                'width="{1}" height="{2}" viewBox="{0}" '
-                'preserveAspectRatio="xMinYMin meet">'
-                '<g transform="{3}">{4}</g></svg>'
-            ).format(view_box, width, height, transform, self.svg(scale_factor))
+
+            doc = ET.Element("svg", xmlns=SVG_NAMESPACE)
+            doc.set("xmlns:xlink", SVG_XLINK_NAMESPACE)
+            doc.set("width", f"{width}")
+            doc.set("height", f"{height}")
+            doc.set("viewBox", f"{xmin} {ymin} {xmax - xmin} {ymax - ymin}")
+            doc.set("preserveAspectRatio", "xMinYMin meet")
+            doc.append(
+                self.svg_path_element(yflip="transform", scale_factor=scale_factor)
+            )
+
+        return ET.tostring(doc, encoding="unicode")
 
     @property
     def geom_type(self):

--- a/tests/test__repr_svg_.py
+++ b/tests/test__repr_svg_.py
@@ -1,0 +1,135 @@
+from xml.dom.minidom import parseString as parse_xml_string
+from xml.etree import ElementTree as ET
+
+from . import unittest
+from shapely.geometry import Point, MultiPoint, LineString, MultiLineString,\
+    Polygon, MultiPolygon
+from shapely.geometry.collection import GeometryCollection
+
+
+class _Repr_Svg_TestCase(unittest.TestCase):
+
+    def assert_repr_svg_(self, geom, expected):
+        """Helper function to check SVG representation for iPython notebook"""
+        # self.assertEqual(geom._repr_svg_(), expected)
+        # get rid of order and spacing affecting comparison
+        print(geom._repr_svg_())
+        print(expected)
+        self.assertEqual(ET.tostring(ET.fromstring(geom._repr_svg_())),
+                         ET.tostring(ET.fromstring(expected)))
+
+    def test_empty(self):
+        self.assert_repr_svg_(
+            Point(), 
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" />')
+
+    def test_point(self):
+        self.assert_repr_svg_(
+            Point(6, 7),
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="5.0 6.0 2.0 2.0" preserveAspectRatio="xMinYMin meet">'
+            '<circle cx="6.0" cy="7.0" r="0.06" stroke="#555555" '
+            'stroke-width="0.02" fill="#66cc99" opacity="0.6" '
+            'transform="matrix(1,0,0,-1,0,14.0)"/>'
+            '</svg>')
+
+    def test_multipoint(self):
+        self.assert_repr_svg_(
+            MultiPoint([(6, 7), (3, 4)]),
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="2.88 3.88 3.24 3.24" preserveAspectRatio="xMinYMin meet">'
+            '<g transform="matrix(1,0,0,-1,0,11.0)">'
+            '<circle cx="6.0" cy="7.0" r="0.09720000000000001" '
+            'stroke="#555555" stroke-width="0.032400000000000005" '
+            'fill="#66cc99" opacity="0.6" /><circle cx="3.0" cy="4.0" '
+            'r="0.09720000000000001" stroke="#555555" '
+            'stroke-width="0.032400000000000005" '
+            'fill="#66cc99" opacity="0.6" />'
+            '</g></svg>')
+
+    def test_linestring(self):
+        self.assert_repr_svg_(
+            LineString([(5, 8), (496, -6), (530, 20)]), 
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="300" height="100.0" '
+            'viewBox="-16.0 -27.0 567.0 68.0" '
+            'preserveAspectRatio="xMinYMin meet">'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="3.78" '
+            'points="5.0,8.0 496.0,-6.0 530.0,20.0" opacity="0.8" '
+            'transform="matrix(1,0,0,-1,0,14.0)"/>'
+            '</svg>') 
+
+    def test_multilinestring(self):
+        self.assert_repr_svg_(
+            MultiLineString([[(6, 7), (3, 4)], [(2, 8), (9, 1)]]), 
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="1.72 0.72 7.56 7.56" preserveAspectRatio="xMinYMin meet">'
+            '<g transform="matrix(1,0,0,-1,0,9.0)">'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="0.1512" '
+            'points="6.0,7.0 3.0,4.0" opacity="0.8" />'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="0.1512" '
+            'points="2.0,8.0 9.0,1.0" opacity="0.8" />'
+            '</g></svg>')
+
+
+    def test_polygon(self):
+        self.assert_repr_svg_(
+            Polygon([(35, 10), (45, 45), (15, 40), (10, 20), (35, 10)],
+                    [[(20, 30), (35, 35), (30, 20), (20, 30)]]),
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="8.6 8.6 37.8 37.8" preserveAspectRatio="xMinYMin meet">'
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="0.7559999999999999" opacity="0.6" '
+            'd="M 35.0,10.0 L 45.0,45.0 L 15.0,40.0 L 10.0,20.0 L 35.0,10.0 z '
+            'M 20.0,30.0 L 35.0,35.0 L 30.0,20.0 L 20.0,30.0 z" '
+            'transform="matrix(1,0,0,-1,0,55.0)"/>'
+            '</svg>')
+
+    def test_multipolygon(self):
+        self.assert_repr_svg_(
+            MultiPolygon([
+                Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+                Polygon([(20, 35), (10, 30), (10, 10), (30, 5), (45, 20),
+                         (20, 35)],
+                        [[(30, 20), (20, 15), (20, 25), (30, 20)]])
+                ]), 
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="8.4 3.4 38.2 43.2" preserveAspectRatio="xMinYMin meet">'
+            '<g transform="matrix(1,0,0,-1,0,50.0)">'
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="0.8640000000000001" opacity="0.6" '
+            'd="M 40.0,40.0 L 20.0,45.0 L 45.0,30.0 L 40.0,40.0 z" />'
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="0.8640000000000001" opacity="0.6" '
+            'd="M 20.0,35.0 L 10.0,30.0 L 10.0,10.0 L 30.0,5.0 L 45.0,20.0 L '
+            '20.0,35.0 z M 30.0,20.0 L 20.0,15.0 L 20.0,25.0 L 30.0,20.0 z" />'
+            '</g></svg>')
+
+    def test_collection(self):
+        self.assert_repr_svg_(
+            GeometryCollection(
+                [Point(7, 3), LineString([(4, 2), (8, 4)])]),
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'width="100.0" height="100.0" '
+            'viewBox="3.84 1.84 4.32 2.3200000000000003" '
+            'preserveAspectRatio="xMinYMin meet">'
+            '<g transform="matrix(1,0,0,-1,0,6.0)">'
+            '<circle cx="7.0" cy="3.0" r="0.1296" stroke="#555555" '
+            'stroke-width="0.0432" fill="#66cc99" opacity="0.6" />'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="0.0864" '
+            'points="4.0,2.0 8.0,4.0" opacity="0.8" />'
+            '</g></svg>')
+

--- a/tests/test__repr_svg_.py
+++ b/tests/test__repr_svg_.py
@@ -11,125 +11,41 @@ class _Repr_Svg_TestCase(unittest.TestCase):
 
     def assert_repr_svg_(self, geom, expected):
         """Helper function to check SVG representation for iPython notebook"""
-        # self.assertEqual(geom._repr_svg_(), expected)
         # get rid of order and spacing affecting comparison
-        print(geom._repr_svg_())
-        print(expected)
+        # if we compared these as ET.Element, we would miss the xmlns and
+        # xmlns:xlink properties
         self.assertEqual(ET.tostring(ET.fromstring(geom._repr_svg_())),
                          ET.tostring(ET.fromstring(expected)))
 
+    def assertCloseStr(self, test_str, expected, ndigits=5):
+        self.assertEqual(round(float(test_str), ndigits), expected)
+
+    def assertCloseStrList(self, test_str, expected, ndigits=5):
+        tests_float = test_str.split()
+        for t, e in zip(tests_float, expected):
+            self.assertCloseStr(t, e, ndigits=ndigits)
+
+
     def test_empty(self):
-        self.assert_repr_svg_(
-            Point(), 
+        self.assertEqual(
+            Point()._repr_svg_(),
             '<svg xmlns="http://www.w3.org/2000/svg" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" />')
 
     def test_point(self):
-        self.assert_repr_svg_(
-            Point(6, 7),
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="5.0 6.0 2.0 2.0" preserveAspectRatio="xMinYMin meet">'
-            '<circle cx="6.0" cy="7.0" r="0.06" stroke="#555555" '
-            'stroke-width="0.02" fill="#66cc99" opacity="0.6" '
-            'transform="matrix(1,0,0,-1,0,14.0)"/>'
-            '</svg>')
+        test_ET = ET.fromstring(Point(6, 7)._repr_svg_())
+        self.assertCloseStr(test_ET.attrib['width'], 100)
+        self.assertCloseStr(test_ET.attrib['height'], 100)
+        self.assertCloseStrList(test_ET.attrib['viewBox'], [5, 6, 2, 2])
 
-    def test_multipoint(self):
-        self.assert_repr_svg_(
-            MultiPoint([(6, 7), (3, 4)]),
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="2.88 3.88 3.24 3.24" preserveAspectRatio="xMinYMin meet">'
-            '<g transform="matrix(1,0,0,-1,0,11.0)">'
-            '<circle cx="6.0" cy="7.0" r="0.09720000000000001" '
-            'stroke="#555555" stroke-width="0.032400000000000005" '
-            'fill="#66cc99" opacity="0.6" /><circle cx="3.0" cy="4.0" '
-            'r="0.09720000000000001" stroke="#555555" '
-            'stroke-width="0.032400000000000005" '
-            'fill="#66cc99" opacity="0.6" />'
-            '</g></svg>')
+        self.assertEqual(test_ET[0].attrib['transform'], 'matrix(1,0,0,-1,0,14.0)')
 
-    def test_linestring(self):
-        self.assert_repr_svg_(
-            LineString([(5, 8), (496, -6), (530, 20)]), 
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="300" height="100.0" '
-            'viewBox="-16.0 -27.0 567.0 68.0" '
-            'preserveAspectRatio="xMinYMin meet">'
-            '<polyline fill="none" stroke="#66cc99" stroke-width="3.78" '
-            'points="5.0,8.0 496.0,-6.0 530.0,20.0" opacity="0.8" '
-            'transform="matrix(1,0,0,-1,0,14.0)"/>'
-            '</svg>') 
+    def test_non_point(self):
+        """The logic for any non-point feature is the same, so this covers
+        polygons, multipolygons, etc"""
+        test_ET = ET.fromstring(MultiPoint([(6, 7), (3, 4)])._repr_svg_())
+        self.assertCloseStr(test_ET.attrib['width'], 100)
+        self.assertCloseStr(test_ET.attrib['height'], 100)
+        self.assertCloseStrList(test_ET.attrib['viewBox'], [2.88, 3.88, 3.24, 3.24])
 
-    def test_multilinestring(self):
-        self.assert_repr_svg_(
-            MultiLineString([[(6, 7), (3, 4)], [(2, 8), (9, 1)]]), 
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="1.72 0.72 7.56 7.56" preserveAspectRatio="xMinYMin meet">'
-            '<g transform="matrix(1,0,0,-1,0,9.0)">'
-            '<polyline fill="none" stroke="#66cc99" stroke-width="0.1512" '
-            'points="6.0,7.0 3.0,4.0" opacity="0.8" />'
-            '<polyline fill="none" stroke="#66cc99" stroke-width="0.1512" '
-            'points="2.0,8.0 9.0,1.0" opacity="0.8" />'
-            '</g></svg>')
-
-
-    def test_polygon(self):
-        self.assert_repr_svg_(
-            Polygon([(35, 10), (45, 45), (15, 40), (10, 20), (35, 10)],
-                    [[(20, 30), (35, 35), (30, 20), (20, 30)]]),
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="8.6 8.6 37.8 37.8" preserveAspectRatio="xMinYMin meet">'
-            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
-            'stroke-width="0.7559999999999999" opacity="0.6" '
-            'd="M 35.0,10.0 L 45.0,45.0 L 15.0,40.0 L 10.0,20.0 L 35.0,10.0 z '
-            'M 20.0,30.0 L 35.0,35.0 L 30.0,20.0 L 20.0,30.0 z" '
-            'transform="matrix(1,0,0,-1,0,55.0)"/>'
-            '</svg>')
-
-    def test_multipolygon(self):
-        self.assert_repr_svg_(
-            MultiPolygon([
-                Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
-                Polygon([(20, 35), (10, 30), (10, 10), (30, 5), (45, 20),
-                         (20, 35)],
-                        [[(30, 20), (20, 15), (20, 25), (30, 20)]])
-                ]), 
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="8.4 3.4 38.2 43.2" preserveAspectRatio="xMinYMin meet">'
-            '<g transform="matrix(1,0,0,-1,0,50.0)">'
-            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
-            'stroke-width="0.8640000000000001" opacity="0.6" '
-            'd="M 40.0,40.0 L 20.0,45.0 L 45.0,30.0 L 40.0,40.0 z" />'
-            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
-            'stroke-width="0.8640000000000001" opacity="0.6" '
-            'd="M 20.0,35.0 L 10.0,30.0 L 10.0,10.0 L 30.0,5.0 L 45.0,20.0 L '
-            '20.0,35.0 z M 30.0,20.0 L 20.0,15.0 L 20.0,25.0 L 30.0,20.0 z" />'
-            '</g></svg>')
-
-    def test_collection(self):
-        self.assert_repr_svg_(
-            GeometryCollection(
-                [Point(7, 3), LineString([(4, 2), (8, 4)])]),
-            '<svg xmlns="http://www.w3.org/2000/svg" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            'width="100.0" height="100.0" '
-            'viewBox="3.84 1.84 4.32 2.3200000000000003" '
-            'preserveAspectRatio="xMinYMin meet">'
-            '<g transform="matrix(1,0,0,-1,0,6.0)">'
-            '<circle cx="7.0" cy="3.0" r="0.1296" stroke="#555555" '
-            'stroke-width="0.0432" fill="#66cc99" opacity="0.6" />'
-            '<polyline fill="none" stroke="#66cc99" stroke-width="0.0864" '
-            'points="4.0,2.0 8.0,4.0" opacity="0.8" />'
-            '</g></svg>')
-
+        self.assertEqual(test_ET[0].attrib['transform'], 'matrix(1,0,0,-1,0,11.0)')

--- a/tests/test_svg_path_element.py
+++ b/tests/test_svg_path_element.py
@@ -1,0 +1,79 @@
+from xml.etree import ElementTree as ET
+
+from shapely.geometry import Point, Polygon
+
+from . import unittest
+from unittest.mock import Mock
+
+
+class SVGPathElementTestCase(unittest.TestCase):
+    def setUp(self):
+        # triangle that is lower-left half of a unit square
+        # with lower-left corner offset from origin by +1 in x and y dir.
+        self.coords = ((1,1),(1,2),(2,1),(1,1))
+
+    def assertElementsEqual(self, test, expected):
+        """Test equivalence of two Element Trees"""
+        # Ref: https://stackoverflow.com/a/24349916
+        self.assertEqual(test.tag, expected.tag)
+        self.assertEqual(test.text, expected.text)
+        self.assertEqual(test.tail, expected.tail)
+        self.assertEqual(test.attrib, expected.attrib)
+        self.assertEqual(len(test), len(expected))
+
+        # run recursively for all children
+        for c1, c2 in zip(test, expected):
+            self.assertElementsEqual(c1, c2) 
+
+    def test_kwargs(self):
+        """Ensure that kwargs are passed on to svg method"""
+        mocked_svg = Mock()
+        mocked_svg.return_value = (
+            '<path fill="#000000" stroke-width="200.0" opacity="0.0" '
+            'd="M 1.0,1.0 L 1.0,2.0 L 2.0,1.0 L 1.0,1.0 z" />'
+            )
+
+        with unittest.mock.patch.object(Polygon, 'svg', mocked_svg):
+            polygon = Polygon(self.coords)
+
+            test = polygon.svg_path_element(
+                yflip=None, scale_factor=100, fill_color="#000000", opacity=0)
+
+            mocked_svg.assert_called_once_with(
+                scale_factor=100, fill_color="#000000", opacity=0)
+
+        expected = ET.Element(
+                'path',
+                {
+                    "fill": "#000000",
+                    "stroke-width": "200.0",
+                    "opacity": "0.0",
+                    "d": "M 1.0,1.0 L 1.0,2.0 L 2.0,1.0 L 1.0,1.0 z"
+                })
+
+    
+        self.assertElementsEqual(test, expected)
+
+    def test_yflip_invalid(self):
+        with self.assertRaises(ValueError):
+            Polygon(self.coords).svg_path_element(yflip='invalid')
+
+
+    def test_yflip_transform(self):
+        polygon = Polygon(self.coords)
+
+        test = polygon.svg_path_element(yflip='transform')
+
+        # test that actual path is not changed
+        original_d = "M 1.0,1.0 L 1.0,2.0 L 2.0,1.0 L 1.0,1.0 z"
+        assert test.attrib['d'] == original_d
+
+        # test that transform entry is added and is accurate
+        # ref: https://drafts.csswg.org/css-transforms/#transformation-matrix-computation
+        # matrix format: matrix(1,0,tx,-1,0,3.0)
+        expected_transform = 'matrix(1,0,0,-1,0,3.0)'
+        assert test.attrib['transform'] == expected_transform
+
+        # test that the geometry was not changed by the operation 
+        assert polygon == Polygon(self.coords)
+


### PR DESCRIPTION
### Changes

- add `BaseGeometry.svg_path_element(yflip='transform', **kwargs)`
- add pre-commit to requirements-dev.txt
- add tests for `_repr_svg_` and `svg_path_element`

### Use Case
I have been using shapely for generating paths for laser cutting. The input for laser cutting is SVG. The current options for SVG export from BaseGeometry are the subclass implementation of `svg()` and `_repr_svg_()`. The subclass implementation of `svg()` outputs the svg as a string that includes baked-in styling and does not account for the y-axis flip between shapeley (y-up) and svg (y-down). `_repr_svg_()` is a private method so it doesn't feel great to use it and it still returns the output as a string with styling baked in.

### Proposed Solution
This PR adds a third option for svg export: an ElementTree Element with the option of y-axis flip (defaults to implementing the flip). The signature is:
```python
svg_path_element(yflip='transform', **kwargs)
```
It is a simple wrapper around `svg()` with logic to handle y-flip and logic to convert to an Element. The `kwargs` are passed through to `svg()`  and `yflip` is specified as None or "transform". The reason `yflip` is None and "transform" is because originally I had logic for a third option - "scale". This would use shapely's `scale` function to actually flip the coordinates. However, on revisit I couldn't find clarity on where this approach would be needed. It's a judgement call whether we want to keep this flexible to allow for more options in the future without changing user interface or if we want to simplify and change yflip to a `bool` - I'm happy to go either way.

### Usage
```python
from xml.etree import ElementTree as ET

from shapely import Polygon

SVG_NAMESPACE = "http://www.w3.org/2000/svg"
SVG_XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
ET.register_namespace("", SVG_NAMESPACE)
ET.register_namespace("xlink", SVG_XLINK_NAMESPACE)

# triangle that is lower-left half of a unit square
# with lower-left corner offset from origin by +1 in x and y dir.
coords = ((1,1),(1,2),(2,1),(1,1))
polygon = Polygon(coords)

# create SVG
doc = ET.Element("svg", xmlns=SVG_NAMESPACE)
doc.set("xmlns:xlink", SVG_XLINK_NAMESPACE)
doc.set("preserveAspectRatio", "xMinYMin meet")

xmin, ymin, xmax, ymax = polygon.bounds
doc.set("width", "100.0")
doc.set("height", "100.0")
doc.set("viewBox", "1,1,1,1")
scale_factor = 0.010 # change the stroke width
doc.append(
    polygon.svg_path_element(yflip='transform', scale_factor=scale_factor)
)

# SVG string for piping into svg file
print(ET.tostring(doc, encoding='unicode'))
```

### Limitations
- Because this is a wrapper around `svg()`, the styling is still baked in but at least it is much easier to traverse the tree to change it at will.
- The output of svg_path_element only describes the svg path, not the entire svg document. It is left to the user to figure out how to make the document and it's not trivial (see usage). But the argument can be made that creating svg documents is outside of the scope of shapely. If not, we can consider a function I included in an earlier PR (#1295, superseded by this one):

```python
def svg_doc_element(elements, width, height, xmin, ymin, xmax, ymax):
    doc = ET.Element("svg", xmlns=SVG_NAMESPACE)
    doc.set("xmlns:xlink", SVG_XLINK_NAMESPACE)
    doc.set("width", f"{width}")
    doc.set("height", f"{height}")
    doc.set("viewBox", f"{xmin} {ymin} {xmax - xmin} {ymax - ymin}")
    doc.set("preserveAspectRatio", "xMinYMin meet")

    for e in elements:
        doc.append(e)
    return doc
```

The primary benefit of this function being that it handles the xml headers

### Alternatives
The truth is that someone could work around not having `svg_path_element` with e.g.:
```python
point = Point(1,1)
path = ET.fromstring(point.svg())
_, ymin, _, ymax = point.bounds
path.set("transform", f"matrix(1,0,0,-1,0,{ymax + ymin})")
```
So this method is not entirely necessary.

However, including it does allow simplification of the `_repr_svg_()` function, which now focuses on constructing the SVG document instead of actually performing the y-axis transformation.