### PR TITLE
FIX: setup.py didn't run geos-config properly on Windows/MSYS2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def get_geos_config(option):
     cmd = os.environ.get("GEOS_CONFIG", "geos-config")
     try:
         stdout, stderr = subprocess.Popen(
-            [cmd, option], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ['bash', '-c', cmd+' '+option], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
         ).communicate()
     except OSError:
         return


### PR DESCRIPTION
Installing shapely in Windows/MSYS2 from source using
```
git clone https://github.com/shapely/shapely.git
cd shapely
pip install .
```
resulted in the `Could not find geos-config executable` error even though it was present in the system. My patch works on MSYS2 properly, I'm just not sure it's the way it should be done.