### PR TITLE
CI/BLD: update GEOS minor versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium
     environment:
-      GEOS_VERSION: 3.11.1
+      GEOS_VERSION: 3.11.2
       CIBUILDWHEEL: 1
       CIBW_BUILD: "cp*-manylinux_aarch64"
       CIBW_ENVIRONMENT_PASS_LINUX: "GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.11.1"
+      GEOS_VERSION: "3.11.2"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, 3.11.1, main]
+        geos: [3.6.6, 3.7.5, 3.8.3, 3.9.4, 3.10.5, 3.11.2, main]
         include:
           # 2017
           - python: 3.7  # 3.6 is dropped
-            geos: 3.6.5
+            geos: 3.6.6
             numpy: 1.14.6
           # 2018
           - python: 3.7
@@ -27,18 +27,18 @@ jobs:
           # 2019
           - python: 3.8
             geos: 3.8.3
-            numpy: 1.17.5
+            numpy: 1.16.2
           # 2020
           - python: 3.9
-            geos: 3.9.3
+            geos: 3.9.4
             numpy: 1.19.5
           # 2021
           - python: "3.10"
-            geos: 3.10.3
+            geos: 3.10.5
             numpy: 1.21.3
           # 2022
           - python: "3.11"
-            geos: 3.11.1
+            geos: 3.11.2
             numpy: 1.23.4
             matplotlib: true
             doctest: true
@@ -61,7 +61,7 @@ jobs:
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-20.04
             python: "pypy3.8"
-            geos: 3.11.1
+            geos: 3.11.2
             numpy: 1.23.4
 
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ if: (branch = main OR tag IS present) AND (type = push)
 
 env:
   global:
-  - GEOS_VERSION=3.11.1
+  - GEOS_VERSION=3.11.2
 
 cache:
   directories:

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Build and install GEOS on a POSIX system, save cache for later
 #
@@ -36,13 +36,28 @@ build_geos(){
     pip install cmake
 
     echo "Building geos-$GEOS_VERSION"
+    rm -rf build
     mkdir build
     cd build
-     # Use Ninja on windows, otherwise, use the platform's default
+    # Use Ninja on Windows, otherwise, use the platform's default
     if [ "$RUNNER_OS" = "Windows" ]; then
         export CMAKE_GENERATOR=Ninja
     fi
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GEOS_INSTALL -DCMAKE_INSTALL_LIBDIR=lib ..
+    # Avoid building tests, depends on version
+    case ${GEOS_VERSION} in
+        3.5.*|3.6.*|3.7.*)
+            BUILD_TESTING="";;
+        3.8.*)
+            BUILD_TESTING="-DBUILD_TESTING=ON";;
+        *)
+            BUILD_TESTING="-DBUILD_TESTING=OFF";;
+    esac
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${GEOS_INSTALL} \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        ${BUILD_TESTING} \
+        ..
     cmake --build . -j 4
     cmake --install .
 }

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -42,8 +42,9 @@ def test_geos_version():
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win") and shapely.geos_version[:2] == (3, 7),
-    reason="GEOS_C_API_VERSION broken for GEOS 3.7.x on Windows",
+    sys.platform.startswith("win")
+    and (shapely.geos_version == (3, 6, 6) or shapely.geos_version[:2] == (3, 7)),
+    reason="GEOS_C_API_VERSION broken for GEOS 3.6.6 and 3.7.x on Windows",
 )
 def test_geos_capi_version():
     expected = "{}.{}.{}-CAPI-{}.{}.{}".format(


### PR DESCRIPTION
Update `maint-2.0` to use the latest GEOS minor versions for CI testing.

Also set the version for the binary wheels for the next maintenance release to use GEOS 3.11.2; see [NEWS.md](https://github.com/libgeos/geos/blob/3.11/NEWS.md) for changes.