### PR TITLE
release CI: Use release/v1 branch for PyPI publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Release Assets to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Use the stable release branch for the PyPI publish GitHub Action, as recommended in their docs.

See https://github.com/pypa/gh-action-pypi-publish#usage.

This PR replaces #1641.