### PR TITLE
Prepare for Python 3.12 wheels for 2.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,9 @@ jobs:
         include:
         - os: ubuntu-20.04
           arch: x86_64
-        - os: ubuntu-20.04
-          arch: i686
+        # Numpy no longer builds i686 packages
+        # - os: ubuntu-20.04
+        #   arch: i686
         # The aarch64 build has been transferred to Travis
         # - os: ubuntu-20.04
         #   arch: aarch64
@@ -113,10 +114,10 @@ jobs:
         if: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: cp36-* pp* *musllinux* cp310-manylinux_i686
+          CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.7"


### PR DESCRIPTION
* Bump pypa/cibuildwheel from 2.14.1 to 2.16.2
* Don't build manylinux_i686
* Add Python 3.12 classifier