### PR TITLE
TST: Cleanup STRtree xfails & skipifs

### DIFF
--- a/shapely/tests/test_strtree.py
+++ b/shapely/tests/test_strtree.py
@@ -365,10 +365,7 @@ def test_query_with_partially_prepared_inputs(tree):
 @pytest.mark.parametrize(
     "predicate",
     [
-        pytest.param(
-            "intersects",
-            marks=pytest.mark.xfail(reason="intersects does not raise exception"),
-        ),
+        # intersects is intentionally omitted; it does not raise an exception
         pytest.param(
             "within",
             marks=pytest.mark.xfail(geos_version < (3, 8, 0), reason="GEOS < 3.8"),
@@ -402,8 +399,6 @@ def test_query_predicate_errors(tree, predicate):
 ### predicate == 'intersects'
 
 
-# TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
-# properly on GEOS 3.5.x; it was fixed in 3.6+
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -433,29 +428,25 @@ def test_query_predicate_errors(tree, predicate):
             [[0, 0, 0], [2, 3, 4]],
         ),
         # multipoints intersect
-        pytest.param(
+        (
             MultiPoint([[5, 5], [7, 7]]),
             [5, 7],
-            marks=pytest.mark.xfail(geos_version < (3, 6, 0), reason="GEOS 3.5"),
         ),
-        pytest.param(
+        (
             [MultiPoint([[5, 5], [7, 7]])],
             [[0, 0], [5, 7]],
-            marks=pytest.mark.xfail(reason="GEOS 3.5"),
         ),
         # envelope of points contains points, but points do not intersect
         (MultiPoint([[5, 7], [7, 5]]), []),
         ([MultiPoint([[5, 7], [7, 5]])], [[], []]),
         # only one point of multipoint intersects
-        pytest.param(
+        (
             MultiPoint([[5, 7], [7, 7]]),
             [7],
-            marks=pytest.mark.xfail(geos_version < (3, 6, 0), reason="GEOS 3.5"),
         ),
-        pytest.param(
+        (
             [MultiPoint([[5, 7], [7, 7]])],
             [[0], [7]],
-            marks=pytest.mark.xfail(reason="GEOS 3.5"),
         ),
     ],
 )
@@ -1516,28 +1507,23 @@ def test_query_dwithin_polygons(poly_tree, geometry, distance, expected):
 ### STRtree nearest
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_nearest_empty_tree():
     tree = STRtree([])
-    # TODO what do we want here?
     assert tree.nearest(point) is None
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize("geometry", ["I am not a geometry"])
 def test_nearest_invalid_geom(tree, geometry):
     with pytest.raises(TypeError):
         tree.nearest(geometry)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize("geometry", [None, [None], [Point(1, 1), None]])
 def test_nearest_none(tree, geometry):
     with pytest.raises(ValueError):
         tree.nearest(geometry)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry", [empty_point, [empty_point], [Point(1, 1), empty_point]]
 )
@@ -1546,7 +1532,6 @@ def test_nearest_empty(tree, geometry):
         tree.nearest(geometry)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1567,8 +1552,6 @@ def test_nearest_points(tree, geometry, expected):
     assert_array_equal(tree.nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
-@pytest.mark.xfail(reason="equidistant geometries may produce nondeterministic results")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1581,11 +1564,13 @@ def test_nearest_points(tree, geometry, expected):
     ],
 )
 def test_nearest_points_equidistant(tree, geometry, expected):
+    # results are returned in order they are traversed when searching the tree,
+    # which can vary between GEOS versions, so we test that one of the valid
+    # results is present
     result = tree.nearest(geometry)
     assert result in expected
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1599,8 +1584,6 @@ def test_nearest_lines(line_tree, geometry, expected):
     assert_array_equal(line_tree.nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
-@pytest.mark.xfail(reason="equidistant geometries may produce nondeterministic results")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1623,11 +1606,13 @@ def test_nearest_lines(line_tree, geometry, expected):
     ],
 )
 def test_nearest_lines_equidistant(line_tree, geometry, expected):
+    # results are returned in order they are traversed when searching the tree,
+    # which can vary between GEOS versions, so we test that one of the valid
+    # results is present
     result = line_tree.nearest(geometry)
     assert result in expected
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1641,8 +1626,6 @@ def test_nearest_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
-@pytest.mark.xfail(reason="equidistant geometries may produce nondeterministic results")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1661,25 +1644,25 @@ def test_nearest_polygons(poly_tree, geometry, expected):
     ],
 )
 def test_nearest_polygons_equidistant(poly_tree, geometry, expected):
