### PR TITLE
TST: update 'invalid value encountered' floating-point warnings (fixed with GEOS>=3.12)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,7 @@ jobs:
             numpy: 1.23.4
             matplotlib: true
             doctest: true
-            # TODO(shapely-2.0) temporary allow warnings
-            # extra_pytest_args: "-W error"  # error on warnings
+            extra_pytest_args: "-W error"  # error on warnings
           # dev
           - python: "3.11"
             geos: main

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -77,7 +77,9 @@ def test_float_arg_array(geometry, func):
     # voronoi_polygons emits an "invalid" warning when supplied with an empty
     # point (see https://github.com/libgeos/geos/issues/515)
     with ignore_invalid(
-        func is shapely.voronoi_polygons and shapely.get_type_id(geometry) == 0
+        func is shapely.voronoi_polygons
+        and shapely.get_type_id(geometry) == 0
+        and shapely.geos_version < (3, 12, 0)
     ):
         actual = func([geometry, geometry], 0.0)
     assert actual.shape == (2,)
@@ -251,7 +253,7 @@ def test_normalize(geom, expected):
 
 
 def test_offset_curve_empty():
-    with ignore_invalid():
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
         # Empty geometries emit an "invalid" warning
         # (see https://github.com/libgeos/geos/issues/515)
         actual = shapely.offset_curve(empty_line_string, 2.0)

--- a/shapely/tests/test_measurement.py
+++ b/shapely/tests/test_measurement.py
@@ -52,6 +52,16 @@ def test_distance_missing():
     assert np.isnan(actual)
 
 
+def test_distance_duplicated():
+    a = Point(1, 2)
+    b = LineString([(0, 0), (0, 0), (1, 1)])
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
+        # https://github.com/shapely/shapely/issues/1552
+        # GEOS < 3.12 raises "invalid" floating point errors
+        actual = shapely.distance(a, b)
+    assert actual == 1.0
+
+
 @pytest.mark.parametrize(
     "geom,expected",
     [
@@ -145,7 +155,7 @@ def test_hausdorff_distance():
     # example from GEOS docs
     a = shapely.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = shapely.linestrings([[0, 100], [0, 10], [80, 10]])
-    with ignore_invalid():
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
         # Hausdorff distance emits "invalid value encountered"
         # (see https://github.com/libgeos/geos/issues/515)
         actual = shapely.hausdorff_distance(a, b)
@@ -156,7 +166,7 @@ def test_hausdorff_distance_densify():
     # example from GEOS docs
     a = shapely.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = shapely.linestrings([[0, 100], [0, 10], [80, 10]])
-    with ignore_invalid():
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
         # Hausdorff distance emits "invalid value encountered"
         # (see https://github.com/libgeos/geos/issues/515)
         actual = shapely.hausdorff_distance(a, b, densify=0.001)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -118,7 +118,6 @@ def test_binary_empty_result():
         # Intersection resulting in empty geometries give 'invalid value encountered'
         # (https://github.com/shapely/shapely/issues/1345)
         assert shapely.intersection(a, b).is_empty
-    assert actual.is_empty
 
 
 @pytest.mark.parametrize("a", all_types)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -89,7 +89,7 @@ def test_unary_missing(func):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func", BINARY_PREDICATES)
 def test_binary_array(a, func):
-    with ignore_invalid(shapely.is_empty(a)):
+    with ignore_invalid(shapely.is_empty(a) and shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
         actual = func([a, a], point)
@@ -111,10 +111,20 @@ def test_binary_missing(func):
     assert (~actual).all()
 
 
+def test_binary_empty_result():
+    a = LineString([(0, 0), (3, 0), (3, 3), (0, 3)])
+    b = LineString([(5, 1), (6, 1)])
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
+        # Intersection resulting in empty geometries give 'invalid value encountered'
+        # (https://github.com/shapely/shapely/issues/1345)
+        actual = shapely.intersection(a, b)
+    assert actual.is_empty
+
+
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func, func_bin", XY_PREDICATES)
 def test_xy_array(a, func, func_bin):
-    with ignore_invalid(shapely.is_empty(a)):
+    with ignore_invalid(shapely.is_empty(a) and shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
         actual = func([a, a], 2, 3)
@@ -127,7 +137,7 @@ def test_xy_array(a, func, func_bin):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func, func_bin", XY_PREDICATES)
 def test_xy_array_broadcast(a, func, func_bin):
-    with ignore_invalid(shapely.is_empty(a)):
+    with ignore_invalid(shapely.is_empty(a) and shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
         actual = func(a, [0, 1, 2], [1, 2, 3])
@@ -239,7 +249,7 @@ def test_relate_pattern():
 
 
 def test_relate_pattern_empty():
-    with ignore_invalid():
+    with ignore_invalid(shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
         assert shapely.relate_pattern(empty, empty, "*" * 9).item() is True
@@ -299,7 +309,7 @@ def _prepare_with_copy(geometry):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func", BINARY_PREPARED_PREDICATES)
 def test_binary_prepared(a, func):
-    with ignore_invalid(shapely.is_empty(a)):
+    with ignore_invalid(shapely.is_empty(a) and shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
         actual = func(a, point)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -117,7 +117,7 @@ def test_binary_empty_result():
     with ignore_invalid(shapely.geos_version < (3, 12, 0)):
         # Intersection resulting in empty geometries give 'invalid value encountered'
         # (https://github.com/shapely/shapely/issues/1345)
-        actual = shapely.intersection(a, b)
+        assert shapely.intersection(a, b).is_empty
     assert actual.is_empty
 
 


### PR DESCRIPTION
Closes #1345
Closes #1552
Closes #1709

This PR doesn't actually "fix" those issues, but in the meantime those warnings have been fixed upstream in GEOS (https://github.com/libgeos/geos/issues/515, https://github.com/libgeos/geos/pull/791, https://github.com/libgeos/geos/pull/806),a and so this PR updates the tests to no longer suppress the warnings for GEOS >= 3.12 (so we can actually ensure the test suite doesn't generate such warnings). And it also adds some additional cases from the listed issues.