### PR TITLE
Reenable Python 3.12 wheel building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686 cp312-*
+          CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,14 @@ jobs:
             numpy: 1.24.4
             matplotlib: true
             doctest: true
+            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning" # error on warnings
           - python: "3.12"
             geos: 3.12.0
             numpy: 1.26.0
           # dev
           - python: "3.11"
             geos: main
+            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
             # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
             extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
           # dev
-          - python: "3.11"
+          - python: "3.12"
             geos: main
             # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
             extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,16 +33,13 @@ jobs:
             geos: 3.11.2
             numpy: 1.23.4
           # 2023
-          - python: "3.11"
+          - python: "3.12"
             geos: 3.12.0
-            numpy: 1.24.4
+            numpy: 1.26.0
             matplotlib: true
             doctest: true
             # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
             extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
-          - python: "3.12"
-            geos: 3.12.0
-            numpy: 1.26.0
           # dev
           - python: "3.11"
             geos: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,14 +38,16 @@ jobs:
             numpy: 1.24.4
             matplotlib: true
             doctest: true
-            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning" # error on warnings
+            # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
+            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
           - python: "3.12"
             geos: 3.12.0
             numpy: 1.26.0
           # dev
           - python: "3.11"
             geos: main
-            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning" # error on warnings
+            # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
+            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
             matplotlib: true
             doctest: true
             extra_pytest_args: "-W error"  # error on warnings
+          - python: "3.12"
+            geos: 3.12.0
+            numpy: 1.26.0
           # dev
           - python: "3.11"
             geos: main
@@ -95,6 +98,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
+          allow-prereleases: true
 
       - name: Cache GEOS and pip packages
         uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,14 +38,12 @@ jobs:
             numpy: 1.24.4
             matplotlib: true
             doctest: true
-            extra_pytest_args: "-W error"  # error on warnings
           - python: "3.12"
             geos: 3.12.0
             numpy: 1.26.0
           # dev
           - python: "3.11"
             geos: main
-            extra_pytest_args: "-W error" # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ force_alphabetical_sort_within_sections = true
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 xfail_strict = true
 filterwarnings =
+    error
     # Dateutil deprecation warning already fixed upstream.
     # Can be dropped with the next release, `dateutil > 2.8.2`
     # https://github.com/dateutil/dateutil/pull/1285

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,3 @@ force_alphabetical_sort_within_sections = true
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 xfail_strict = true
-filterwarnings =
-    error
-    # Dateutil deprecation warning already fixed upstream.
-    # Can be dropped with the next release, `dateutil > 2.8.2`
-    # https://github.com/dateutil/dateutil/pull/1285
-    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ filterwarnings =
     # Dateutil deprecation warning already fixed upstream.
     # Can be dropped with the next release, `dateutil > 2.8.2`
     # https://github.com/dateutil/dateutil/pull/1285
-    ignore:datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,8 @@ force_alphabetical_sort_within_sections = true
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 xfail_strict = true
+filterwarnings =
+    # Dateutil deprecation warning already fixed upstream.
+    # Can be dropped with the next release, `dateutil > 2.8.2`
+    # https://github.com/dateutil/dateutil/pull/1285
+    ignore:datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ filterwarnings =
     # Dateutil deprecation warning already fixed upstream.
     # Can be dropped with the next release, `dateutil > 2.8.2`
     # https://github.com/dateutil/dateutil/pull/1285
-    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning


### PR DESCRIPTION
I'm working on building Python 3.12 wheels for some of my packages that depend on shapely. It'd be great to have a shapely wheel for Python 3.12.

Side note: I think in pyproject.toml you're supposed to be able to just say "numpy" from 1.25 or 1.26 on. Of course I can't find it now, but I believe it is supposed to be bundled with backwards compatible APIs...I think.