### PR TITLE
TST: skip failing test on GEOS master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,6 +166,7 @@ jobs:
         # Enable this if we have failures on GEOS main
         # continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
+          python -c "import shapely; print(f'GEOS version: {shapely.geos_version_string}')"
           pytest shapely/tests tests --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -46,13 +46,15 @@ non_polygon_types = [
 
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func", SET_OPERATIONS)
-def test_set_operation_array(a, func):
+def test_set_operation_array(request, a, func):
     if (
         func == shapely.difference
         and a == geometry_collection
         and shapely.geos_version >= (3, 12, 0)
     ):
-        pytest.xfail("https://github.com/libgeos/geos/issues/797")
+        request.node.add_marker(
+            pytest.mark.xfail(reason="https://github.com/libgeos/geos/issues/797")
+        )
     actual = func(a, point)
     assert isinstance(actual, Geometry)
 


### PR DESCRIPTION
Skip failing test (`shapely.errors.GEOSException: IllegalArgumentException: Overlay input is mixed-dimension`) with GEOS master till that issue is resolved upstream

Related to: https://github.com/libgeos/geos/issues/797
