### PR TITLE
FIX: Copy geometries input to STRtree to prevent modification instead of adding write lock to array

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -90,7 +90,11 @@ class STRtree:
 
     def __del__(self):
         # release write lock on geometry array
-        self._geometries.flags.writeable = self._prev_writeable
+        # (in try/catch in case any attributes are out of scope when this runs)
+        try:
+            self._geometries.flags.writeable = self._prev_writeable
+        except AttributeError:
+            pass
 
     def __len__(self):
         return self._tree.count

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -76,7 +76,7 @@ class STRtree:
     ):
         # Keep references to geoms in a copied array so that this array is not
         # modified while the tree depends on it remaining the same
-        self._geometries = np.asarray(geoms, dtype=np.object_).copy()
+        self._geometries = np.array(geoms, dtype=np.object_, copy=True)
 
         # initialize GEOS STRtree
         self._tree = lib.STRtree(self.geometries, node_capacity)

--- a/shapely/tests/common.py
+++ b/shapely/tests/common.py
@@ -1,4 +1,3 @@
-import sys
 from contextlib import contextmanager
 
 import numpy as np
@@ -68,26 +67,6 @@ all_types = (
     geometry_collection,
     empty,
 )
-
-
-@contextmanager
-def assert_increases_refcount(obj):
-    try:
-        before = sys.getrefcount(obj)
-    except AttributeError:  # happens on Pypy
-        pytest.skip("sys.getrefcount is not available.")
-    yield
-    assert sys.getrefcount(obj) == before + 1
-
-
-@contextmanager
-def assert_decreases_refcount(obj):
-    try:
-        before = sys.getrefcount(obj)
-    except AttributeError:  # happens on Pypy
-        pytest.skip("sys.getrefcount is not available.")
-    yield
-    assert sys.getrefcount(obj) == before - 1
 
 
 @contextmanager

--- a/shapely/tests/test_strtree.py
+++ b/shapely/tests/test_strtree.py
@@ -83,14 +83,15 @@ def test_write_lock():
     assert geoms.flags.writeable is False
 
     # deleting tree releases lock
-    del tree
+    # del tree also works except on PyPy
+    tree.__del__()
     assert geoms.flags.writeable is True
     geoms[0] = shapely.Point(100, 100)
     assert_array_equal(shapely.get_coordinates(geoms[0])[0], [100, 100])
 
     # creating a tree from a copy of geoms does not lock geoms
-    tree = STRtree(geoms.copy())
-    assert tree.geometries.flags.writeable is False
+    tree2 = STRtree(geoms.copy())
+    assert tree2.geometries.flags.writeable is False
     assert geoms.flags.writeable is True
 
 

--- a/shapely/tests/test_strtree.py
+++ b/shapely/tests/test_strtree.py
@@ -12,15 +12,9 @@ from numpy.testing import assert_array_equal
 import shapely
 from shapely import box, geos_version, MultiPoint, Point, STRtree
 from shapely.errors import UnsupportedGEOSVersionError
+from shapely.testing import assert_geometries_equal
 
-from .common import (
-    assert_decreases_refcount,
-    assert_increases_refcount,
-    empty,
-    empty_line_string,
-    empty_point,
-    point,
-)
+from .common import empty, empty_line_string, empty_point, point
 
 # the distance between 2 points spaced at whole numbers along a diagonal
 HALF_UNIT_DIAG = math.sqrt(2) / 2
@@ -73,44 +67,9 @@ def test_init(geometry, count, hits):
     assert tree.query(box(0, 0, 100, 100)).size == hits
 
 
-def test_write_lock():
-    geoms = shapely.points(np.arange(10), np.arange(10))
-    assert geoms.flags.writeable is True
-
-    # creating tree locks geoms
-    tree = STRtree(geoms)
-    assert tree.geometries.flags.writeable is False
-    assert geoms.flags.writeable is False
-
-    # deleting tree releases lock
-    # del tree also works except on PyPy
-    tree.__del__()
-    assert geoms.flags.writeable is True
-    geoms[0] = shapely.Point(100, 100)
-    assert_array_equal(shapely.get_coordinates(geoms[0])[0], [100, 100])
-
-    # creating a tree from a copy of geoms does not lock geoms
-    tree2 = STRtree(geoms.copy())
-    assert tree2.geometries.flags.writeable is False
-    assert geoms.flags.writeable is True
-
-
 def test_init_with_invalid_geometry():
     with pytest.raises(TypeError):
         STRtree(["Not a geometry"])
-
-
-def test_init_increases_refcount():
-    arr = np.array([point])
-    with assert_increases_refcount(point):
-        _ = STRtree(arr)
-
-
-def test_del_decreases_refcount():
-    arr = np.array([point])
-    tree = STRtree(arr)
-    with assert_decreases_refcount(point):
-        del tree
 
 
 def test_references():
@@ -136,7 +95,6 @@ def test_flush_geometries():
     tree = STRtree(arr)
 
     # Dereference geometries
-    tree._geometries.flags.writeable = True
     arr[:] = None
     import gc
 
@@ -148,7 +106,11 @@ def test_flush_geometries():
 def test_geometries_property():
     arr = np.array([point])
     tree = STRtree(arr)
-    assert arr is tree.geometries
+    assert_geometries_equal(arr, tree.geometries)
+
+    # modifying elements of input should not modify tree.geometries
+    arr[0] = shapely.Point(0, 0)
+    assert_geometries_equal(point, tree.geometries[0])
 
 
 # TODO(shapely-2.0) this fails on Appveyor, see


### PR DESCRIPTION
Resolves #1714 

Instead of adding a write lock to the geometry array input to construct the tree, we now take a copy of the input array, which allows the user to modify the input array later without modifying the geometries stored in the tree.