### PR TITLE
CI: update isort to fix install error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       exclude: shapely/__init__.py


### PR DESCRIPTION
The isort installation for pre-commit is currently failing, xref https://github.com/PyCQA/isort/issues/2077