### PR TITLE
RLS/BLD: also build Python 3.12 wheels for linux aarch64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ workflows:
   wheel-build:
     jobs:
       - linux-aarch64-wheels:
-          filters:
-            branches:
-              only:
-                - main
-            tags:
-              only: /.*/
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
+          #   tags:
+          #     only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Build the Linux aarch64 wheels.
           command: |
-            python3 -m pip install --user cibuildwheel==2.11.2
+            python3 -m pip install --user cibuildwheel==2.16.2
             echo 'export GEOS_INSTALL=~/linux-aarch64-wheels/geosinstall/geos-"$GEOS_VERSION"' >> "$BASH_ENV"
             echo 'export GEOS_CONFIG="$GEOS_INSTALL"/bin/geos-config' >> "$BASH_ENV"
             echo 'export LD_LIBRARY_PATH="$GEOS_INSTALL"/lib' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,11 @@ jobs:
 workflows:
   wheel-build:
     jobs:
-      - linux-aarch64-wheels
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
-          #   tags:
-          #     only: /.*/
+      - linux-aarch64-wheels:
+          filters:
+            branches:
+              only:
+                - main
+                - maint-2.0
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 workflows:
   wheel-build:
     jobs:
-      - linux-aarch64-wheels:
+      - linux-aarch64-wheels
           # filters:
           #   branches:
           #     only:


### PR DESCRIPTION
We added those for the github actions based workflows, but not yet for CircleCI for Linux aarch64