### PR TITLE
BUG: correct `directed=True` usage in shapely.ops.line_merge

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -110,9 +110,7 @@ class CollectionOperator:
                 source = MultiLineString(lines)
         if source is None:
             raise ValueError(f"Cannot linemerge {lines}")
-        if directed:
-            return shapely.line_merge_directed(source)
-        return shapely.line_merge(source)
+        return shapely.line_merge(source, directed)
 
     def cascaded_union(self, geoms):
         """Returns the union of a sequence of geometries


### PR DESCRIPTION
`line_merge_directed` does not exist, and regular `line_merge` accepts this argument instead.