### PR TITLE
ENH: Enable M and ZM in WKT and WKB outputs

### DIFF
--- a/shapely/io.py
+++ b/shapely/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from shapely import lib
+from shapely import geos_version, lib
 from shapely._enum import ParamEnum
 
 # include ragged array functions here for reference documentation purpose
@@ -33,7 +33,7 @@ def to_wkt(
     geometry,
     rounding_precision=6,
     trim=True,
-    output_dimension=3,
+    output_dimension=None,
     old_3d=False,
     **kwargs,
 ):
@@ -58,8 +58,10 @@ def to_wkt(
         -1 to indicate the full precision.
     trim : bool, default True
         If True, trim unnecessary decimals (trailing zeros).
-    output_dimension : int, default 3
-        The output dimension for the WKT string. Supported values are 2 and 3.
+    output_dimension : int, default None
+        The output dimension for the WKT string. Supported values are 2, 3 and
+        4 for GEOS 3.12+. Default None will automatically choose 3 or 4,
+        depending on the version of GEOS.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKT string.
     old_3d : bool, default False
@@ -97,7 +99,9 @@ def to_wkt(
         raise TypeError("rounding_precision only accepts scalar values")
     if not np.isscalar(trim):
         raise TypeError("trim only accepts scalar values")
-    if not np.isscalar(output_dimension):
+    if output_dimension is None:
+        output_dimension = 3 if geos_version < (3, 12, 0) else 4
+    elif not np.isscalar(output_dimension):
         raise TypeError("output_dimension only accepts scalar values")
     if not np.isscalar(old_3d):
         raise TypeError("old_3d only accepts scalar values")
@@ -115,7 +119,7 @@ def to_wkt(
 def to_wkb(
     geometry,
     hex=False,
-    output_dimension=3,
+    output_dimension=None,
     byte_order=-1,
     include_srid=False,
     flavor="extended",
@@ -141,8 +145,10 @@ def to_wkb(
     hex : bool, default False
         If true, export the WKB as a hexidecimal string. The default is to
         return a binary bytes object.
-    output_dimension : int, default 3
-        The output dimension for the WKB. Supported values are 2 and 3.
+    output_dimension : int, default None
+        The output dimension for the WKB. Supported values are 2, 3 and 4 for
+        GEOS 3.12+. Default None will automatically choose 3 or 4, depending on
+        the version of GEOS.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKB represenation.
     byte_order : int, default -1
@@ -173,7 +179,9 @@ def to_wkb(
     """
     if not np.isscalar(hex):
         raise TypeError("hex only accepts scalar values")
-    if not np.isscalar(output_dimension):
+    if output_dimension is None:
+        output_dimension = 3 if geos_version < (3, 12, 0) else 4
+    elif not np.isscalar(output_dimension):
         raise TypeError("output_dimension only accepts scalar values")
     if not np.isscalar(byte_order):
         raise TypeError("byte_order only accepts scalar values")

--- a/shapely/tests/common.py
+++ b/shapely/tests/common.py
@@ -76,6 +76,64 @@ multi_point_empty_z = shapely.multipoints([empty_point_z])
 multi_line_stringt_empty_z = shapely.multilinestrings([empty_line_string_z])
 multi_polygon_empty_z = shapely.multipolygons([empty_polygon_z])
 geometry_collection_empty_z = shapely.geometrycollections([empty_line_string_z])
+# XYM
+point_m = shapely.from_wkt("POINT M (2 3 5)")
+line_string_m = shapely.from_wkt("LINESTRING M (0 0 1, 1 0 2, 1 1 3)")
+linear_ring_m = shapely.from_wkt("LINEARRING M (0 0 1, 1 0 2, 1 1 3, 0 1 2, 0 0 1)")
+polygon_m = shapely.from_wkt("POLYGON M ((0 0 1, 2 0 2, 2 2 3, 0 2 2, 0 0 1))")
+polygon_with_hole_m = shapely.from_wkt(
+    """POLYGON M ((0 0 1, 0 10 2, 10 10 3, 10 0 2, 0 0 1),
+                  (2 2 6, 2 4 5, 4 4 4, 4 2 5, 2 2 6))"""
+)
+multi_point_m = shapely.from_wkt("MULTIPOINT M ((0 0 3), (1 2 5))")
+multi_line_string_m = shapely.from_wkt("MULTILINESTRING M ((0 0 3, 1 2 5))")
+multi_polygon_m = shapely.from_wkt(
+    """MULTIPOLYGON M (((0 0 1, 2 0 2, 2 2 3, 0 2 2, 0 0 1)),
+       ((2.1 2.1 1.1, 2.2 2.1 1.2, 2.2 2.2 1.3, 2.1 2.2 1.4, 2.1 2.1 1.1)))"""
+)
+geometry_collection_m = shapely.GeometryCollection([point_m, line_string_m])
+empty_geometry_collection_m = shapely.from_wkt("GEOMETRYCOLLECTION M EMPTY")
+empty_point_m = shapely.from_wkt("POINT M EMPTY")
+empty_line_string_m = shapely.from_wkt("LINESTRING M EMPTY")
+empty_polygon_m = shapely.from_wkt("POLYGON M EMPTY")
+empty_multi_point_m = shapely.from_wkt("MULTIPOINT M EMPTY")
+empty_multi_line_string_m = shapely.from_wkt("MULTILINESTRING M EMPTY")
+empty_multi_polygon_m = shapely.from_wkt("MULTIPOLYGON M EMPTY")
+multi_point_empty_m = shapely.multipoints([empty_point_m])
+multi_line_stringt_empty_m = shapely.multilinestrings([empty_line_string_m])
+multi_polygon_empty_m = shapely.multipolygons([empty_polygon_m])
+geometry_collection_empty_m = shapely.geometrycollections([empty_line_string_m])
+# XYZM
+point_zm = shapely.from_wkt("POINT ZM (2 3 4 5)")
+line_string_zm = shapely.from_wkt("LINESTRING ZM (0 0 4 1, 1 0 4 2, 1 1 4 3)")
+linear_ring_zm = shapely.from_wkt(
+    "LINEARRING ZM (0 0 1 8, 1 0 2 7, 1 1 3 6, 0 1 2 9, 0 0 1 8)"
+)
+polygon_zm = shapely.from_wkt(
+    "POLYGON ZM ((0 0 4 1, 2 0 4 2, 2 2 4 3, 0 2 4 2, 0 0 4 1))"
+)
+polygon_with_hole_zm = shapely.from_wkt(
+    """POLYGON ZM ((0 0 4 1, 0 10 4 2, 10 10 4 3, 10 0 4 2, 0 0 4 1),
+       (2 2 4 6, 2 4 4 5, 4 4 4 4, 4 2 4 5, 2 2 4 6))"""
+)
+multi_point_zm = shapely.from_wkt("MULTIPOINT ZM ((0 0 4 3), (1 2 4 5))")
+multi_line_string_zm = shapely.from_wkt("MULTILINESTRING ZM ((0 0 4 3, 1 2 4 5))")
+multi_polygon_zm = shapely.from_wkt(
+    """MULTIPOLYGON ZM (((0 0 4 1, 2 0 4 2, 2 2 4 3, 0 2 4 2, 0 0 4 1)),
+       ((2.1 2.1 4 1.1, 2.2 2.1 4 1.2, 2.2 2.2 4 1.3, 2.1 2.2 4 1.4, 2.1 2.1 4 1.1)))"""
+)
+geometry_collection_zm = shapely.GeometryCollection([point_zm, line_string_zm])
+empty_geometry_collection_zm = shapely.from_wkt("GEOMETRYCOLLECTION ZM EMPTY")
+empty_point_zm = shapely.from_wkt("POINT ZM EMPTY")
+empty_line_string_zm = shapely.from_wkt("LINESTRING ZM EMPTY")
+empty_polygon_zm = shapely.from_wkt("POLYGON ZM EMPTY")
+empty_multi_point_zm = shapely.from_wkt("MULTIPOINT ZM EMPTY")
+empty_multi_line_string_zm = shapely.from_wkt("MULTILINESTRING ZM EMPTY")
+empty_multi_polygon_zm = shapely.from_wkt("MULTIPOLYGON ZM EMPTY")
+multi_point_empty_zm = shapely.multipoints([empty_point_zm])
+multi_line_stringt_empty_zm = shapely.multilinestrings([empty_line_string_zm])
+multi_polygon_empty_zm = shapely.multipolygons([empty_polygon_zm])
+geometry_collection_empty_zm = shapely.geometrycollections([empty_line_string_zm])
 
 all_types = (
     point,
@@ -121,6 +179,50 @@ all_types_z = (
     multi_line_stringt_empty_z,
     multi_polygon_empty_z,
     geometry_collection_empty_z,
+)
+all_types_m = (
+    point_m,
+    line_string_m,
+    linear_ring_m,
+    polygon_m,
+    polygon_with_hole_m,
+    multi_point_m,
+    multi_line_string_m,
+    multi_polygon_m,
+    geometry_collection_m,
+    empty_geometry_collection_m,
+    empty_point_m,
+    empty_line_string_m,
+    empty_polygon_m,
+    empty_multi_point_m,
+    empty_multi_line_string_m,
+    empty_multi_polygon_m,
+    multi_point_empty_m,
+    multi_line_stringt_empty_m,
+    multi_polygon_empty_m,
+    geometry_collection_empty_m,
+)
+all_types_zm = (
+    point_zm,
+    line_string_zm,
+    linear_ring_zm,
+    polygon_zm,
+    polygon_with_hole_zm,
+    multi_point_zm,
+    multi_line_string_zm,
+    multi_polygon_zm,
+    geometry_collection_zm,
+    empty_geometry_collection_zm,
+    empty_point_zm,
+    empty_line_string_zm,
+    empty_polygon_zm,
+    empty_multi_point_zm,
+    empty_multi_line_string_zm,
+    empty_multi_polygon_zm,
+    multi_point_empty_zm,
+    multi_line_stringt_empty_zm,
+    multi_polygon_empty_zm,
+    geometry_collection_empty_zm,
 )
 
 

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -584,7 +584,9 @@ def test_repr_point_z_empty():
     assert repr(empty_point_z) == "<POINT Z EMPTY>"
 
 
-@pytest.mark.xfail(reason="TODO: fix WKT for empty M and ZM geometries", strict=True)
+@pytest.mark.xfail(
+    reason="TODO: fix WKT for empty M and ZM geometries; see GH-2004", strict=True
+)
 @pytest.mark.skipif(
     shapely.geos_version < (3, 12, 0),
     reason="M coordinates not supported with GEOS < 3.12",
@@ -951,10 +953,6 @@ def test_to_wkb_point_empty_zm(geom, expected):
     assert np.isnan(struct.unpack("<4d", actual[header_length:])).all()
 
 
-@pytest.mark.xfail(
-    shapely.geos_version < (3, 8, 0),
-    reason="GEOS<3.8 always outputs 3D empty points if output_dimension=3",
-)
 @pytest.mark.parametrize(
     "geom,expected",
     [
@@ -1092,7 +1090,7 @@ def test_pickle_z(geom):
 @pytest.mark.parametrize("geom", all_types_m)
 def test_pickle_m(geom):
     if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
-        pytest.xfail("TODO: M gets dropped for some reason")
+        pytest.xfail("TODO: M gets dropped for LinearRing types; see GH-2005")
     pickled = pickle.dumps(geom)
     actual = pickle.loads(pickled)
     assert_geometries_equal(actual, geom, tolerance=0)
@@ -1107,7 +1105,7 @@ def test_pickle_m(geom):
 @pytest.mark.parametrize("geom", all_types_zm)
 def test_pickle_zm(geom):
     if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
-        pytest.xfail("TODO: ZM gets dropped for some reason")
+        pytest.xfail("TODO: ZM gets dropped for LinearRing types; see GH-2005")
     pickled = pickle.dumps(geom)
     actual = pickle.loads(pickled)
     assert_geometries_equal(actual, geom, tolerance=0)

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -21,29 +21,51 @@ from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 from shapely.tests.common import (
     all_types,
+    all_types_m,
     all_types_z,
+    all_types_zm,
     empty_point,
+    empty_point_m,
     empty_point_z,
+    empty_point_zm,
     equal_geometries_abnormally_yield_unequal,
     multi_point_empty,
+    multi_point_empty_m,
     multi_point_empty_z,
+    multi_point_empty_zm,
     point,
+    point_m,
     point_z,
+    point_zm,
     polygon_z,
 )
 
 EWKBZ = 0x80000000
+EWKBM = 0x40000000
+EWKBZM = EWKBZ | EWKBM
 ISOWKBZ = 1000
+ISOWKBM = 2000
+ISOWKBZM = ISOWKBZ + ISOWKBM
 POINT11_WKB = struct.pack("<BI2d", 1, 1, 1.0, 1.0)
 NAN = struct.pack("<d", float("nan"))
 POINT_NAN_WKB = struct.pack("<BI", 1, 1) + (NAN * 2)
 POINTZ_NAN_WKB = struct.pack("<BI", 1, 1 | EWKBZ) + (NAN * 3)
+POINTM_NAN_WKB = struct.pack("<BI", 1, 1 | EWKBM) + (NAN * 3)
+POINTZM_NAN_WKB = struct.pack("<BI", 1, 1 | EWKBZM) + (NAN * 4)
 MULTIPOINT_NAN_WKB = struct.pack("<BII", 1, 4, 1) + POINT_NAN_WKB
 MULTIPOINTZ_NAN_WKB = struct.pack("<BII", 1, 4 | EWKBZ, 1) + POINTZ_NAN_WKB
+MULTIPOINTM_NAN_WKB = struct.pack("<BII", 1, 4 | EWKBM, 1) + POINTM_NAN_WKB
+MULTIPOINTZM_NAN_WKB = struct.pack("<BII", 1, 4 | EWKBZM, 1) + POINTZM_NAN_WKB
 GEOMETRYCOLLECTION_NAN_WKB = struct.pack("<BII", 1, 7, 1) + POINT_NAN_WKB
 GEOMETRYCOLLECTIONZ_NAN_WKB = struct.pack("<BII", 1, 7 | EWKBZ, 1) + POINTZ_NAN_WKB
+GEOMETRYCOLLECTIONM_NAN_WKB = struct.pack("<BII", 1, 7 | EWKBM, 1) + POINTM_NAN_WKB
+GEOMETRYCOLLECTIONZM_NAN_WKB = struct.pack("<BII", 1, 7 | EWKBZM, 1) + POINTZM_NAN_WKB
 NESTED_COLLECTION_NAN_WKB = struct.pack("<BII", 1, 7, 1) + MULTIPOINT_NAN_WKB
 NESTED_COLLECTIONZ_NAN_WKB = struct.pack("<BII", 1, 7 | EWKBZ, 1) + MULTIPOINTZ_NAN_WKB
+NESTED_COLLECTIONM_NAN_WKB = struct.pack("<BII", 1, 7 | EWKBM, 1) + MULTIPOINTM_NAN_WKB
+NESTED_COLLECTIONZM_NAN_WKB = (
+    struct.pack("<BII", 1, 7 | EWKBZM, 1) + MULTIPOINTZM_NAN_WKB
+)
 INVALID_WKB = "01030000000100000002000000507daec600b1354100de02498e5e3d41306ea321fcb03541a011a53d905e3d41"
 
 GEOJSON_GEOMETRY = json.dumps({"type": "Point", "coordinates": [125.6, 10.1]}, indent=4)
@@ -289,6 +311,36 @@ def test_from_wkb_all_types_z(geom, use_hex, byte_order):
     assert_geometries_equal(actual, geom)
 
 
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize("geom", all_types_m)
+@pytest.mark.parametrize("use_hex", [False, True])
+@pytest.mark.parametrize("byte_order", [0, 1])
+def test_from_wkb_all_types_m(geom, use_hex, byte_order):
+    if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
+        pytest.skip("Linearrings are not preserved in WKB")
+    wkb = shapely.to_wkb(geom, hex=use_hex, byte_order=byte_order)
+    actual = shapely.from_wkb(wkb)
+    assert_geometries_equal(actual, geom)
+
+
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize("geom", all_types_zm)
+@pytest.mark.parametrize("use_hex", [False, True])
+@pytest.mark.parametrize("byte_order", [0, 1])
+def test_from_wkb_all_types_zm(geom, use_hex, byte_order):
+    if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
+        pytest.skip("Linearrings are not preserved in WKB")
+    wkb = shapely.to_wkb(geom, hex=use_hex, byte_order=byte_order)
+    actual = shapely.from_wkb(wkb)
+    assert_geometries_equal(actual, geom)
+
+
 @pytest.mark.parametrize(
     "geom",
     (Point(), LineString(), Polygon(), GeometryCollection()),
@@ -320,6 +372,42 @@ def test_to_wkt_z():
     assert shapely.to_wkt(point, output_dimension=2) == "POINT (1 2)"
     assert shapely.to_wkt(point, output_dimension=3) == "POINT Z (1 2 3)"
     assert shapely.to_wkt(point, old_3d=True) == "POINT (1 2 3)"
+
+    if shapely.geos_version >= (3, 12, 0):
+        assert shapely.to_wkt(point, output_dimension=4) == "POINT Z (1 2 3)"
+
+
+def test_to_wkt_m():
+    point = shapely.from_wkt("POINT M (1 2 4)")
+
+    assert shapely.to_wkt(point, output_dimension=2) == "POINT (1 2)"
+
+    if shapely.geos_version < (3, 12, 0):
+        # previous behavior was to incorrectly parse M as Z
+        assert shapely.to_wkt(point) == "POINT Z (1 2 4)"
+        assert shapely.to_wkt(point, output_dimension=3) == "POINT Z (1 2 4)"
+        assert shapely.to_wkt(point, old_3d=True) == "POINT (1 2 4)"
+    else:
+        assert shapely.to_wkt(point) == "POINT M (1 2 4)"
+        assert shapely.to_wkt(point, output_dimension=3) == "POINT M (1 2 4)"
+        assert shapely.to_wkt(point, output_dimension=4) == "POINT M (1 2 4)"
+        assert shapely.to_wkt(point, old_3d=True) == "POINT M (1 2 4)"
+
+
+def test_to_wkt_zm():
+    point = shapely.from_wkt("POINT ZM (1 2 3 4)")
+
+    assert shapely.to_wkt(point, output_dimension=2) == "POINT (1 2)"
+    assert shapely.to_wkt(point, output_dimension=3) == "POINT Z (1 2 3)"
+
+    if shapely.geos_version < (3, 12, 0):
+        # previous behavior was to parse and ignore M
+        assert shapely.to_wkt(point) == "POINT Z (1 2 3)"
+        assert shapely.to_wkt(point, old_3d=True) == "POINT (1 2 3)"
+    else:
+        assert shapely.to_wkt(point) == "POINT ZM (1 2 3 4)"
+        assert shapely.to_wkt(point, output_dimension=4) == "POINT ZM (1 2 3 4)"
+        assert shapely.to_wkt(point, old_3d=True) == "POINT (1 2 3 4)"
 
 
 def test_to_wkt_none():
@@ -461,6 +549,15 @@ def test_repr():
     assert repr(point_z) == "<POINT Z (2 3 4)>"
 
 
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+def test_repr_m():
+    assert repr(point_m) == "<POINT M (2 3 5)>"
+    assert repr(point_zm) == "<POINT ZM (2 3 4 5)>"
+
+
 def test_repr_max_length():
     # the repr is limited to 80 characters
     geom = shapely.linestrings(np.arange(1000), np.arange(1000))
@@ -487,6 +584,16 @@ def test_repr_point_z_empty():
     assert repr(empty_point_z) == "<POINT Z EMPTY>"
 
 
+@pytest.mark.xfail(reason="TODO: fix WKT for empty M and ZM geometries", strict=True)
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+def test_repr_point_m_empty():
+    assert repr(empty_point_m) == "<POINT M EMPTY>"
+    assert repr(empty_point_zm) == "<POINT ZM EMPTY>"
+
+
 def test_to_wkb():
     point = shapely.points(1, 1)
     actual = shapely.to_wkb(point, byte_order=1)
@@ -511,6 +618,45 @@ def test_to_wkb_z():
     assert shapely.to_wkb(point, byte_order=1) == expected_wkb_z
     assert shapely.to_wkb(point, output_dimension=2, byte_order=1) == expected_wkb
     assert shapely.to_wkb(point, output_dimension=3, byte_order=1) == expected_wkb_z
+    if shapely.geos_version >= (3, 12, 0):
+        assert shapely.to_wkb(point, output_dimension=4, byte_order=1) == expected_wkb_z
+
+
+def test_to_wkb_m():
+    # POINT M (1 2 4)
+    point = shapely.from_wkb(struct.pack("<BI3d", 1, 1 | EWKBM, 1.0, 2.0, 4.0))
+
+    expected_wkb = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
+    expected_wkb_m = struct.pack("<BI3d", 1, 1 | EWKBM, 1.0, 2.0, 4.0)
+    if shapely.geos_version < (3, 12, 0):
+        # previous behavior was to ignore M, treat as 2D
+        expected_wkb_m = expected_wkb
+
+    assert shapely.to_wkb(point, byte_order=1) == expected_wkb_m
+    assert shapely.to_wkb(point, output_dimension=2, byte_order=1) == expected_wkb
+    assert shapely.to_wkb(point, output_dimension=3, byte_order=1) == expected_wkb_m
+    if shapely.geos_version >= (3, 12, 0):
+        assert shapely.to_wkb(point, output_dimension=4, byte_order=1) == expected_wkb_m
+
+
+def test_to_wkb_zm():
+    # POINT ZM (1 2 3 4)
+    point = shapely.from_wkb(struct.pack("<BI4d", 1, 1 | EWKBZM, 1.0, 2.0, 3.0, 4.0))
+
+    expected_wkb = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
+    expected_wkb_z = struct.pack("<BI3d", 1, 1 | EWKBZ, 1.0, 2.0, 3.0)
+    expected_wkb_zm = struct.pack("<BI4d", 1, 1 | EWKBZM, 1.0, 2.0, 3.0, 4.0)
+    if shapely.geos_version < (3, 12, 0):
+        # previous behavior was to ignore M, treat as XYZ
+        expected_wkb_zm = expected_wkb_z
+
+    assert shapely.to_wkb(point, byte_order=1) == expected_wkb_zm
+    assert shapely.to_wkb(point, output_dimension=2, byte_order=1) == expected_wkb
+    assert shapely.to_wkb(point, output_dimension=3, byte_order=1) == expected_wkb_z
+    if shapely.geos_version >= (3, 12, 0):
+        assert (
+            shapely.to_wkb(point, output_dimension=4, byte_order=1) == expected_wkb_zm
+        )
 
 
 def test_to_wkb_none():
@@ -570,6 +716,24 @@ def test_to_wkb_flavor():
     assert actual.hex()[2:10] == struct.pack("<I", 1 | ISOWKBZ).hex()
 
 
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+def test_to_wkb_m_flavor():
+    # XYM
+    actual = shapely.to_wkb(point_m, byte_order=1)  # default "extended"
+    assert actual.hex()[2:10] == struct.pack("<I", 1 | EWKBM).hex()
+    actual = shapely.to_wkb(point_m, byte_order=1, flavor="iso")
+    assert actual.hex()[2:10] == struct.pack("<I", 1 | ISOWKBM).hex()
+
+    # XYZM
+    actual = shapely.to_wkb(point_zm, byte_order=1)  # default "extended"
+    assert actual.hex()[2:10] == struct.pack("<I", 1 | EWKBZM).hex()
+    actual = shapely.to_wkb(point_zm, byte_order=1, flavor="iso")
+    assert actual.hex()[2:10] == struct.pack("<I", 1 | ISOWKBZM).hex()
+
+
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10.0")
 def test_to_wkb_flavor_srid():
     with pytest.raises(ValueError, match="cannot be used together"):
@@ -587,6 +751,8 @@ def test_to_wkb_flavor_unsupported_geos():
     [
         pytest.param(empty_point, POINT_NAN_WKB, id="POINT EMPTY"),
         pytest.param(empty_point_z, POINT_NAN_WKB, id="POINT Z EMPTY"),
+        pytest.param(empty_point_m, POINT_NAN_WKB, id="POINT M EMPTY"),
+        pytest.param(empty_point_zm, POINT_NAN_WKB, id="POINT ZM EMPTY"),
         pytest.param(
             multi_point_empty,
             MULTIPOINT_NAN_WKB,
@@ -596,6 +762,16 @@ def test_to_wkb_flavor_unsupported_geos():
             multi_point_empty_z,
             MULTIPOINT_NAN_WKB,
             id="MULTIPOINT Z EMPTY",
+        ),
+        pytest.param(
+            multi_point_empty_m,
+            MULTIPOINT_NAN_WKB,
+            id="MULTIPOINT M EMPTY",
+        ),
+        pytest.param(
+            multi_point_empty_zm,
+            MULTIPOINT_NAN_WKB,
+            id="MULTIPOINT ZM EMPTY",
         ),
         pytest.param(
             shapely.geometrycollections([empty_point]),
@@ -608,6 +784,16 @@ def test_to_wkb_flavor_unsupported_geos():
             id="GEOMETRYCOLLECTION (POINT Z EMPTY)",
         ),
         pytest.param(
+            shapely.geometrycollections([empty_point_m]),
+            GEOMETRYCOLLECTION_NAN_WKB,
+            id="GEOMETRYCOLLECTION (POINT M EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([empty_point_zm]),
+            GEOMETRYCOLLECTION_NAN_WKB,
+            id="GEOMETRYCOLLECTION (POINT ZM EMPTY)",
+        ),
+        pytest.param(
             shapely.geometrycollections([multi_point_empty]),
             NESTED_COLLECTION_NAN_WKB,
             id="GEOMETRYCOLLECTION (MULTIPOINT EMPTY)",
@@ -616,6 +802,16 @@ def test_to_wkb_flavor_unsupported_geos():
             shapely.geometrycollections([multi_point_empty_z]),
             NESTED_COLLECTION_NAN_WKB,
             id="GEOMETRYCOLLECTION (MULTIPOINT Z EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([multi_point_empty_m]),
+            NESTED_COLLECTION_NAN_WKB,
+            id="GEOMETRYCOLLECTION (MULTIPOINT M EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([multi_point_empty_zm]),
+            NESTED_COLLECTION_NAN_WKB,
+            id="GEOMETRYCOLLECTION (MULTIPOINT ZM EMPTY)",
         ),
     ],
 )
@@ -639,10 +835,16 @@ def test_to_wkb_point_empty_2d(geom, expected):
     "geom,expected",
     [
         pytest.param(empty_point_z, POINTZ_NAN_WKB, id="POINT Z EMPTY"),
+        pytest.param(empty_point_zm, POINTZ_NAN_WKB, id="POINT ZM EMPTY"),
         pytest.param(
             multi_point_empty_z,
             MULTIPOINTZ_NAN_WKB,
             id="MULTIPOINT Z EMPTY",
+        ),
+        pytest.param(
+            multi_point_empty_zm,
+            MULTIPOINTZ_NAN_WKB,
+            id="MULTIPOINT ZM EMPTY",
         ),
         pytest.param(
             shapely.geometrycollections([empty_point_z]),
@@ -650,9 +852,19 @@ def test_to_wkb_point_empty_2d(geom, expected):
             id="GEOMETRYCOLLECTION (POINT Z EMPTY)",
         ),
         pytest.param(
+            shapely.geometrycollections([empty_point_zm]),
+            GEOMETRYCOLLECTIONZ_NAN_WKB,
+            id="GEOMETRYCOLLECTION (POINT ZM EMPTY)",
+        ),
+        pytest.param(
             shapely.geometrycollections([multi_point_empty_z]),
             NESTED_COLLECTIONZ_NAN_WKB,
             id="GEOMETRYCOLLECTION (MULTIPOINT Z EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([multi_point_empty_zm]),
+            NESTED_COLLECTIONZ_NAN_WKB,
+            id="GEOMETRYCOLLECTION (MULTIPOINT ZM EMPTY)",
         ),
     ],
 )
@@ -669,6 +881,80 @@ def test_to_wkb_point_empty_z(geom, expected):
     assert np.isnan(struct.unpack("<3d", actual[header_length:])).all()
 
 
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize(
+    "geom,expected",
+    [
+        pytest.param(empty_point_m, POINTM_NAN_WKB, id="POINT M EMPTY"),
+        pytest.param(
+            multi_point_empty_m,
+            MULTIPOINTM_NAN_WKB,
+            id="MULTIPOINT M EMPTY",
+        ),
+        pytest.param(
+            shapely.geometrycollections([empty_point_m]),
+            GEOMETRYCOLLECTIONM_NAN_WKB,
+            id="GEOMETRYCOLLECTION (POINT M EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([multi_point_empty_m]),
+            NESTED_COLLECTIONM_NAN_WKB,
+            id="GEOMETRYCOLLECTION (MULTIPOINT M EMPTY)",
+        ),
+    ],
+)
+def test_to_wkb_point_empty_m(geom, expected):
+    actual = shapely.to_wkb(geom, output_dimension=3, byte_order=1)
+    # Split 'actual' into header and coordinates
+    coordinate_length = 8 * 3
+    header_length = len(expected) - coordinate_length
+    assert len(actual) == header_length + coordinate_length
+    assert actual[:header_length] == expected[:header_length]
+    assert np.isnan(struct.unpack("<3d", actual[header_length:])).all()
+
+
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize(
+    "geom,expected",
+    [
+        pytest.param(empty_point_zm, POINTZM_NAN_WKB, id="POINT ZM EMPTY"),
+        pytest.param(
+            multi_point_empty_zm,
+            MULTIPOINTZM_NAN_WKB,
+            id="MULTIPOINT ZM EMPTY",
+        ),
+        pytest.param(
+            shapely.geometrycollections([empty_point_zm]),
+            GEOMETRYCOLLECTIONZM_NAN_WKB,
+            id="GEOMETRYCOLLECTION (POINT ZM EMPTY)",
+        ),
+        pytest.param(
+            shapely.geometrycollections([multi_point_empty_zm]),
+            NESTED_COLLECTIONZM_NAN_WKB,
+            id="GEOMETRYCOLLECTION (MULTIPOINT ZM EMPTY)",
+        ),
+    ],
+)
+def test_to_wkb_point_empty_zm(geom, expected):
+    actual = shapely.to_wkb(geom, output_dimension=4, byte_order=1)
+    # Split 'actual' into header and coordinates
+    coordinate_length = 8 * 4
+    header_length = len(expected) - coordinate_length
+    assert len(actual) == header_length + coordinate_length
+    assert actual[:header_length] == expected[:header_length]
+    assert np.isnan(struct.unpack("<4d", actual[header_length:])).all()
+
+
+@pytest.mark.xfail(
+    shapely.geos_version < (3, 8, 0),
+    reason="GEOS<3.8 always outputs 3D empty points if output_dimension=3",
+)
 @pytest.mark.parametrize(
     "geom,expected",
     [
@@ -724,6 +1010,54 @@ def test_from_wkb_point_empty(wkb, expected_type, expected_dim):
         assert shapely.get_coordinate_dimension(geom) == expected_dim
 
 
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize(
+    "wkb,expected_type",
+    [
+        pytest.param(POINTM_NAN_WKB, 0, id="POINTM_NAN_WKB"),
+        pytest.param(MULTIPOINTM_NAN_WKB, 4, id="MULTIPOINTM_NAN_WKB"),
+        pytest.param(GEOMETRYCOLLECTIONM_NAN_WKB, 7, id="GEOMETRYCOLLECTIONM_NAN_WKB"),
+        pytest.param(NESTED_COLLECTIONM_NAN_WKB, 7, id="NESTED_COLLECTIONM_NAN_WKB"),
+    ],
+)
+def test_from_wkb_point_empty_m(wkb, expected_type):
+    geom = shapely.from_wkb(wkb)
+
+    assert shapely.is_empty(geom)
+    assert shapely.get_type_id(geom) == expected_type
+    assert shapely.get_coordinate_dimension(geom) == 3
+    assert not shapely.has_z(geom)
+    # TODO: assert shapely.has_m(geom)
+
+
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize(
+    "wkb,expected_type",
+    [
+        pytest.param(POINTZM_NAN_WKB, 0, id="POINTZM_NAN_WKB"),
+        pytest.param(MULTIPOINTZM_NAN_WKB, 4, id="MULTIPOINTZM_NAN_WKB"),
+        pytest.param(
+            GEOMETRYCOLLECTIONZM_NAN_WKB, 7, id="GEOMETRYCOLLECTIONZM_NAN_WKB"
+        ),
+        pytest.param(NESTED_COLLECTIONZM_NAN_WKB, 7, id="NESTED_COLLECTIONZM_NAN_WKB"),
+    ],
+)
+def test_from_wkb_point_empty_zm(wkb, expected_type):
+    geom = shapely.from_wkb(wkb)
+
+    assert shapely.is_empty(geom)
+    assert shapely.get_type_id(geom) == expected_type
+    assert shapely.get_coordinate_dimension(geom) == 4
+    assert shapely.has_z(geom)
+    # TODO: assert shapely.has_m(geom)
+
+
 def test_to_wkb_point_empty_srid():
     expected = shapely.set_srid(empty_point, 4236)
     wkb = shapely.to_wkb(expected, include_srid=True)
@@ -749,6 +1083,39 @@ def test_pickle_z(geom):
         pass  # GEOSHasZ with EMPTY geometries is inconsistent
     else:
         assert actual.has_z
+
+
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize("geom", all_types_m)
+def test_pickle_m(geom):
+    if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
+        pytest.xfail("TODO: M gets dropped for some reason")
+    pickled = pickle.dumps(geom)
+    actual = pickle.loads(pickled)
+    assert_geometries_equal(actual, geom, tolerance=0)
+    assert not actual.has_z
+    # TODO: assert actual.has_m
+
+
+@pytest.mark.skipif(
+    shapely.geos_version < (3, 12, 0),
+    reason="M coordinates not supported with GEOS < 3.12",
+)
+@pytest.mark.parametrize("geom", all_types_zm)
+def test_pickle_zm(geom):
+    if shapely.get_type_id(geom) == shapely.GeometryType.LINEARRING:
+        pytest.xfail("TODO: ZM gets dropped for some reason")
+    pickled = pickle.dumps(geom)
+    actual = pickle.loads(pickled)
+    assert_geometries_equal(actual, geom, tolerance=0)
+    if actual.is_empty:
+        pass  # GEOSHasZ with EMPTY geometries is inconsistent
+    else:
+        assert actual.has_z
+    # TODO: assert actual.has_m
 
 
 @pytest.mark.parametrize("geom", all_types + (point_z, empty_point))

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -49,11 +49,11 @@ def dumps(ob, trim=False, rounding_precision=-1, **kw):
         A geometry object of any type to be dumped to WKT.
     trim : bool, default False
         Remove excess decimals from the WKT.
-    rounding_precision : int
+    rounding_precision : int, default -1
         Round output to the specified number of digits.
         Default behavior returns full precision.
-    output_dimension : int, default 3
-        Force removal of dimensions above the one specified.
+    **kw : kwargs, optional
+        Keyword output options passed to :func:`~shapely.to_wkt`.
 
     Returns
     -------
@@ -72,13 +72,8 @@ def dump(ob, fp, **settings):
         A geometry object of any type to be dumped to WKT.
     fp :
         A file-like object which implements a `write` method.
-    trim : bool, default False
-        Remove excess decimals from the WKT.
-    rounding_precision : int
-        Round output to the specified number of digits.
-        Default behavior returns full precision.
-    output_dimension : int, default 3
-        Force removal of dimensions above the one specified.
+    **settings : kwargs, optional
+        Keyword output options passed to :func:`~shapely.wkt.dumps`.
 
     Returns
     -------

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -119,6 +119,8 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
 
   GEOSWKTWriter_setRoundingPrecision_r(ctx, writer, precision);
 #if !GEOS_SINCE_3_12_0
+  // Override defaults only for older versions
+  // See https://github.com/libgeos/geos/pull/915
   GEOSWKTWriter_setTrim_r(ctx, writer, trim);
   GEOSWKTWriter_setOutputDimension_r(ctx, writer, dimension);
   // GEOSWKTWriter_setOld3D_r(ctx, writer, use_old_3d);
@@ -183,6 +185,7 @@ static PyObject* GeometryObject_ToWKB(GeometryObject* obj) {
   }
 #if !GEOS_SINCE_3_12_0
   // Allow 3D output for GEOS<3.12 (it is default 4 afterwards)
+  // See https://github.com/libgeos/geos/pull/908
   GEOSWKBWriter_setOutputDimension_r(ctx, writer, 3);
 #endif  // !GEOS_SINCE_3_12_0
   // include SRID

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -72,8 +72,12 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
   GEOSGeometry* geom = obj->ptr;
   char trim = 1;
   int precision = 3;
+#if GEOS_SINCE_3_12_0
+  int dimension = 4;
+#else
   int dimension = 3;
-  int use_old_3d = 0;
+#endif
+  // int use_old_3d = 0;  // default is false
 
   if (geom == NULL) {
     Py_INCREF(Py_None);
@@ -114,9 +118,11 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
   }
 
   GEOSWKTWriter_setRoundingPrecision_r(ctx, writer, precision);
+#if !GEOS_SINCE_3_12_0
   GEOSWKTWriter_setTrim_r(ctx, writer, trim);
   GEOSWKTWriter_setOutputDimension_r(ctx, writer, dimension);
-  GEOSWKTWriter_setOld3D_r(ctx, writer, use_old_3d);
+  // GEOSWKTWriter_setOld3D_r(ctx, writer, use_old_3d);
+#endif  // !GEOS_SINCE_3_12_0
 
   // Check if the above functions caused a GEOS exception
   if (last_error[0] != 0) {
@@ -175,8 +181,11 @@ static PyObject* GeometryObject_ToWKB(GeometryObject* obj) {
     errstate = PGERR_GEOS_EXCEPTION;
     goto finish;
   }
-  // Allow 3D output and include SRID
+#if !GEOS_SINCE_3_12_0
+  // Allow 3D output for GEOS<3.12 (it is default 4 afterwards)
   GEOSWKBWriter_setOutputDimension_r(ctx, writer, 3);
+#endif  // !GEOS_SINCE_3_12_0
+  // include SRID
   GEOSWKBWriter_setIncludeSRID_r(ctx, writer, 1);
   // Check if the above functions caused a GEOS exception
   if (last_error[0] != 0) {


### PR DESCRIPTION
Working towards #1648 as a first step, to enable outputs with M or ZM dimensions. This requires GEOS 3.12+, which <s>is currently under development</s> was released 2023-06-27.

Earlier supported GEOS versions have always had limited support for reading these geometries:

- WKT will parse XYM geometries like `POINT M (1 2 4)` as XYZ, incorrectly interpreting M values as Z values
- WKT will parse XYZM geometries like `POINT ZM (1 2 3 4)` as XYZ, ignoring M values
- WKB will parse XYM geometries as XY, ignoring M values
- WKB will parse XYZM geometries as XYZ, ignoring M values

With GEOS 3.12+, the default `output_dimension` is adjusted from 3 to 4. Under the hood, this uses `GEOSWKBWriter_setOutputDimension_r` or `GEOSWKTWriter_setOutputDimension_r` to output XYZ, XYM or XYZM geometries.

I've flagged `test_repr_point_m_empty` is set to xfail, since `POINT M EMPTY` and `POINT ZM EMPTY` are incorrectly emitted as `POINT Z EMPTY`. This can be investigated/resolved later, as I'm aware there are workarounds in shapely to handle empty points.

Several of the tests were re-written to use more `struct` representations of binary strings, rather than raw binary strings. This was done to make them easier to read and modify.