### PR TITLE
CI/RLS: set up CircleCI to build Linux aarch64 wheels (instead of Travis CI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.5.0
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build-and-test: # This is the name of the job, feel free to change it to better match what you're trying to do!
+    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
+    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
+    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
+    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
+    # Change the version below to your required version of python
+    docker:
+      - image: cimg/python:3.10.2
+    # Checkout the code as the first step. This is a dedicated CircleCI step.
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+      - run:
+          name: Run tests
+          # This assumes pytest is installed via the install-package step above
+          command: pytest
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,13 @@ jobs:
     # resource_class is what tells CircleCI to use an ARM worker for native arm builds
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium
+    environment:
+      CIBUILDWHEEL=1
+      CIBW_BUILD="cp*-manylinux_aarch64"
+      CIBW_ENVIRONMENT_PASS_LINUX="GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"
+      CIBW_BEFORE_ALL="./ci/install_geos.sh"
+      CIBW_TEST_REQUIRES="pytest"
+      CIBW_TEST_COMMAND="pytest --pyargs shapely.tests"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,24 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
-# See: https://circleci.com/docs/2.0/orb-intro/
-orbs:
-  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
-  # Orb commands and jobs help you with common scripting around a language/tool
-  # so you dont have to copy and paste it everywhere.
-  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
-  python: circleci/python@1.5.0
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build-and-test: # This is the name of the job, feel free to change it to better match what you're trying to do!
-    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
-    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
-    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
-    # Change the version below to your required version of python
-    docker:
-      - image: cimg/python:3.10.2
-    # Checkout the code as the first step. This is a dedicated CircleCI step.
-    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
-    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
-    # Then run your tests!
-    # CircleCI will report the results back to your VCS provider.
+  linux-aarch64-wheels:
+    working_directory: ~/linux-aarch64-wheels
+    machine:
+      image: ubuntu-2004:2022.04.1
+    # resource_class is what tells CircleCI to use an ARM worker for native arm builds
+    # https://circleci.com/product/features/resource-classes/
+    resource_class: arm.medium
     steps:
       - checkout
-      - python/install-packages:
-          pkg-manager: pip
-          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
-          # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
       - run:
-          name: Run tests
-          # This assumes pytest is installed via the install-package step above
-          command: pytest
+          name: Build the Linux aarch64 wheels.
+          command: |
+            python3 -m pip install --user cibuildwheel==2.11.2
+            python3 -m cibuildwheel --output-dir wheelhouse
+      - store_artifacts:
+          path: wheelhouse/
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  wheel-build:
     jobs:
-      - build-and-test
+      - linux-aarch64-wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           name: Build the Linux aarch64 wheels.
           command: |
             python3 -m pip install --user cibuildwheel==2.11.2
+            echo 'export GEOS_INSTALL=~/linux-aarch64-wheels/geosinstall/geos-"$GEOS_VERSION"' >> "$BASH_ENV"
+            echo 'export GEOS_CONFIG="$GEOS_INSTALL"/bin/geos-config' >> "$BASH_ENV"
+            echo 'export LD_LIBRARY_PATH="$GEOS_INSTALL"/lib' >> "$BASH_ENV"
+            source "$BASH_ENV"
             python3 -m cibuildwheel --output-dir wheelhouse
       - store_artifacts:
           path: wheelhouse/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,13 @@ jobs:
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium
     environment:
-      CIBUILDWHEEL=1
-      CIBW_BUILD="cp*-manylinux_aarch64"
-      CIBW_ENVIRONMENT_PASS_LINUX="GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"
-      CIBW_BEFORE_ALL="./ci/install_geos.sh"
-      CIBW_TEST_REQUIRES="pytest"
-      CIBW_TEST_COMMAND="pytest --pyargs shapely.tests"
+      GEOS_VERSION: 3.11.1
+      CIBUILDWHEEL: 1
+      CIBW_BUILD: "cp*-manylinux_aarch64"
+      CIBW_ENVIRONMENT_PASS_LINUX: "GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"
+      CIBW_BEFORE_ALL: "./ci/install_geos.sh"
+      CIBW_TEST_REQUIRES: "pytest"
+      CIBW_TEST_COMMAND: "pytest --pyargs shapely.tests"
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,49 +19,16 @@ jobs:
   - arch: ppc64le
   - arch: s390x
   - arch: arm64
-  - arch: arm64
-    dist: bionic  # docker pull gives TLS handshake timeouts on focal
-    services: docker
-    env:
-    - CIBUILDWHEEL=1
-    - CIBW_BUILD="cp*-manylinux_aarch64"
-    - CIBW_ENVIRONMENT_PASS_LINUX="GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"
-    - CIBW_BEFORE_ALL="./ci/install_geos.sh"
-    - CIBW_TEST_REQUIRES="pytest"
-    - CIBW_TEST_COMMAND="pytest --pyargs shapely.tests"
 
 install:
 - |
-  if [[ -z $CIBUILDWHEEL ]]; then
-    export GEOS_INSTALL=$HOME/geosinstall/geos-$GEOS_VERSION
-    ./ci/install_geos.sh
-    export PATH=$HOME/geosinstall/geos-$GEOS_VERSION/bin:$PATH
-    pip install .[test]
-  else
-    python3 -m pip install cibuildwheel==2.10.2
-  fi
+  export GEOS_INSTALL=$HOME/geosinstall/geos-$GEOS_VERSION
+  ./ci/install_geos.sh
+  export PATH=$HOME/geosinstall/geos-$GEOS_VERSION/bin:$PATH
+  pip install .[test]
 
 script:
 - |
-  if [[ -z $CIBUILDWHEEL ]]; then
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/geosinstall/geos-$GEOS_VERSION/lib
-    cd ..
-    pytest -v --pyargs shapely.tests
-  else
-    export GEOS_INSTALL=/host$HOME/geosinstall/geos-$GEOS_VERSION
-    export GEOS_CONFIG=$GEOS_INSTALL/bin/geos-config
-    export LD_LIBRARY_PATH=$GEOS_INSTALL/lib
-    python3 -m cibuildwheel --output-dir dist
-  fi
-
-deploy:
-  provider: pypi
-  username: "__token__"
-  password:
-    secure: "hU7JzC2F1GomDVpSOw9L3WHV/qwVWkc3NI6YCkkqUArMyYnJPSMBJck9ugeZIJ6OrIKORs50vIAdGrYQnjbhcntQzwc384mfnNO3FNPMnkBaxi4y0ofERy/ygqysM+tEOXINzJpFcYyylpknQdSnuzLSgYhdm+OXfob5Sqy/ABX+dXEuz1pb7UWvK0oYcLC1PYkfneFK4IcUIHYuMhia48y0jfxlez9gFZMAos3PKtn6m9CRN4xU370RgNjvy7Ey/hXwiTlm4rrX4KbEFj1q/SoaXvgK+mQqofM7n/4MakA8VFzKtz5a/L64f4iiJy0V2WgO/DiO2fLFwfEFmr+23WY8TTkMV/p7IAjZzeMY9ZmODymzXRKaJxIVt0MerLiwdul7nVCmXbJ/HkQwW2p32IUxzL37XaEk6ZN4lTb+5BhPA9e6jCZdgRY8sfJrrOzFxNNVm0wuf9nbve662PYhmgq9sETk4sdvqK8ODem/TSqMZzsq6FPRf2JCeFGZn+2TAKp+nwAFTByoJ/mMNsTc3TjtAzFhhtd2DUQriGadD+aNPZexA+yKCVSY/EGDYxpbnyS1h1fJv17kgyLxQfUi5FDBwrcGX0Ld01IyqcQbaw57DLDTQYYK4yvrfsYaQJDIQlySe8BkwgtJ5Dz9WP13MUZJ7VrISYMdTRU805eTvRE="
-  skip_cleanup: true
-  skip_existing: true
-  distributions: ""
-  on:
-    tags: true
-    condition: $CIBUILDWHEEL = 1
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/geosinstall/geos-$GEOS_VERSION/lib
+  cd ..
+  pytest -v --pyargs shapely.tests


### PR DESCRIPTION
I am having troubles with getting the deployment step in Travis working as we want it (only uploading the wheels it builds, https://github.com/shapely/shapely/pull/1576 didn't work). And in addition the credits on Travis are limited anyway (and will have to be requested again when they are finished). 
So CircleCI seems to be a good alternative to build linux aarch64 wheels (https://cibuildwheel.readthedocs.io/en/stable/#usage).

