### PR TITLE
ENH:.gitignore - add *.dylib, *.dll to ignore binaries from MacOS and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 
 # C extensions
 *.so
+*.dylib
+*.dll
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
`.gitignore` already includes `*.so`. 
This PR adds also ` *.dylib`, `*.dll` to ignore this binary file types on MacOS and Windows.