### PR TITLE
Use Py3 integers where appropriate

### DIFF
--- a/docs/code/figures.py
+++ b/docs/code/figures.py
@@ -1,8 +1,8 @@
 from math import sqrt
 from shapely import affinity
 
-GM = (sqrt(5)-1.0)/2.0
-W = 8.0
+GM = (sqrt(5) - 1) / 2
+W = 8
 H = W*GM
 SIZE = (W, H)
 

--- a/docs/code/parallel_offset.py
+++ b/docs/code/parallel_offset.py
@@ -6,8 +6,8 @@ from figures import SIZE, BLUE, GRAY, set_limits
 
 line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 line_bounds = line.bounds
-ax_range = [int(line_bounds[0] - 1.0), int(line_bounds[2] + 1.0)]
-ay_range = [int(line_bounds[1] - 1.0), int(line_bounds[3] + 1.0)]
+ax_range = [int(line_bounds[0] - 1), int(line_bounds[2] + 1)]
+ay_range = [int(line_bounds[1] - 1), int(line_bounds[3] + 1)]
 
 fig = plt.figure(1, figsize=(SIZE[0], 1.5 * SIZE[1]), dpi=90)
 

--- a/docs/code/parallel_offset_mitre.py
+++ b/docs/code/parallel_offset_mitre.py
@@ -6,8 +6,8 @@ from figures import SIZE, BLUE, GRAY, set_limits
 
 line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 line_bounds = line.bounds
-ax_range = [int(line_bounds[0] - 1.0), int(line_bounds[2] + 1.0)]
-ay_range = [int(line_bounds[1] - 1.0), int(line_bounds[3] + 1.0)]
+ax_range = [int(line_bounds[0] - 1), int(line_bounds[2] + 1)]
+ay_range = [int(line_bounds[1] - 1), int(line_bounds[3] + 1)]
 
 fig = plt.figure(1, figsize=(SIZE[0], 1.5 * SIZE[1]), dpi=90)
 

--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -1,6 +1,6 @@
 """Affine transforms, both in general and specific, named transforms."""
 
-from math import cos, pi, sin, tan
+from math import cos, radians, sin, tan
 
 import numpy as np
 
@@ -87,7 +87,7 @@ def interpret_origin(geom, origin, ndim):
     if origin == "center":
         # bounding box center
         minx, miny, maxx, maxy = geom.bounds
-        origin = ((maxx + minx) / 2.0, (maxy + miny) / 2.0)
+        origin = ((maxx + minx) / 2, (maxy + miny) / 2)
     elif origin == "centroid":
         origin = geom.centroid.coords[0]
     elif isinstance(origin, str):
@@ -132,7 +132,7 @@ def rotate(geom, angle, origin="center", use_radians=False):
     if geom.is_empty:
         return geom
     if not use_radians:  # convert from degrees
-        angle = angle * pi / 180.0
+        angle = radians(angle)
     cosp = cos(angle)
     sinp = sin(angle)
     if abs(cosp) < 2.5e-16:
@@ -209,8 +209,8 @@ def skew(geom, xs=0.0, ys=0.0, origin="center", use_radians=False):
     if geom.is_empty:
         return geom
     if not use_radians:  # convert from degrees
-        xs = xs * pi / 180.0
-        ys = ys * pi / 180.0
+        xs = radians(xs)
+        ys = radians(ys)
     tanx = tan(xs)
     tany = tan(ys)
     if abs(tanx) < 2.5e-16:

