### PR TITLE
BUG: ops.substring function inhomogeneous input when used on 3D polyline

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -658,7 +658,7 @@ def substring(geom, start_dist, end_dist, normalized=False):
     current_distance = 0
     for p1, p2 in zip(coords, coords[1:]):
         if start_dist < current_distance < end_dist:
-            vertex_list.append(p1)
+            vertex_list.append((p1[0],p1[1]))
         elif current_distance >= end_dist:
             break
 


### PR DESCRIPTION
Closes #1782 

Previously substring function appended entire coordinate tuple when building up new linestring. Now it takes only first two values of coordinate tuple to prevent inhomogeneous errors when returning new LineString
