### PR TITLE
CI: flake8 has migrated to GH – update .pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
 -   repo: https://github.com/pycqa/isort


### PR DESCRIPTION
`flake8` has migrated from GitLab to GitHub, causing the `pre-commit` hook & [linting to fail](https://github.com/jGaboardi/shapely/actions/runs/3479810906/jobs/5818811980#step:4:52). This PR updates `.pre-commit-config.yml`.

xref geopandas/geopandas#2651 (piggybacking @rraymondgh's PR)