### PR TITLE
ENH: Allow getting matplotlib patch from polygon without plotting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
           else
             pip install --upgrade Cython numpy==${{ matrix.numpy }} pytest pytest-cov coveralls;
           fi
-          if [ -n "${{ matrix.numpy }}" ]; then
+          if [ -n "${{ matrix.matplotlib }}" ]; then
             pip install matplotlib
           fi
           pip list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,14 +40,12 @@ jobs:
           - python: "3.11"
             geos: 3.11.1
             numpy: 1.23.4
-            matplotlib: true
             doctest: true
             # TODO(shapely-2.0) temporary allow warnings
             # extra_pytest_args: "-W error"  # error on warnings
           # dev
           - python: "3.11"
             geos: main
-            matplotlib: true
             extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
@@ -129,9 +127,7 @@ jobs:
           else
             pip install --upgrade Cython numpy==${{ matrix.numpy }} pytest pytest-cov coveralls;
           fi
-          if [ -n "${{ matrix.numpy }}" ]; then
-            pip install matplotlib
-          fi
+          pip install matplotlib
           pip list
 
       - name: Set environment variables (Linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,12 +40,14 @@ jobs:
           - python: "3.11"
             geos: 3.11.1
             numpy: 1.23.4
+            matplotlib: true
             doctest: true
             # TODO(shapely-2.0) temporary allow warnings
             # extra_pytest_args: "-W error"  # error on warnings
           # dev
           - python: "3.11"
             geos: main
+            matplotlib: true
             extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
@@ -127,7 +129,9 @@ jobs:
           else
             pip install --upgrade Cython numpy==${{ matrix.numpy }} pytest pytest-cov coveralls;
           fi
-          pip install matplotlib
+          if [ -n "${{ matrix.numpy }}" ]; then
+            pip install matplotlib
+          fi
           pip list
 
       - name: Set environment variables (Linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
           # dev
           - python: "3.11"
             geos: main
+            matplotlib: true
             extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,6 @@ jobs:
           # dev
           - python: "3.11"
             geos: main
-            matplotlib: true
             extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -6,11 +6,11 @@ exploration, debugging and illustration purposes.
 
 """
 
+import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import colors
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
-import matplotlib.pyplot as plt
-import numpy as np
 
 import shapely
 
@@ -34,7 +34,7 @@ def _path_from_polygon(polygon):
         )
 
 
-def patch_from_polygon(polygon, facecolor=None, edgecolor=None, linewidth=None, **kwargs):
+def patch_from_polygon(polygon, **kwargs):
     """
     Gets a Matplotlib patch from a (Multi)Polygon.
 
@@ -44,12 +44,6 @@ def patch_from_polygon(polygon, facecolor=None, edgecolor=None, linewidth=None, 
     Parameters
     ----------
     polygon : shapely.Polygon or shapely.MultiPolygon
-    facecolor : matplotlib color specification
-        Color for the polygon fill.
-    edgecolor : matplotlib color specification
-        Color for the polygon boundary.
-    linewidth : float
-        The line width for the polygon boundary.
     **kwargs
         Additional keyword arguments passed to the matplotlib Patch.
 
@@ -57,10 +51,7 @@ def patch_from_polygon(polygon, facecolor=None, edgecolor=None, linewidth=None, 
     -------
     Matplotlib artist (PathPatch)
     """
-    path = _path_from_polygon(polygon)
-    return PathPatch(
-        path, facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth, **kwargs
-    )
+    return PathPatch(_path_from_polygon(polygon), **kwargs)
 
 
 def plot_polygon(
@@ -120,7 +111,9 @@ def plot_polygon(
     if edgecolor is None:
         edgecolor = color
 
-    patch = patch_from_polygon(polygon, facecolor, edgecolor, linewidth, **kwargs)
+    patch = patch_from_polygon(
+        polygon, facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth, **kwargs
+    )
     ax.add_patch(patch)
     ax.autoscale_view()
 

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -103,7 +103,7 @@ def plot_polygon(
     Returns
     -------
     Matplotlib artist (PathPatch), if `add_points` is false.
-    A tuple of Matplotlib artists (PatchPatch, Line2D), if `add_points` is true.
+    A tuple of Matplotlib artists (PathPatch, Line2D), if `add_points` is true.
     """
     if ax is None:
         ax = _default_ax()

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -6,16 +6,14 @@ exploration, debugging and illustration purposes.
 
 """
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import colors
-from matplotlib.patches import PathPatch
-from matplotlib.path import Path
 
 import shapely
 
 
 def _default_ax():
+    import matplotlib.pyplot as plt
+
     ax = plt.gca()
     ax.grid(True)
     ax.set_aspect("equal")
@@ -23,6 +21,8 @@ def _default_ax():
 
 
 def _path_from_polygon(polygon):
+    from matplotlib.path import Path
+
     if isinstance(polygon, shapely.MultiPolygon):
         return Path.make_compound_path(
             *[_path_from_polygon(poly) for poly in polygon.geoms]
@@ -51,6 +51,8 @@ def patch_from_polygon(polygon, **kwargs):
     -------
     Matplotlib artist (PathPatch)
     """
+    from matplotlib.patches import PathPatch
+
     return PathPatch(_path_from_polygon(polygon), **kwargs)
 
 
@@ -96,6 +98,8 @@ def plot_polygon(
     Matplotlib artist (PathPatch), if `add_points` is false.
     A tuple of Matplotlib artists (PathPatch, Line2D), if `add_points` is true.
     """
+    from matplotlib import colors
+
     if ax is None:
         ax = _default_ax()
 
@@ -150,6 +154,9 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     -------
     Matplotlib artist (PathPatch)
     """
+    from matplotlib.patches import PathPatch
+    from matplotlib.path import Path
+
     if ax is None:
         ax = _default_ax()
 

--- a/shapely/tests/test_plotting.py
+++ b/shapely/tests/test_plotting.py
@@ -1,18 +1,41 @@
 import pytest
 from numpy.testing import assert_allclose
 
-import shapely
-from shapely import box, LineString, MultiLineString, Point
-from shapely.plotting import plot_line, plot_points, plot_polygon
+from shapely import box, get_coordinates, LineString, MultiLineString, Point
+from shapely.plotting import patch_from_polygon, plot_line, plot_points, plot_polygon
 
 pytest.importorskip("matplotlib")
+
+
+def test_patch_from_polygon():
+    poly = box(0, 0, 1, 1)
+    artist = patch_from_polygon(poly, facecolor="red", edgecolor="blue", linewidth=3)
+    assert equal_color(artist.get_facecolor(), "red")
+    assert equal_color(artist.get_edgecolor(), "blue")
+    assert artist.get_linewidth() == 3
+
+
+def test_patch_from_polygon_with_interior():
+    poly = box(0, 0, 1, 1).difference(box(0.2, 0.2, 0.5, 0.5))
+    artist = patch_from_polygon(poly, facecolor="red", edgecolor="blue", linewidth=3)
+    assert equal_color(artist.get_facecolor(), "red")
+    assert equal_color(artist.get_edgecolor(), "blue")
+    assert artist.get_linewidth() == 3
+
+
+def test_patch_from_multipolygon():
+    poly = box(0, 0, 1, 1).union(box(2, 2, 3, 3))
+    artist = patch_from_polygon(poly, facecolor="red", edgecolor="blue", linewidth=3)
+    assert equal_color(artist.get_facecolor(), "red")
+    assert equal_color(artist.get_edgecolor(), "blue")
+    assert artist.get_linewidth() == 3
 
 
 def test_plot_polygon():
     poly = box(0, 0, 1, 1)
     artist, _ = plot_polygon(poly)
     plot_coords = artist.get_path().vertices
-    assert_allclose(plot_coords, shapely.get_coordinates(poly))
+    assert_allclose(plot_coords, get_coordinates(poly))
 
     # overriding default styling
     artist = plot_polygon(poly, add_points=False, color="red", linewidth=3)
@@ -22,24 +45,24 @@ def test_plot_polygon():
 
 
 def test_plot_polygon_with_interior():
-    poly = box(0, 0, 1, 1).difference(shapely.box(0.2, 0.2, 0.5, 0.5))
+    poly = box(0, 0, 1, 1).difference(box(0.2, 0.2, 0.5, 0.5))
     artist, _ = plot_polygon(poly)
     plot_coords = artist.get_path().vertices
-    assert_allclose(plot_coords, shapely.get_coordinates(poly))
+    assert_allclose(plot_coords, get_coordinates(poly))
 
 
 def test_plot_multipolygon():
     poly = box(0, 0, 1, 1).union(box(2, 2, 3, 3))
     artist, _ = plot_polygon(poly)
     plot_coords = artist.get_path().vertices
-    assert_allclose(plot_coords, shapely.get_coordinates(poly))
+    assert_allclose(plot_coords, get_coordinates(poly))
 
 
 def test_plot_line():
     line = LineString([(0, 0), (1, 0), (1, 1)])
     artist, _ = plot_line(line)
     plot_coords = artist.get_path().vertices
-    assert_allclose(plot_coords, shapely.get_coordinates(line))
+    assert_allclose(plot_coords, get_coordinates(line))
 
     # overriding default styling
     artist = plot_line(line, add_points=False, color="red", linewidth=3)
@@ -54,14 +77,14 @@ def test_plot_multilinestring():
     )
     artist, _ = plot_line(line)
     plot_coords = artist.get_path().vertices
-    assert_allclose(plot_coords, shapely.get_coordinates(line))
+    assert_allclose(plot_coords, get_coordinates(line))
 
 
 def test_plot_points():
     for geom in [Point(0, 0), LineString([(0, 0), (1, 0), (1, 1)]), box(0, 0, 1, 1)]:
         artist = plot_points(geom)
         plot_coords = artist.get_path().vertices
-        assert_allclose(plot_coords, shapely.get_coordinates(geom))
+        assert_allclose(plot_coords, get_coordinates(geom))
         assert artist.get_linestyle() == "None"
 
     # overriding default styling

--- a/shapely/tests/test_plotting.py
+++ b/shapely/tests/test_plotting.py
@@ -1,10 +1,7 @@
-import pytest
 from numpy.testing import assert_allclose
 
 from shapely import box, get_coordinates, LineString, MultiLineString, Point
 from shapely.plotting import patch_from_polygon, plot_line, plot_points, plot_polygon
-
-pytest.importorskip("matplotlib")
 
 
 def test_patch_from_polygon():

--- a/shapely/tests/test_plotting.py
+++ b/shapely/tests/test_plotting.py
@@ -1,7 +1,10 @@
+import pytest
 from numpy.testing import assert_allclose
 
 from shapely import box, get_coordinates, LineString, MultiLineString, Point
 from shapely.plotting import patch_from_polygon, plot_line, plot_points, plot_polygon
+
+pytest.importorskip("matplotlib")
 
 
 def test_patch_from_polygon():


### PR DESCRIPTION
This PR stems from my use case to get a Matplotlib patch from a Shapely polygon, but manipulate it in [my own GUI](https://github.com/sea-bass/pyrobosim) instead of directly plotting it.

This adds a new `patch_from_polygon()` function that is internally called by `plot_polygon()` but can also be used standalone to return a patch without plotting. In the process I also did some slight cleanup.