### PR TITLE
DOC: include plotting in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@
    coordinates
    strtree
    testing
+   plotting
 
 Indices and tables
 ==================

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -1,0 +1,12 @@
+Plotting
+========
+
+.. currentmodule:: shapely
+
+.. autosummary::
+   :toctree: reference/
+
+   plotting.patch_from_polygon
+   plotting.plot_polygon
+   plotting.plot_line
+   plotting.plot_points


### PR DESCRIPTION
Fixes #1712 instead of the closed #1713.

This follows @jorisvandenbossche's suggestion to hard-code the functions in the rst instead of depending on the jinja template.