### PR TITLE
CLN: remove remaining references to shapely/examples directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 files: 'shapely/'
-exclude: 'shapely/examples'
 repos:
 -   repo: https://github.com/psf/black
     rev: 22.3.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include CITATION.cff CHANGES.txt CREDITS.txt LICENSE.txt README.rst
 include pyproject.toml versioneer.py
 recursive-include src *.c *.h
 recursive-include tests *.py
-recursive-include shapely/examples *.py
 recursive-include shapely *.pxd *.pyx
 recursive-exclude shapely *.c
 include docs/*.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,3 @@ force_alphabetical_sort_within_sections = true
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
-addopts = --ignore _vendor --ignore shapely/examples


### PR DESCRIPTION
I removed the `shapely/example/*` directory a while ago (https://github.com/shapely/shapely/pull/1645), but there were still some references to it.