### PR TITLE
TST: update parallel_offset (offset_curve) tests for GEOS main (minimum quad_segs of 8)

### DIFF
--- a/shapely/tests/legacy/test_parallel_offset.py
+++ b/shapely/tests/legacy/test_parallel_offset.py
@@ -30,21 +30,21 @@ class OperationsTestCase(unittest.TestCase):
 
         line2 = LineString([(0, 0), (5, 0), (5, -5)])
         assert_geometries_equal(
-            line2.parallel_offset(2, "left", resolution=1),
+            line2.parallel_offset(2, "left", join_style=3),
             LineString([(0, 2), (5, 2), (7, 0), (7, -5)]),
         )
         assert_geometries_equal(
-            line2.parallel_offset(2, "left", join_style=2, resolution=1),
+            line2.parallel_offset(2, "left", join_style=2),
             LineString([(0, 2), (7, 2), (7, -5)]),
         )
         # offset_curve alias
         assert_geometries_equal(
-            line1.offset_curve(2, quad_segs=1),
-            line1.parallel_offset(2, "left", resolution=1),
+            line1.offset_curve(2, quad_segs=10),
+            line1.parallel_offset(2, "left", resolution=10),
         )
         assert_geometries_equal(
-            line1.offset_curve(-2, quad_segs=1),
-            line1.parallel_offset(2, "right", resolution=1),
+            line1.offset_curve(-2, join_style="mitre"),
+            line1.parallel_offset(2, "right", join_style=2),
         )
 
     def test_parallel_offset_linear_ring(self):


### PR DESCRIPTION
A recent commit on GEOS main (https://github.com/libgeos/geos/commit/68a5b4d4bfadee1c580fb6702597fe7cfbcc8118) changed to use a minimum quad_segs of 8 for OffsetCurve (this is only relevant for the default "round" join style, the "mitre" and "bevel" join styles still give more coarse results). 

This updates our tests to be compatible with both older as latest GEOS.