### PR TITLE
BUG: allow the creation of MultiPolygon from a numpy array of Polygons

### DIFF
--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -47,7 +47,7 @@ class MultiPolygon(BaseMultipartGeometry):
     __slots__ = []
 
     def __new__(self, polygons=None):
-        if not polygons:
+        if polygons is None:
             # allow creation of empty multipolygons, to support unpickling
             # TODO better empty constructor
             return shapely.from_wkt("MULTIPOLYGON EMPTY")

--- a/shapely/tests/geometry/test_multipolygon.py
+++ b/shapely/tests/geometry/test_multipolygon.py
@@ -8,6 +8,11 @@ from shapely.tests.geometry.test_multi import MultiGeometryTestCase
 
 class TestMultiPolygon(MultiGeometryTestCase):
     def test_multipolygon(self):
+        # Empty
+        geom = MultiPolygon([])
+        assert geom.is_empty
+        assert len(geom.geoms) == 0
+
         # From coordinate tuples
         coords = [
             (
@@ -61,6 +66,15 @@ class TestMultiPolygon(MultiGeometryTestCase):
                 [(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25), (0.25, 0.25)],
             ]
         ]
+
+        # Or from a list of multiple polygons
+        geom_multiple_from_list = MultiPolygon([p, p])
+        assert len(geom_multiple_from_list.geoms) == 2
+        assert all(p == geom.geoms[0] for p in geom_multiple_from_list.geoms)
+
+        # Or from a np.array of polygons
+        geom_multiple_from_array = MultiPolygon(np.array([p, p]))
+        assert geom_multiple_from_array == geom_multiple_from_list
 
         # Or from another multi-polygon
         geom2 = MultiPolygon(geom)


### PR DESCRIPTION
… by replacing the check with a `is None` check so that it does not try to make a `bool` out of a `numpy array`. Also added tests to make sure that the `numpy array` creation is now allowed, and added a test for an empty `MultiPolygon` creation to ensure the original behavior is not broken. 

See [#1877](https://github.com/shapely/shapely/issues/1877).