### PR TITLE
FIX: Fix read-only buffer error in `from_ragged_array`

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -50,12 +50,12 @@ def _check_out_array(object out, Py_ssize_t size):
     if out.dtype != object:
         raise TypeError("out array dtype must be object")
     if out.ndim != 1:
-        raise TypeError("out must be a one-dimensional array.") 
+        raise TypeError("out must be a one-dimensional array.")
     if out.shape[0] < size:
-        raise ValueError(f"out array is too small ({out.shape[0]} < {size})") 
+        raise ValueError(f"out array is too small ({out.shape[0]} < {size})")
     return out
 
- 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def simple_geometries_1d(object coordinates, object indices, int geometry_type, object out = None):
@@ -91,9 +91,9 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
         return np.empty(shape=(0, ), dtype=np.object_)
 
     if np.any(indices[1:] < indices[:indices.shape[0] - 1]):
-        raise ValueError("The indices must be sorted.")  
+        raise ValueError("The indices must be sorted.")
 
-    cdef double[:, :] coord_view = coordinates
+    cdef const double[:, :] coord_view = coordinates
 
     # get the geometry count per collection (this raises on negative indices)
     cdef unsigned int[:] coord_counts = np.bincount(indices).astype(np.uint32)
@@ -296,7 +296,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
         return np.empty(shape=(0, ), dtype=object)
 
     if np.any(indices[1:] < indices[:indices.shape[0] - 1]):
-        raise ValueError("The indices should be sorted.")  
+        raise ValueError("The indices should be sorted.")
 
     # get the geometry count per collection (this raises on negative indices)
     cdef int[:] collection_size = np.bincount(indices).astype(np.int32)
@@ -349,11 +349,11 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
                             f"One of the arguments has unexpected geometry type {curr_type}."
                         )
 
-                # assign to the temporary geometry array  
+                # assign to the temporary geometry array
                 geom = GEOSGeom_clone_r(geos_handle, geom)
                 if geom == NULL:
                     _deallocate_arr(geos_handle, temp_geoms_view, coll_size)
-                    return  # GEOSException is raised by get_geos_handle           
+                    return  # GEOSException is raised by get_geos_handle
                 temp_geoms_view[coll_size] = <np.intp_t>geom
                 coll_size += 1
 
@@ -361,7 +361,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
             if geometry_type != 3:  # Collection
                 coll = GEOSGeom_createCollection_r(
                     geos_handle,
-                    geometry_type, 
+                    geometry_type,
                     <GEOSGeometry**> &temp_geoms_view[0],
                     coll_size
                 )

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -86,6 +86,17 @@ def test_include_z_default():
     assert coords.shape[1] == 2
 
 
+@pytest.mark.parametrize("geom", all_types)
+def test_read_only_arrays(geom):
+    # https://github.com/shapely/shapely/pull/1744
+    typ, coords, offsets = shapely.to_ragged_array([geom, geom])
+    coords.flags.writeable = False
+    for arr in offsets:
+        arr.flags.writeable = False
+    result = shapely.from_ragged_array(typ, coords, offsets)
+    assert_geometries_equal(result, [geom, geom])
+
+
 @pytest.mark.parametrize("geom", all_types_not_supported)
 def test_raise_geometry_type(geom):
     with pytest.raises(ValueError):


### PR DESCRIPTION
Previously calling `shapely.from_ragged_array` on a read-only buffer (such as a coordinates buffer owned by Arrow memory) you'd get an error that the array is read-only

```
File shapely/_geometry_helpers.pyx:96, in shapely._geometry_helpers.simple_geometries_1d()

File stringsource:660, in View.MemoryView.memoryview_cwrapper()

File stringsource:350, in View.MemoryView.memoryview.__cinit__()

ValueError: buffer source array is read-only
```

Since shapely is copying into GEOS memory anyways, it's fine for the buffer to be read-only and only needed to be marked as such with `const`

```py
cdef const double[:, :]
```

I have my editor set to automatically trim trailing whitespace on save. If it's important I can remove the unrelated changes.