### PR TITLE
CI/TST: fix tests for voronoi_diagram for latest GEOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,7 @@ jobs:
         # Enable this if we have failures on GEOS main
         # continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
-          pytest shapely/tests tests --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
+          pytest shapely/tests tests -s --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,7 @@ jobs:
         # Enable this if we have failures on GEOS main
         # continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
-          pytest shapely/tests tests -s --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
+          pytest shapely/tests tests --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -40,6 +40,7 @@ def test_edges():
     mp = MultiPoint(points=[(0.5, 0.5), (1.0, 1.0)])
     regions = voronoi_diagram(mp, edges=True)
 
+    print(regions)
     assert len(regions.geoms) == 1
     assert all(r.geom_type == 'LineString' for r in regions.geoms)
 

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -40,9 +40,9 @@ def test_edges():
     mp = MultiPoint(points=[(0.5, 0.5), (1.0, 1.0)])
     regions = voronoi_diagram(mp, edges=True)
 
-    print(regions)
     assert len(regions.geoms) == 1
-    assert all(r.geom_type == 'LineString' for r in regions.geoms)
+    # can be LineString or MultiLineString depending on the GEOS version
+    assert all(r.geom_type.endswith('LineString') for r in regions.geoms)
 
 
 @requires_geos_35


### PR DESCRIPTION
The return value has been changed to always be a MultiLineString, instead of either LineString or MultiLineString, depending on the number of input points -> https://github.com/libgeos/geos/pull/702 
This updates the test to reflect that.