+    # results are returned in order they are traversed when searching the tree,
+    # which can vary between GEOS versions, so we test that one of the valid
+    # results is present
     result = poly_tree.nearest(geometry)
     assert result in expected
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_query_nearest_empty_tree():
     tree = STRtree([])
     assert_array_equal(tree.query_nearest(point), [])
     assert_array_equal(tree.query_nearest([point]), [[], []])
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize("geometry", ["I am not a geometry", ["still not a geometry"]])
 def test_query_nearest_invalid_geom(tree, geometry):
     with pytest.raises(TypeError):
         tree.query_nearest(geometry)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,return_distance,expected",
     [
@@ -1699,7 +1682,6 @@ def test_query_nearest_none(tree, geometry, return_distance, expected):
         assert_array_equal(tree.query_nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [(empty, []), ([empty], [[], []]), ([empty, point], [[1, 1], [2, 3]])],
@@ -1708,7 +1690,6 @@ def test_query_nearest_empty_geom(tree, geometry, expected):
     assert_array_equal(tree.query_nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1749,7 +1730,6 @@ def test_query_nearest_points(tree, geometry, expected):
     assert_array_equal(tree.query_nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1785,7 +1765,6 @@ def test_query_nearest_lines(line_tree, geometry, expected):
     assert_array_equal(line_tree.query_nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1820,7 +1799,6 @@ def test_query_nearest_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query_nearest(geometry), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,max_distance,expected",
     [
@@ -1843,7 +1821,6 @@ def test_query_nearest_max_distance(tree, geometry, max_distance, expected):
     )
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,max_distance",
     [
@@ -1858,13 +1835,11 @@ def test_query_nearest_invalid_max_distance(tree, geometry, max_distance):
         tree.query_nearest(geometry, max_distance=max_distance)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_query_nearest_nonscalar_max_distance(tree):
     with pytest.raises(ValueError, match="parameter only accepts scalar values"):
         tree.query_nearest(Point(0.5, 0.5), max_distance=[1])
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1885,7 +1860,6 @@ def test_query_nearest_return_distance(tree, geometry, expected):
     assert_array_equal(np.round(actual_dist, 4), expected_dist)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,exclusive,expected",
     [
@@ -1900,7 +1874,6 @@ def test_query_nearest_exclusive(tree, geometry, exclusive, expected):
     assert_array_equal(tree.query_nearest(geometry, exclusive=exclusive), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -1913,7 +1886,6 @@ def test_query_nearest_exclusive_no_results(tree, geometry, expected):
     assert_array_equal(tree.query_nearest(geometry, exclusive=True), expected)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,exclusive",
     [
@@ -1929,7 +1901,6 @@ def test_query_nearest_invalid_exclusive(tree, geometry, exclusive):
         tree.query_nearest(geometry, exclusive=exclusive)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,all_matches",
     [
@@ -1945,7 +1916,6 @@ def test_query_nearest_invalid_all_matches(tree, geometry, all_matches):
         tree.query_nearest(geometry, all_matches=all_matches)
 
 
-@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_query_nearest_all_matches(tree):
     point = Point(0.5, 0.5)
     assert_array_equal(tree.query_nearest(point, all_matches=True), [0, 1])


### PR DESCRIPTION
This address [#1729 comment](https://github.com/shapely/shapely/pull/1729#issue-1552080758) and cleans up xfails that were not actually necessary, removes xfails related to GEOS 3.5 (outdated), and removes version guards for < GEOS 3.6 since that is now the min version tested.