### PR TITLE
ENH:base.py - add `coords_array` and `xy_array` properties

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -207,6 +207,18 @@ class BaseGeometry(shapely.Geometry):
         return CoordinateSequence(coords_array)
 
     @property
+    def coords_array(self):
+        """Access to geometry's full coordinates array [N, 2|3] (xy/xyz depending on coordinate dimensionality)"""
+        coords_array = shapely.get_coordinates(self, include_z=self.has_z)
+        return coords_array
+
+    @property
+    def xy_array(self):
+        """Access to geometry's xy coordinates array [N, 2] (regardless of coordinate dimensionality)"""
+        coords_array = shapely.get_coordinates(self)
+        return coords_array
+
+    @property
     def xy(self):
         """Separate arrays of X and Y coordinate values"""
         raise NotImplementedError

--- a/shapely/tests/geometry/test_linestring.py
+++ b/shapely/tests/geometry/test_linestring.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 import shapely
 from shapely import LinearRing, LineString, Point
@@ -8,18 +9,28 @@ from shapely.coords import CoordinateSequence
 
 def test_from_coordinate_sequence():
     # From coordinate tuples
-    line = LineString([(1.0, 2.0), (3.0, 4.0)])
+    coords_xy = [(1.0, 2.0), (3.0, 4.0)]
+    xy = [(1.0, 3.0), (2.0, 4.0)]
+    line = LineString(coords_xy)
     assert len(line.coords) == 2
-    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
-
-    line = LineString([(1.0, 2.0), (3.0, 4.0)])
-    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+    assert line.coords[:] == coords_xy
+    assert_array_equal(line.coords_array, coords_xy)
+    assert_array_equal(line.xy_array, coords_xy)
+    assert_array_equal(line.xy_array.T, xy)
+    assert_array_equal(line.xy, xy)
 
 
 def test_from_coordinate_sequence_3D():
-    line = LineString([(1.0, 2.0, 3.0), (3.0, 4.0, 5.0)])
+    coords_xyz = [(1.0, 2.0, 3.0), (3.0, 4.0, 5.0)]
+    coords_xy = [(1.0, 2.0), (3.0, 4.0)]
+    xy = [(1.0, 3.0), (2.0, 4.0)]
+    line = LineString(coords_xyz)
     assert line.has_z
-    assert line.coords[:] == [(1.0, 2.0, 3.0), (3.0, 4.0, 5.0)]
+    assert line.coords[:] == coords_xyz
+    assert_array_equal(line.coords_array, coords_xyz)
+    assert_array_equal(line.xy_array, coords_xy)
+    assert_array_equal(line.xy_array.T, xy)
+    assert_array_equal(line.xy, xy)
 
 
 def test_from_points():

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -2,6 +2,7 @@
 """
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from shapely import LinearRing, LineString, Point, Polygon
 from shapely.coords import CoordinateSequence
@@ -127,6 +128,7 @@ def test_polygon_from_coordinate_sequence():
     polygon = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])
     assert polygon.exterior.coords[:] == coords
     assert len(polygon.interiors) == 0
+    assert_array_equal(polygon.coords_array, coords)
 
     polygon = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])
     assert polygon.exterior.coords[:] == coords
@@ -135,12 +137,16 @@ def test_polygon_from_coordinate_sequence():
 
 def test_polygon_from_coordinate_sequence_with_holes():
     coords = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.0, 0.0)]
+    hole = [(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)]
+    hole_closed = hole + [hole[0]]
 
     # Interior rings (holes)
-    polygon = Polygon(coords, [[(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)]])
+    polygon = Polygon(coords, [hole])
     assert polygon.exterior.coords[:] == coords
     assert len(polygon.interiors) == 1
     assert len(polygon.interiors[0].coords) == 5
+
+    assert_array_equal(polygon.coords_array, coords + hole_closed)
 
     # Multiple interior rings with different length
     coords = [(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]
@@ -153,6 +159,8 @@ def test_polygon_from_coordinate_sequence_with_holes():
     assert len(polygon.interiors) == 2
     assert len(polygon.interiors[0].coords) == 5
     assert len(polygon.interiors[1].coords) == 6
+
+    assert_array_equal(polygon.coords_array, coords + holes[0] + holes[1])
 
 
 def test_polygon_from_linearring():


### PR DESCRIPTION
This PR adds `coords_array` and `xy_array` properties to geometries. 
These are in addition to the existing `coords` and `xy` which are slower, and stay for backwards compatibility.