### PR TITLE
BUG: fix setup.py AttributeError when old versioneer is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 # ensure the current directory is on sys.path so versioneer can be imported
 # when pip uses PEP 517/518 build rules.
 # https://github.com/python-versioneer/python-versioneer/issues/193
-sys.path.append(os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(__file__))
 import versioneer
 
 # Skip Cython build if not available


### PR DESCRIPTION
Prepend the current directory to `sys.path` rather than appending it, in order to ensure that the local `versioneer.py` is used.  Otherwise, if one has an incompatible version of `versioneer` installed, the setup script fails, e.g.:

```
$ python -m build -nw
* Getting build dependencies for wheel...
Could not find geos-config executable. Either append the path to geos-config to PATH or manually provide the include_dirs, library_dirs, libraries and other link args for compiling against a GEOS version >=3.5.
Compiling shapely/_geometry_helpers.pyx because it changed.
Compiling shapely/_geos.pyx because it changed.
[1/2] Cythonizing shapely/_geometry_helpers.pyx
[2/2] Cythonizing shapely/_geos.pyx
Traceback (most recent call last):
  File "/tmp/shapely/venv/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/tmp/shapely/venv/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/tmp/shapely/venv/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
    return hook(config_settings)
  File "/tmp/shapely/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
  File "/tmp/shapely/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
    self.run_setup()
  File "/tmp/shapely/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 335, in run_setup
    exec(code, locals())
  File "<string>", line 207, in <module>
AttributeError: module 'versioneer' has no attribute 'get_cmdclass'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

Original bug: https://bugs.gentoo.org/889368