### PR TITLE
BLD: pin to Cython~=0.29, ignore .c and .pyx files in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cython",
+    "Cython~=0.29",
     "oldest-supported-numpy",
     "setuptools>=61.0.0",
 ]
@@ -57,11 +57,14 @@ docs = [
 Documentation = "https://shapely.readthedocs.io/"
 Repository = "https://github.com/shapely/shapely"
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
-include = [
-    "shapely",
-    "shapely.*",
-]
+include = ["shapely", "shapely.*"]
+
+[tool.setuptools.package-data]
+"shapely" = ["*.pxd"]
 
 [tool.coverage.run]
 source = ["shapely"]


### PR DESCRIPTION
This PR ignores a few files from binary wheels that should not be there. The .c, .pxd and .pyx files were not present before #1426.

The curious change of packaging is because the default for include_package_data is different between `setup.py` and `pyproject.toml` metadata structures. Before #1426 the default for `setup.py`'s `include_package_data` was False, but the default for `pyproject.toml`'s `include-package-data` is true ([ref](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data)), so it needs to be explicitly set back to false.

Only a few .c, .pxd and .pyx files in .whl files are excluded. Sdist contents are unchanged.