### PR TITLE
Disable check_to_wkt_trim_compatible for GEOS >= 3.13.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ Changes
 
 Bug fixes:
 
-- Prevent crash when serializing a number > 1e100 to WKT. (#1907)
+- Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13. (#1907)
 
 Improvements:
 

--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -93,7 +93,12 @@ def test_format_polygon():
     )
 
     # 'g' format varies depending on GEOS version
-    if geos_version < (3, 10, 0):
+    if geos_version >= (3, 13, 0):
+        expected_2G = (
+            "POLYGON ((10 0, 7.07 -7.07, 6.12E-16 -10, -7.07 -7.07, "
+            "-10 -1.22E-15, -7.07 7.07, -1.84E-15 10, 7.07 7.07, 10 0))"
+        )
+    elif geos_version < (3, 10, 0):
         expected_2G = (
             "POLYGON ((10 0, 7.1 -7.1, 1.6E-14 -10, -7.1 -7.1, "
             "-10 -3.2E-14, -7.1 7.1, -4.6E-14 10, 7.1 7.1, 10 0))"

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -396,11 +396,17 @@ def test_to_wkt_large_float_ok(geom):
 
 
 @pytest.mark.parametrize("geom", [Point(1e101, 0), Point(0, 1e101)])
-def test_to_wkt_large_float_err(geom):
-    # https://github.com/shapely/shapely/issues/1903
-    with pytest.raises(ValueError, match="WKT output of coordinates greater than.*"):
-        shapely.to_wkt(geom)
-    assert "Exception in WKT writer" in repr(geom)
+def test_to_wkt_large_float(geom):
+    if shapely.geos_version >= (3, 13, 0):
+        # round-trip WKT
+        assert geom.equals(shapely.from_wkt(shapely.to_wkt(geom)))
+    else:
+        # https://github.com/shapely/shapely/issues/1903
+        with pytest.raises(
+            ValueError, match="WKT output of coordinates greater than.*"
+        ):
+            shapely.to_wkt(geom)
+        assert "Exception in WKT writer" in repr(geom)
 
 
 @pytest.mark.parametrize(

--- a/src/geos.c
+++ b/src/geos.c
@@ -402,6 +402,7 @@ char get_zmax_collection(GEOSContextHandle_t ctx, const GEOSGeometry* geom,
   return 1;
 }
 
+#if !GEOS_SINCE_3_13_0
 char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* geom,
                                   int dimension) {
   char is_empty;
@@ -431,6 +432,7 @@ char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* g
 
   return PGERR_SUCCESS;
 }
+#endif  // !GEOS_SINCE_3_13_0
 
 #if GEOS_SINCE_3_9_0
 

--- a/src/geos.h
+++ b/src/geos.h
@@ -91,7 +91,7 @@ enum ShapelyErrorCode {
                       "WKT output of multipoints with an empty point is unsupported on " \
                       "this version of GEOS.");                                          \
       break;                                                                             \
-    case PGERR_COORD_OUT_OF_BOUNDS:                                                      \
+    case PGERR_COORD_OUT_OF_BOUNDS:  /* applies to GEOS <3.13.0 with trim enabled  */    \
       PyErr_SetString(PyExc_ValueError,                                                  \
                       "WKT output of coordinates greater than 1E+100 is unsupported on " \
                       "this version of GEOS.");                                          \
@@ -163,6 +163,7 @@ enum ShapelyErrorCode {
 #define GEOS_SINCE_3_10_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 10))
 #define GEOS_SINCE_3_11_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 11))
 #define GEOS_SINCE_3_12_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 12))
+#define GEOS_SINCE_3_13_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 13))
 
 extern void* geos_context[1];
 extern PyObject* geos_exception[1];
@@ -173,7 +174,9 @@ extern char has_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 extern GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx,
                                                   GEOSGeometry* geom);
 extern char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom);
+#if !GEOS_SINCE_3_13_0
 extern char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* geom, int dimension);
+#endif  // !GEOS_SINCE_3_13_0
 #if GEOS_SINCE_3_9_0
 extern char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom,
                                   char** wkt);

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -81,12 +81,14 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
   }
 
   GEOS_INIT;
+#if !GEOS_SINCE_3_13_0
   if (trim) {
     errstate = check_to_wkt_trim_compatible(ctx, geom, dimension);
   }
   if (errstate != PGERR_SUCCESS) {
     goto finish;
   }
+#endif  // !GEOS_SINCE_3_13_0
 
 #if GEOS_SINCE_3_9_0
   errstate = wkt_empty_3d_geometry(ctx, geom, &wkt);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3275,12 +3275,14 @@ static void to_wkt_func(char** args, const npy_intp* dimensions, const npy_intp*
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
+#if !GEOS_SINCE_3_13_0
       if (trim) {
         errstate = check_to_wkt_trim_compatible(ctx, in1, dimension);
         if (errstate != PGERR_SUCCESS) {
           goto finish;
         }
       }
+#endif  // !GEOS_SINCE_3_13_0
 #if GEOS_SINCE_3_9_0
       errstate = wkt_empty_3d_geometry(ctx, in1, &wkt);
       if (errstate != PGERR_SUCCESS) {


### PR DESCRIPTION
This is a follow-up to #1907 that considers upstream changes for upcoming GEOS 3.13.0 in https://github.com/libgeos/geos/pull/973

It also fixes a related regression with tests against GEOS main branch, where small non-zero coordinates are shown with scientific notation (with trim enabled) rather than misrepresenting them as zero.