### PR TITLE
TST: update expected results for GEOS 3.13.0dev

### DIFF
--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -87,28 +87,28 @@ def test_format_polygon():
     assert format(poly, "X") == poly.wkb_hex
 
     # Use f-strings with extra characters and rounding precision
-    assert f"<{poly:.2f}>" == (
-        "<POLYGON ((10.00 0.00, 7.07 -7.07, 0.00 -10.00, -7.07 -7.07, "
-        "-10.00 -0.00, -7.07 7.07, -0.00 10.00, 7.07 7.07, 10.00 0.00))>"
-    )
+    if geos_version < (3, 13, 0):
+        assert f"<{poly:.2f}>" == (
+            "<POLYGON ((10.00 0.00, 7.07 -7.07, 0.00 -10.00, -7.07 -7.07, "
+            "-10.00 -0.00, -7.07 7.07, -0.00 10.00, 7.07 7.07, 10.00 0.00))>"
+        )
+    else:
+        assert f"<{poly:.2f}>" == (
+            "<POLYGON ((10.00 0.00, 7.07 -7.07, 0.00 -10.00, -7.07 -7.07, "
+            "-10.00 0.00, -7.07 7.07, 0.00 10.00, 7.07 7.07, 10.00 0.00))>"
+        )
 
     # 'g' format varies depending on GEOS version
-    if geos_version >= (3, 13, 0):
-        expected_2G = (
-            "POLYGON ((10 0, 7.07 -7.07, 6.12E-16 -10, -7.07 -7.07, "
-            "-10 -1.22E-15, -7.07 7.07, -1.84E-15 10, 7.07 7.07, 10 0))"
-        )
-    elif geos_version < (3, 10, 0):
-        expected_2G = (
+    if geos_version < (3, 10, 0):
+        assert f"{poly:.2G}" == (
             "POLYGON ((10 0, 7.1 -7.1, 1.6E-14 -10, -7.1 -7.1, "
             "-10 -3.2E-14, -7.1 7.1, -4.6E-14 10, 7.1 7.1, 10 0))"
         )
     else:
-        expected_2G = (
+        assert f"{poly:.2G}" == (
             "POLYGON ((10 0, 7.07 -7.07, 0 -10, -7.07 -7.07, "
             "-10 0, -7.07 7.07, 0 10, 7.07 7.07, 10 0))"
         )
-    assert f"{poly:.2G}" == expected_2G
 
     # check empty
     empty = Polygon()

--- a/shapely/tests/test_strtree.py
+++ b/shapely/tests/test_strtree.py
@@ -10,7 +10,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import shapely
-from shapely import box, geos_version, MultiPoint, Point, STRtree
+from shapely import box, geos_version, LineString, MultiPoint, Point, STRtree
 from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 from shapely.tests.common import (
@@ -912,12 +912,12 @@ def test_query_crosses_polygons(poly_tree, geometry, expected):
         # box contains points but touches only those at edges
         (box(3, 3, 6, 6), [3, 6]),
         ([box(3, 3, 6, 6)], [[0, 0], [3, 6]]),
-        # buffer completely contains point in tree
+        # polygon completely contains point in tree
         (shapely.buffer(Point(3, 3), 1), []),
         ([shapely.buffer(Point(3, 3), 1)], [[], []]),
-        # buffer intersects 2 points but touches only one
-        (shapely.buffer(Point(0, 1), 1), [1]),
-        ([shapely.buffer(Point(0, 1), 1)], [[0], [1]]),
+        # linestring intersects 2 points but touches only one
+        (LineString([(-1, -1), (1, 1)]), [1]),
+        ([LineString([(-1, -1), (1, 1)])], [[0], [1]]),
         # multipoints intersect but not valid relation
         (MultiPoint([[5, 5], [7, 7]]), []),
         ([MultiPoint([[5, 5], [7, 7]])], [[], []]),


### PR DESCRIPTION
This updates tests to work with GEOS main.

Upstream changes from https://github.com/libgeos/geos/pull/978 remove small precision errors from (e.g.) buffered points.