### PR TITLE
Docs: pin Cython=0.29, geos=3.11, add pip for ReadTheDocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,10 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - geos=3.10
+  - geos=3.11
   - numpy
-  - cython
+  - cython=0.29
   - sphinx-book-theme
   - sphinx-remove-toctrees
-  - numpydoc==1.1.*
+  - numpydoc=1.1
   - matplotlib
+  - pip


### PR DESCRIPTION
Since Cython 3.0 was released a few weeks ago, the ReadTheDocs builds have been failing:
```
$ python ./setup.py install --force
...
Error compiling Cython file:
------------------------------------------------------------
...
        self.last_error = <char *> malloc((1025) * sizeof(char))
        self.last_error[0] = 0
        self.last_warning = <char *> malloc((1025) * sizeof(char))
        self.last_warning[0] = 0
        GEOSContext_setErrorMessageHandler_r(
            self.handle, &geos_message_handler, self.last_error
                         ^
------------------------------------------------------------

shapely/_geos.pyx:30:25: Cannot assign type 'void (*)(const char *, void *) except *' to 'GEOSMessageHandler_r'
```
While this is a curious bug to fix for Cython 3.x, the short-term solution is to pin the docs/environment.yml for now. (This error doesn't occur in the main build, since `pyproject.toml` has `"Cython~=0.29"` in `build-system.requires`)

This also upgrades geos to 3.11 which is the same version used for the binary wheels. Furthermore, add pip for ReadTheDocs (which auto-adds a few pip deps).

Also, the RTD option described in #1857 is now toggled, so we should see the build in this PR.