### PR TITLE
CI/RLS: ensure to run CircleCI on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,9 @@ workflows:
   wheel-build:
     jobs:
       - linux-aarch64-wheels
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              only: /.*/


### PR DESCRIPTION
By default CircleCI only runs on pushes to branches, not on tags, so as a result we didn't build the wheels for 2.0rc1 (only on the push that didn't yet have the tag, so that wheel has the wrong version in it). 

In addition also limiting to the main branch. 