### PR TITLE
TST: fix tests for GEOS changes in M handling

### DIFF
--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -49,8 +49,11 @@ def test_points_from_xyz():
 
 
 def test_points_invalid_ndim():
-    with pytest.raises(shapely.GEOSException):
+    with pytest.raises(ValueError, match="dimension should be 2 or 3, got 4"):
         shapely.points([0, 1, 2, 3])
+
+    with pytest.raises(ValueError, match="dimension should be 2 or 3, got 1"):
+        shapely.points([0])
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -183,7 +183,13 @@ def test_from_wkb_exceptions():
         shapely.from_wkb(1)
 
     # invalid WKB
-    with pytest.raises(shapely.GEOSException, match="Unexpected EOF parsing WKB"):
+    with pytest.raises(
+        shapely.GEOSException,
+        match=(
+            "Unexpected EOF parsing WKB|"
+            "ParseException: Input buffer is smaller than requested object size"
+        ),
+    ):
         result = shapely.from_wkb(b"\x01\x01\x00\x00\x00\x00")
         assert result is None
 
@@ -287,7 +293,7 @@ def test_to_wkt_exceptions():
         shapely.to_wkt(1)
 
     with pytest.raises(shapely.GEOSException):
-        shapely.to_wkt(point, output_dimension=4)
+        shapely.to_wkt(point, output_dimension=5)
 
 
 def test_to_wkt_point_empty():
@@ -403,7 +409,7 @@ def test_to_wkb_exceptions():
         shapely.to_wkb(1)
 
     with pytest.raises(shapely.GEOSException):
-        shapely.to_wkb(point, output_dimension=4)
+        shapely.to_wkb(point, output_dimension=5)
 
     with pytest.raises(ValueError):
         shapely.to_wkb(point, flavor="other")

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2455,6 +2455,14 @@ static void points_func(char** args, npy_intp* dimensions, npy_intp* steps, void
   GEOSCoordSequence* coord_seq = NULL;
   GEOSGeometry** geom_arr;
 
+  // check the ordinate dimension before calling GEOSCoordSeq_create_r
+  if (dimensions[1] < 2 || dimensions[1] > 3) {
+    PyErr_Format(PyExc_ValueError,
+                 "The ordinate (last) dimension should be 2 or 3, got %ld",
+                 dimensions[1]);
+    return;
+  }
+
   // allocate a temporary array to store output GEOSGeometry objects
   geom_arr = malloc(sizeof(void*) * dimensions[0]);
   CHECK_ALLOC(geom_arr);


### PR DESCRIPTION
GEOS is improving its support for M values (it can now store either XYZ or XYZM buffers under the hood, https://github.com/libgeos/geos/pull/721), and for example can (I think) now also parse WKT or WKB with M values. We will need to update our code to actually make use of those abilities(-> opened https://github.com/shapely/shapely/issues/1648 for this), but this PR just fixes a few test failures because of those changes in GEOS.