--- a/shapely/algorithms/cga.py
+++ b/shapely/algorithms/cga.py
@@ -9,7 +9,7 @@ def signed_area(ring):
     """
     coords = np.array(ring.coords)[:, :2]
     xs, ys = np.vstack([coords, coords[1]]).T
-    return np.sum(xs[1:-1] * (ys[2:] - ys[:-2])) / 2.0
+    return np.sum(xs[1:-1] * (ys[2:] - ys[:-2])) / 2
 
 
 def is_ccw_impl(name=None):

--- a/shapely/algorithms/polylabel.py
+++ b/shapely/algorithms/polylabel.py
@@ -94,7 +94,7 @@ def polylabel(polygon, tolerance=1.0):
     width = maxx - minx
     height = maxy - miny
     cell_size = min(width, height)
-    h = cell_size / 2.0
+    h = cell_size / 2
     cell_queue = []
 
     # First best cell approximation is one constructed from the centroid
@@ -103,7 +103,7 @@ def polylabel(polygon, tolerance=1.0):
     best_cell = Cell(x, y, 0, polygon)
 
     # Special case for rectangular polygons avoiding floating point error
-    bbox_cell = Cell(minx + width / 2.0, miny + height / 2, 0, polygon)
+    bbox_cell = Cell(minx + width / 2, miny + height / 2, 0, polygon)
     if bbox_cell.distance > best_cell.distance:
         best_cell = bbox_cell
 
@@ -130,7 +130,7 @@ def polylabel(polygon, tolerance=1.0):
             continue
 
         # split the cell into quadrants
-        h = cell.h / 2.0
+        h = cell.h / 2
         heappush(cell_queue, Cell(cell.x - h, cell.y - h, h, polygon))
         heappush(cell_queue, Cell(cell.x + h, cell.y - h, h, polygon))
         heappush(cell_queue, Cell(cell.x - h, cell.y + h, h, polygon))

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -79,7 +79,7 @@ class LineString(BaseGeometry):
     def __geo_interface__(self):
         return {"type": "LineString", "coordinates": tuple(self.coords)}
 
-    def svg(self, scale_factor=1.0, stroke_color=None, opacity=None):
+    def svg(self, scale_factor=1, stroke_color=None, opacity=None):
         """Returns SVG polyline element for the LineString geometry.
 
         Parameters
@@ -102,7 +102,7 @@ class LineString(BaseGeometry):
         return (
             '<polyline fill="none" stroke="{2}" stroke-width="{1}" '
             'points="{0}" opacity="{3}" />'
-        ).format(pnt_format, 2.0 * scale_factor, stroke_color, opacity)
+        ).format(pnt_format, 2 * scale_factor, stroke_color, opacity)
 
     @property
     def xy(self):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -267,7 +267,7 @@ class Polygon(BaseGeometry):
                 coords.append(tuple(hole.coords))
         return {"type": "Polygon", "coordinates": tuple(coords)}
 
-    def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
+    def svg(self, scale_factor=1, fill_color=None, opacity=None):
         """Returns SVG path element for the Polygon geometry.
 
         Parameters
@@ -299,7 +299,7 @@ class Polygon(BaseGeometry):
         return (
             '<path fill-rule="evenodd" fill="{2}" stroke="#555555" '
             'stroke-width="{0}" opacity="{3}" d="{1}" />'
-        ).format(2.0 * scale_factor, path, fill_color, opacity)
+        ).format(2 * scale_factor, path, fill_color, opacity)
 
     @classmethod
     def from_bounds(cls, xmin, ymin, xmax, ymax):
@@ -310,16 +310,16 @@ class Polygon(BaseGeometry):
 shapely.lib.registry[3] = Polygon
 
 
-def orient(polygon, sign=1.0):
+def orient(polygon, sign=1):
     s = float(sign)
     rings = []
     ring = polygon.exterior
-    if signed_area(ring) / s >= 0.0:
+    if signed_area(ring) / s >= 0:
         rings.append(ring)
     else:
         rings.append(list(ring.coords)[::-1])
     for ring in polygon.interiors:
-        if signed_area(ring) / s <= 0.0:
+        if signed_area(ring) / s <= 0:
             rings.append(ring)
         else:
             rings.append(list(ring.coords)[::-1])

--- a/shapely/tests/legacy/test_union.py
+++ b/shapely/tests/legacy/test_union.py
@@ -15,7 +15,7 @@ def halton(base):
 
     def value(index):
         result = 0.0
-        f = 1.0 / base
+        f = 1 / base
         i = index
         while i > 0:
             result += f * (i % base)


### PR DESCRIPTION
Get rid of Python2 relics and use integers in mathematical operations.