### PR TITLE
REGR: fix __eq__ to not ignore z values

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
         # continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
           python -c "import shapely; print(f'GEOS version: {shapely.geos_version_string}')"
-          pytest shapely/tests -r a --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
+          pytest shapely/tests -r a -v -s --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
         # continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
           python -c "import shapely; print(f'GEOS version: {shapely.geos_version_string}')"
-          pytest shapely/tests -r a -v -s --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
+          pytest shapely/tests -r a --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,13 @@ Improvements:
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
   behaviour (allow) is backwards compatible (#1594).
 
+Version 2.0.2 (unreleased)
+--------------------------
+
+Bug fixes:
+
+- Fix regression in the (in)equality comparison (``geom1 == geom2``) using ``__eq__`` to
+  not ignore the z-coordinates (#1732).
 
 2.0.1 (2023-01-30)
 ------------------

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -13,6 +13,15 @@ Improvements:
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
   behaviour (allow) is backwards compatible (#1594).
 
+.. _version-2-0-2:
+
+Version 2.0.2 (unreleased)
+--------------------------
+
+Bug fixes:
+
+- Fix regression in the (in)equality comparison (``geom1 == geom2``) using ``__eq__`` to
+  not ignore the z-coordinates (#1732).
 
 .. _version-2-0-1:
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -201,6 +201,7 @@ class BaseGeometry(shapely.Geometry):
         if not isinstance(other, BaseGeometry):
             return NotImplemented
         # equal_nan=False is the default, but not yet available for older numpy
+        # TODO updated once we require numpy >= 1.19
         return type(other) == type(self) and np.array_equal(
             self.coords, other.coords  # , equal_nan=False
         )

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -200,7 +200,9 @@ class BaseGeometry(shapely.Geometry):
     def __eq__(self, other):
         if not isinstance(other, BaseGeometry):
             return NotImplemented
-        return type(other) == type(self) and tuple(self.coords) == tuple(other.coords)
+        return type(other) == type(self) and np.array_equal(
+            self.coords, other.coords, equal_nan=False
+        )
 
     def __ne__(self, other):
         if not isinstance(other, BaseGeometry):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -939,7 +939,7 @@ class BaseMultipartGeometry(BaseGeometry):
         return (
             type(other) == type(self)
             and len(self.geoms) == len(other.geoms)
-            and all(x == y for x, y in zip(self.geoms, other.geoms))
+            and all(a == b for a, b in zip(self.geoms, other.geoms))
         )
 
     def __hash__(self):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -197,6 +197,19 @@ class BaseGeometry(shapely.Geometry):
     def __xor__(self, other):
         return self.symmetric_difference(other)
 
+    def __eq__(self, other):
+        if not isinstance(other, BaseGeometry):
+            return NotImplemented
+        return type(other) == type(self) and tuple(self.coords) == tuple(other.coords)
+
+    def __ne__(self, other):
+        if not isinstance(other, BaseGeometry):
+            return NotImplemented
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return super().__hash__()
+
     # Coordinate access
     # -----------------
 
@@ -916,6 +929,18 @@ class BaseMultipartGeometry(BaseGeometry):
 
     def __bool__(self):
         return self.is_empty is False
+
+    def __eq__(self, other):
+        if not isinstance(other, BaseGeometry):
+            return NotImplemented
+        return (
+            type(other) == type(self)
+            and len(self.geoms) == len(other.geoms)
+            and all(x == y for x, y in zip(self.geoms, other.geoms))
+        )
+
+    def __hash__(self):
+        return super().__hash__()
 
     def svg(self, scale_factor=1.0, color=None):
         """Returns a group of SVG elements for the multipart geometry.

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -200,8 +200,9 @@ class BaseGeometry(shapely.Geometry):
     def __eq__(self, other):
         if not isinstance(other, BaseGeometry):
             return NotImplemented
+        # equal_nan=False is the default, but not yet available for older numpy
         return type(other) == type(self) and np.array_equal(
-            self.coords, other.coords, equal_nan=False
+            self.coords, other.coords  # , equal_nan=False
         )
 
     def __ne__(self, other):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -267,15 +267,20 @@ class Polygon(BaseGeometry):
             return True
         elif any(check_empty):
             return False
-        my_coords = [
-            tuple(self.exterior.coords),
-            [tuple(interior.coords) for interior in self.interiors],
+        my_coords = [self.exterior.coords] + [
+            interior.coords for interior in self.interiors
         ]
-        other_coords = [
-            tuple(other.exterior.coords),
-            [tuple(interior.coords) for interior in other.interiors],
+        other_coords = [other.exterior.coords] + [
+            interior.coords for interior in other.interiors
         ]
-        return my_coords == other_coords
+        if not len(my_coords) == len(other_coords):
+            return False
+        return np.all(
+            [
+                np.array_equal(left, right, equal_nan=False)
+                for left, right in zip(my_coords, other_coords)
+            ]
+        )
 
     def __hash__(self):
         return super().__hash__()

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -257,6 +257,29 @@ class Polygon(BaseGeometry):
             "Component rings have coordinate sequences, but the polygon does not"
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, BaseGeometry):
+            return NotImplemented
+        if not isinstance(other, Polygon):
+            return False
+        check_empty = (self.is_empty, other.is_empty)
+        if all(check_empty):
+            return True
+        elif any(check_empty):
+            return False
+        my_coords = [
+            tuple(self.exterior.coords),
+            [tuple(interior.coords) for interior in self.interiors],
+        ]
+        other_coords = [
+            tuple(other.exterior.coords),
+            [tuple(interior.coords) for interior in other.interiors],
+        ]
+        return my_coords == other_coords
+
+    def __hash__(self):
+        return super().__hash__()
+
     @property
     def __geo_interface__(self):
         if self.exterior == LinearRing():

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -275,9 +275,10 @@ class Polygon(BaseGeometry):
         ]
         if not len(my_coords) == len(other_coords):
             return False
+        # equal_nan=False is the default, but not yet available for older numpy
         return np.all(
             [
-                np.array_equal(left, right, equal_nan=False)
+                np.array_equal(left, right)  # , equal_nan=False)
                 for left, right in zip(my_coords, other_coords)
             ]
         )

--- a/shapely/tests/common.py
+++ b/shapely/tests/common.py
@@ -67,6 +67,19 @@ all_types = (
     empty,
 )
 
+all_types_z = (
+    point_z,
+    line_string_z,
+    polygon_z,
+    multi_point_z,
+    multi_line_string_z,
+    multi_polygon_z,
+    polygon_with_hole_z,
+    geometry_collection_z,
+    empty_point_z,
+    empty_line_string_z,
+)
+
 
 @contextmanager
 def ignore_invalid(condition=True):

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -3,7 +3,11 @@ import pytest
 
 import shapely
 from shapely import LinearRing, LineString, MultiLineString, Point, Polygon
-from shapely.tests.common import all_types, all_types_z
+from shapely.tests.common import all_types, all_types_z, ignore_invalid
+
+# pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
+
+pytestmark = pytest.mark.filterwarnings("error")
 
 
 @pytest.mark.parametrize("geom", all_types + all_types_z)
@@ -36,9 +40,8 @@ def test_equality_false(left, right):
     assert left != right
 
 
-@pytest.mark.parametrize(
-    "left, right",
-    [
+with ignore_invalid():
+    cases1 = [
         (LineString([(0, 1), (2, np.nan)]), LineString([(0, 1), (2, np.nan)])),
         (
             LineString([(0, 1), (np.nan, np.nan)]),
@@ -64,8 +67,10 @@ def test_equality_false(left, right):
         #     LineString([(0, 1, np.nan), (2, 3, 4)]),
         #     LineString([(0, 1, np.nan), (2, 3, 4)]),
         # ),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("left, right", cases1)
 def test_equality_with_nan(left, right):
     # TODO currently those evaluate as not equal, but we are considering to change this
     # assert left == right
@@ -74,9 +79,8 @@ def test_equality_with_nan(left, right):
     assert left != right
 
 
-@pytest.mark.parametrize(
-    "left, right",
-    [
+with ignore_invalid():
+    cases2 = [
         (
             LineString([(0, 1, np.nan), (2, 3, np.nan)]),
             LineString([(0, 1, np.nan), (2, 3, np.nan)]),
@@ -85,8 +89,10 @@ def test_equality_with_nan(left, right):
             LineString([(0, 1, np.nan), (2, 3, 4)]),
             LineString([(0, 1, np.nan), (2, 3, 4)]),
         ),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("left, right", cases2)
 def test_equality_with_nan_z(left, right):
     # TODO: those are currently considered equal because z dimension is ignored
     if shapely.geos_version < (3, 12, 0):
@@ -97,29 +103,25 @@ def test_equality_with_nan_z(left, right):
         assert left != right
 
 
-@pytest.mark.parametrize(
-    "left, right",
-    [
+with ignore_invalid():
+    cases3 = [
         (LineString([(0, np.nan), (2, 3)]), LineString([(0, 1), (2, 3)])),
         (LineString([(0, 1), (2, np.nan)]), LineString([(0, 1), (2, 3)])),
         (LineString([(0, 1, np.nan), (2, 3, 4)]), LineString([(0, 1, 2), (2, 3, 4)])),
         (LineString([(0, 1, 2), (2, 3, np.nan)]), LineString([(0, 1, 2), (2, 3, 4)])),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("left, right", cases3)
 def test_equality_with_nan_false(left, right):
     assert left != right
 
 
-@pytest.mark.parametrize(
-    "left, right",
-    [
-        (
-            LineString([(0, 1, np.nan), (2, 3, np.nan)]),
-            LineString([(0, 1, np.nan), (2, 3, 4)]),
-        ),
-    ],
-)
-def test_equality_with_nan_z_false(left, right):
+def test_equality_with_nan_z_false():
+    with ignore_invalid():
+        left = LineString([(0, 1, np.nan), (2, 3, np.nan)])
+        right = LineString([(0, 1, np.nan), (2, 3, 4)])
+
     if shapely.geos_version < (3, 10, 0):
         # GEOS <= 3.9 fill the NaN with 0, so the z dimension is different
         # however, has_z still returns False, so z dimension is ignored in .coords

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -89,8 +89,12 @@ def test_equality_with_nan(left, right):
 )
 def test_equality_with_nan_z(left, right):
     # TODO: those are currently considered equal because z dimension is ignored
-    assert left == right
-    assert not (left != right)
+    if shapely.geos_version < (3, 12, 0):
+        assert left == right
+        assert not (left != right)
+    else:
+        # on GEOS main z dimension is not ignored -> NaNs cause inequality
+        assert left != right
 
 
 @pytest.mark.parametrize(
@@ -118,8 +122,9 @@ def test_equality_with_nan_false(left, right):
 def test_equality_with_nan_z_false(left, right):
     if shapely.geos_version < (3, 10, 0):
         # GEOS <= 3.9 fill the NaN with 0, so the z dimension is different
-        print(left.has_z, list(left.coords), right.has_z, list(right.coords))
-        assert left != right
+        # however, has_z still returns False, so z dimension is ignored in .coords
+        # assert left != right
+        assert left == right
     elif shapely.geos_version < (3, 12, 0):
         # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D
         # and so the geometries are considered as 2D (and thus z dimension is ignored)
@@ -138,7 +143,9 @@ def test_equality_z():
     geom2 = Point(0, 1, np.nan)
     if shapely.geos_version < (3, 8, 0):
         # GEOS < 3.8 fill the NaN with 0, so the z dimension is different
-        assert geom1 != geom2
+        # however, has_z still returns False, so z dimension is ignored in .coords
+        # assert geom1 != geom2
+        assert geom1 == geom2
     elif shapely.geos_version < (3, 12, 0):
         # older GEOS versions ignore NaN for Z also when explicitly created with 3D
         assert geom1 == geom2

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -1,0 +1,185 @@
+import numpy as np
+import pytest
+
+import shapely
+from shapely import LinearRing, LineString, MultiLineString, Point, Polygon
+from shapely.tests.common import all_types, all_types_z
+
+
+@pytest.mark.parametrize("geom", all_types + all_types_z)
+def test_equality(geom):
+    assert geom == geom
+    transformed = shapely.transform(geom, lambda x: x, include_z=True)
+    assert geom == transformed
+    assert not (geom != transformed)
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        # (slightly) different coordinate values
+        (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (1, 2)])),
+        (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (1, 1 + 1e-12)])),
+        # different coordinate order
+        (LineString([(0, 0), (1, 1)]), LineString([(1, 1), (0, 0)])),
+        # different number of coordinates (but spatially equal)
+        (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (1, 1), (1, 1)])),
+        (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (0.5, 0.5), (1, 1)])),
+        # different order of sub-geometries
+        (
+            MultiLineString([[(1, 1), (2, 2)], [(2, 2), (3, 3)]]),
+            MultiLineString([[(2, 2), (3, 3)], [(1, 1), (2, 2)]]),
+        ),
+    ],
+)
+def test_equality_false(left, right):
+    assert left != right
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (LineString([(0, 1), (2, np.nan)]), LineString([(0, 1), (2, np.nan)])),
+        (
+            LineString([(0, 1), (np.nan, np.nan)]),
+            LineString([(0, 1), (np.nan, np.nan)]),
+        ),
+        (LineString([(np.nan, 1), (2, 3)]), LineString([(np.nan, 1), (2, 3)])),
+        (LineString([(0, np.nan), (2, 3)]), LineString([(0, np.nan), (2, 3)])),
+        (
+            LineString([(np.nan, np.nan), (np.nan, np.nan)]),
+            LineString([(np.nan, np.nan), (np.nan, np.nan)]),
+        ),
+        # NaN as explicit Z coordinate
+        # TODO: if first z is NaN -> considered as 2D -> tested below explicitly
+        # (
+        #     LineString([(0, 1, np.nan), (2, 3, np.nan)]),
+        #     LineString([(0, 1, np.nan), (2, 3, np.nan)]),
+        # ),
+        (
+            LineString([(0, 1, 2), (2, 3, np.nan)]),
+            LineString([(0, 1, 2), (2, 3, np.nan)]),
+        ),
+        # (
+        #     LineString([(0, 1, np.nan), (2, 3, 4)]),
+        #     LineString([(0, 1, np.nan), (2, 3, 4)]),
+        # ),
+    ],
+)
+def test_equality_with_nan(left, right):
+    # TODO currently those evaluate as not equal, but we are considering to change this
+    # assert left == right
+    assert not (left == right)
+    # assert not (left != right)
+    assert left != right
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (
+            LineString([(0, 1, np.nan), (2, 3, np.nan)]),
+            LineString([(0, 1, np.nan), (2, 3, np.nan)]),
+        ),
+        (
+            LineString([(0, 1, np.nan), (2, 3, 4)]),
+            LineString([(0, 1, np.nan), (2, 3, 4)]),
+        ),
+    ],
+)
+def test_equality_with_nan_z(left, right):
+    # TODO: those are currently considered equal because z dimension is ignored
+    assert left == right
+    assert not (left != right)
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (LineString([(0, np.nan), (2, 3)]), LineString([(0, 1), (2, 3)])),
+        (LineString([(0, 1), (2, np.nan)]), LineString([(0, 1), (2, 3)])),
+        (LineString([(0, 1, np.nan), (2, 3, 4)]), LineString([(0, 1, 2), (2, 3, 4)])),
+        (LineString([(0, 1, 2), (2, 3, np.nan)]), LineString([(0, 1, 2), (2, 3, 4)])),
+    ],
+)
+def test_equality_with_nan_false(left, right):
+    assert left != right
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (
+            LineString([(0, 1, np.nan), (2, 3, np.nan)]),
+            LineString([(0, 1, np.nan), (2, 3, 4)]),
+        ),
+    ],
+)
+def test_equality_with_nan_z_false(left, right):
+    if shapely.geos_version < (3, 10, 0):
+        # GEOS <= 3.9 fill the NaN with 0, so the z dimension is different
+        assert left != right
+    elif shapely.geos_version < (3, 12, 0):
+        # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D
+        # and so the geometries are considered as 2D (and thus z dimension is ignored)
+        assert left == right
+    else:
+        assert left != right
+
+
+def test_equality_z():
+    # different dimensionality
+    geom1 = Point(0, 1)
+    geom2 = Point(0, 1, 0)
+    assert geom1 != geom2
+
+    # different dimensionality with NaN z
+    geom2 = Point(0, 1, np.nan)
+    if shapely.geos_version < (3, 8, 0):
+        # GEOS < 3.8 fill the NaN with 0, so the z dimension is different
+        assert geom1 != geom2
+    elif shapely.geos_version < (3, 12, 0):
+        # older GEOS versions ignore NaN for Z also when explicitly created with 3D
+        assert geom1 == geom2
+    else:
+        assert geom1 != geom2
+
+
+def test_equality_exact_type():
+    # geometries with different type but same coord seq are not equal
+    geom1 = LineString([(0, 0), (1, 1), (0, 1), (0, 0)])
+    geom2 = LinearRing([(0, 0), (1, 1), (0, 1), (0, 0)])
+    geom3 = Polygon([(0, 0), (1, 1), (0, 1), (0, 0)])
+    assert geom1 != geom2
+    assert geom1 != geom3
+    assert geom2 != geom3
+
+    # empty with different type
+    geom1 = shapely.from_wkt("POINT EMPTY")
+    geom2 = shapely.from_wkt("LINESTRING EMPTY")
+    assert geom1 != geom2
+
+
+def test_equality_polygon():
+    # different exterior rings
+    geom1 = shapely.from_wkt("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))")
+    geom2 = shapely.from_wkt("POLYGON ((0 0, 10 0, 10 10, 0 15, 0 0))")
+    assert geom1 != geom2
+
+    # different number of holes
+    geom1 = shapely.from_wkt(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1))"
+    )
+    geom2 = shapely.from_wkt(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1), (3 3, 4 3, 4 4, 3 3))"
+    )
+    assert geom1 != geom2
+
+    # different order of holes
+    geom1 = shapely.from_wkt(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (3 3, 4 3, 4 4, 3 3), (1 1, 2 1, 2 2, 1 1))"
+    )
+    geom2 = shapely.from_wkt(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1), (3 3, 4 3, 4 4, 3 3))"
+    )
+    assert geom1 != geom2

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -211,3 +211,20 @@ def test_comparison_notimplemented(geom):
     result = geom != arr
     assert isinstance(result, np.ndarray)
     assert not result.any()
+
+
+def test_comparison_not_supported():
+    geom1 = Point(1, 1)
+    geom2 = Point(2, 2)
+
+    with pytest.raises(TypeError, match="not supported between instances"):
+        geom1 > geom2
+
+    with pytest.raises(TypeError, match="not supported between instances"):
+        geom1 < geom2
+
+    with pytest.raises(TypeError, match="not supported between instances"):
+        geom1 >= geom2
+
+    with pytest.raises(TypeError, match="not supported between instances"):
+        geom1 <= geom2

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -183,3 +183,31 @@ def test_equality_polygon():
         "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1), (3 3, 4 3, 4 4, 3 3))"
     )
     assert geom1 != geom2
+
+
+@pytest.mark.parametrize("geom", all_types)
+def test_comparison_notimplemented(geom):
+    # comparing to a non-geometry class should return NotImplemented in __eq__
+    # to ensure proper delegation to other (eg to ensure comparison of scalar
+    # with array works)
+    # https://github.com/shapely/shapely/issues/1056
+    assert geom.__eq__(1) is NotImplemented
+
+    # with array
+    arr = np.array([geom, geom], dtype=object)
+
+    result = arr == geom
+    assert isinstance(result, np.ndarray)
+    assert result.all()
+
+    result = geom == arr
+    assert isinstance(result, np.ndarray)
+    assert result.all()
+
+    result = arr != geom
+    assert isinstance(result, np.ndarray)
+    assert not result.any()
+
+    result = geom != arr
+    assert isinstance(result, np.ndarray)
+    assert not result.any()

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -118,6 +118,7 @@ def test_equality_with_nan_false(left, right):
 def test_equality_with_nan_z_false(left, right):
     if shapely.geos_version < (3, 10, 0):
         # GEOS <= 3.9 fill the NaN with 0, so the z dimension is different
+        print(left.has_z, list(left.coords), right.has_z, list(right.coords))
         assert left != right
     elif shapely.geos_version < (3, 12, 0):
         # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -5,10 +5,6 @@ import shapely
 from shapely import LinearRing, LineString, MultiLineString, Point, Polygon
 from shapely.tests.common import all_types, all_types_z, ignore_invalid
 
-# pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
-
-pytestmark = pytest.mark.filterwarnings("error")
-
 
 @pytest.mark.parametrize("geom", all_types + all_types_z)
 def test_equality(geom):
@@ -124,8 +120,8 @@ def test_equality_with_nan_z_false():
 
     if shapely.geos_version < (3, 10, 0):
         # GEOS <= 3.9 fill the NaN with 0, so the z dimension is different
-        # however, has_z still returns False, so z dimension is ignored in .coords
         # assert left != right
+        # however, has_z still returns False, so z dimension is ignored in .coords
         assert left == right
     elif shapely.geos_version < (3, 12, 0):
         # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D
@@ -143,13 +139,14 @@ def test_equality_z():
 
     # different dimensionality with NaN z
     geom2 = Point(0, 1, np.nan)
-    if shapely.geos_version < (3, 8, 0):
+    if shapely.geos_version < (3, 10, 0):
         # GEOS < 3.8 fill the NaN with 0, so the z dimension is different
-        # however, has_z still returns False, so z dimension is ignored in .coords
         # assert geom1 != geom2
+        # however, has_z still returns False, so z dimension is ignored in .coords
         assert geom1 == geom2
     elif shapely.geos_version < (3, 12, 0):
-        # older GEOS versions ignore NaN for Z also when explicitly created with 3D
+        # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D
+        # and so the geometries are considered as 2D (and thus z dimension is ignored)
         assert geom1 == geom2
     else:
         assert geom1 != geom2

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -62,34 +62,6 @@ def test_weakrefable(geom):
     _ = weakref.ref(geom)
 
 
-@pytest.mark.parametrize("geom", geometries_all_types)
-def test_comparison_notimplemented(geom):
-    # comparing to a non-geometry class should return NotImplemented in __eq__
-    # to ensure proper delegation to other (eg to ensure comparison of scalar
-    # with array works)
-    # https://github.com/shapely/shapely/issues/1056
-    assert geom.__eq__(1) is NotImplemented
-
-    # with array
-    arr = np.array([geom, geom], dtype=object)
-
-    result = arr == geom
-    assert isinstance(result, np.ndarray)
-    assert result.all()
-
-    result = geom == arr
-    assert isinstance(result, np.ndarray)
-    assert result.all()
-
-    result = arr != geom
-    assert isinstance(result, np.ndarray)
-    assert not result.any()
-
-    result = geom != arr
-    assert isinstance(result, np.ndarray)
-    assert not result.any()
-
-
 def test_base_class_not_callable():
     with pytest.raises(TypeError):
         shapely.Geometry("POINT (1 1)")

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -238,14 +238,6 @@ def test_set_unique(geom):
     assert len(a) == 1
 
 
-def test_eq_nan():
-    assert line_string_nan != line_string_nan
-
-
-def test_neq_nan():
-    assert not (line_string_nan == line_string_nan)
-
-
 def test_set_nan():
     # As NaN != NaN, you can have multiple "NaN" points in a set
     # set([float("nan"), float("nan")]) also returns a set with 2 elements


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/1732

Broken off from https://github.com/shapely/shapely/pull/1760, to just restore the previous behaviour (using the previous implementaiton) and already add the more extensive tests that I wrote for that PR. This way, the other PR can focus more on the API change.