### PR TITLE
ENH: add normalize keyword to equals_exact() to normalize input geometries (Rebased #1231)

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1097,9 +1097,10 @@ differently.
   >>> b == c
   False
 
-.. method:: object.equals_exact(other, tolerance)
+.. method:: object.equals_exact(other, tolerance=0, normalize=False)
 
-  Returns ``True`` if the object is within a specified `tolerance`.
+  Returns ``True`` if the geometries are structurally equal, within a specified `tolerance`.
+  See the equivalent function :meth:`predicates.equals_exact()` for full details.
 
 .. method:: object.contains(other)
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -721,40 +721,11 @@ class BaseGeometry(shapely.Geometry):
         """
         return _maybe_unpack(shapely.dwithin(self, other, distance))
 
-    def equals_exact(self, other, tolerance):
-        """True if geometries are equal to within a specified
-        tolerance.
-
-        Parameters
-        ----------
-        other : BaseGeometry
-            The other geometry object in this comparison.
-        tolerance : float
-            Absolute tolerance in the same units as coordinates.
-
-        This method considers coordinate equality, which requires
-        coordinates to be equal and in the same order for all components
-        of a geometry.
-
-        Because of this it is possible for "equals()" to be True for two
-        geometries and "equals_exact()" to be False.
-
-        Examples
-        --------
-        >>> LineString(
-        ...     [(0, 0), (2, 2)]
-        ... ).equals_exact(
-        ...     LineString([(0, 0), (1, 1), (2, 2)]),
-        ...     1e-6
-        ... )
-        False
-
-        Returns
-        -------
-        bool
-
+    def equals_exact(self, other, tolerance=0.0, normalize=False):
+        """Returns True if A and B are structurally equal, within a specified tolerance.
+        See shapely.equals_exact() for full details.
         """
-        return _maybe_unpack(shapely.equals_exact(self, other, tolerance))
+        return _maybe_unpack(shapely.equals_exact(self, other, tolerance, normalize))
 
     def almost_equals(self, other, decimal=6):
         """True if geometries are equal at all coordinates to a

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -947,29 +947,44 @@ def within(a, b, **kwargs):
 
 
 @multithreading_enabled
-def equals_exact(a, b, tolerance=0.0, **kwargs):
-    """Returns True if A and B are structurally equal.
+def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
+    """Returns True if A and B are structurally equal, within a specified tolerance.
 
-    This method uses exact coordinate equality, which requires coordinates
-    to be equal (within specified tolerance) and and in the same order for all
+    This method uses exact coordinate equality, which requires coordinates to be
+    equal (within specified tolerance) and in the same order for all
     components of a geometry. This is in contrast with the ``equals`` function
     which uses spatial (topological) equality.
+    For two given geometries, it is thus possible for ``equals`` to be True
+    while ``equals_exact`` is False.
+    The order of the coordinates can be normalized (by setting the `normalize`
+    keyword to True) so that the functions becomes closer to checking
+    approximate topological equality. However, for Polygons with multiple holes
+    and MultiPolygons, two topologically equal geometries can still be
+    structurally different even with `normalize` set to True if the order of the
+    rings or Polygons differs.
 
     Parameters
     ----------
     a, b : Geometry or array_like
     tolerance : float or array_like
+    normalize : bool, optional (default: False)
+        Normalize the two geometries so that the coordinates are in the
+        same order.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
 
+    Returns
+    -------
+    bool or array_like
+
     See Also
     --------
-    equals : Check if A and B are spatially equal.
+    equals : Check if A and B are topologically equal.
 
     Examples
     --------
-    >>> from shapely import Point, Polygon
+    >>> from shapely import Point, Polygon, LineString
     >>> point1 = Point(50, 50)
     >>> point2 = Point(50.1, 50.1)
     >>> equals_exact(point1, point2)
@@ -978,6 +993,11 @@ def equals_exact(a, b, tolerance=0.0, **kwargs):
     True
     >>> equals_exact(point1, None, tolerance=0.2)
     False
+    >>> ls1 = LineString([(0, 0), (2, 2)])
+    >>> ls2 = LineString([(0, 0), (1, 1), (2, 2)])
+    >>> equals_exact(ls1, ls2, 1e-6)
+    False
+
 
     Difference between structucal and spatial equality:
 
@@ -988,6 +1008,10 @@ def equals_exact(a, b, tolerance=0.0, **kwargs):
     >>> equals(polygon1, polygon2)
     True
     """
+    if normalize:
+        a = lib.normalize(a)
+        b = lib.normalize(b)
+
     return lib.equals_exact(a, b, tolerance, **kwargs)
 
 

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,6 +1,6 @@
 import pytest
 
-from shapely import Point
+from shapely import Point, Polygon
 from shapely.errors import ShapelyDeprecationWarning
 
 
@@ -10,6 +10,23 @@ def test_equals_exact():
     assert not p1.equals(p2)
     assert not p1.equals_exact(p2, 0.001)
     assert p1.equals_exact(p2, 1.42)
+
+    p3 = Point(1.0, 1.0 + 1e-7)
+    assert not p1.equals_exact(p3)
+    assert p1.equals_exact(p3, 1e-6)
+
+    # test polygons
+    shell = [(10, 10), (10, -10), (-10, -10), (-10, 10)]
+    holes = [[(1, 1), (1, -1), (-1, -1), (-1, 1)]]
+    p1 = Polygon(shell, holes)
+    p2 = Polygon(shell, holes=[holes[0][::-1]])
+    assert p1.equals(p2)
+    assert not p1.equals_exact(p2, 1e-5)
+    assert p1.equals_exact(p2, 1e-5, normalize=True)
+
+    hole2 = [(1, 1), (1, -1), (-1, -1), (-1, 1.01)]
+    p3 = Polygon(shell, holes=[hole2])
+    assert not p1.equals_exact(p3, 1e-5)
 
 
 def test_almost_equals_default():


### PR DESCRIPTION
This PR is rebase of the work of @tfardet https://github.com/shapely/shapely/pull/1231
@tfardet - I don't want to take credit for your work, please feel free to pull this into your PR if you wish to do so.

I've rebased on main, solved the conflicts and removed the duplicated documentation (full doc in `predicates.equals_exact`, only title in `base.equals_exact`) and made some other cosmetic changes. 