### PR TITLE
TST: Adjust tests and require_geos decorator implementation for docstring indent stripping in Python 3.13

### DIFF
--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -39,7 +39,7 @@ class requires_geos:
             # Insert the message at the first double newline
             position = doc.find("\n\n") + 2
             # Figure out the indentation level
-            indent = 2
+            indent = 0
             while True:
                 if doc[position + indent] == " ":
                     indent += 1

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -87,18 +87,18 @@ def expected_docstring(**kwds):
     doc = """Docstring that will be mocked.
 {indent}A multiline.
 
-{indent}{extra_indent}.. note:: 'func' requires at least GEOS {version}.
+{indent}.. note:: 'func' requires at least GEOS {version}.
 
 {indent}Some description.
-{indent}"""
+{indent}""".format(
+        **kwds
+    )
     if sys.version_info[:2] >= (3, 13):
         # There are subtle differences between inspect.cleandoc() and
         # _PyCompile_CleanDoc(). Most significantly, the latter does not remove
-        # leading or trailing blank lines. The extra_indent is required because
-        # the algorithm in shapely.decorators.requires_geos assumes a minimum
-        # indent of two spaces.
-        return cleandoc(doc.format(extra_indent="  ", **kwds)) + "\n"
-    return doc.format(extra_indent="", **kwds)
+        # leading or trailing blank lines.
+        return cleandoc(doc) + "\n"
+    return doc
 
 
 @pytest.mark.parametrize("version", ["3.10.0", "3.10.1", "3.9.2"])

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from inspect import cleandoc
 from itertools import chain
 from string import ascii_letters, digits
 from unittest import mock
@@ -82,13 +83,22 @@ class SomeClass:
         """
 
 
-expected_docstring = """Docstring that will be mocked.
+def expected_docstring(**kwds):
+    doc = """Docstring that will be mocked.
 {indent}A multiline.
 
-{indent}.. note:: 'func' requires at least GEOS {version}.
+{indent}{extra_indent}.. note:: 'func' requires at least GEOS {version}.
 
 {indent}Some description.
 {indent}"""
+    if sys.version_info[:2] >= (3, 13):
+        # There are subtle differences between inspect.cleandoc() and
+        # _PyCompile_CleanDoc(). Most significantly, the latter does not remove
+        # leading or trailing blank lines. The extra_indent is required because
+        # the algorithm in shapely.decorators.requires_geos assumes a minimum
+        # indent of two spaces.
+        return cleandoc(doc.format(extra_indent="  ", **kwds)) + "\n"
+    return doc.format(extra_indent="", **kwds)
 
 
 @pytest.mark.parametrize("version", ["3.10.0", "3.10.1", "3.9.2"])
@@ -104,7 +114,7 @@ def test_requires_geos_not_ok(version, mocked_geos_version):
     with pytest.raises(shapely.errors.UnsupportedGEOSVersionError):
         wrapped()
 
-    assert wrapped.__doc__ == expected_docstring.format(version=version, indent=" " * 4)
+    assert wrapped.__doc__ == expected_docstring(version=version, indent=" " * 4)
 
 
 @pytest.mark.parametrize("version", ["3.9.0", "3.10.0"])
@@ -112,7 +122,7 @@ def test_requires_geos_doc_build(version, mocked_geos_version, sphinx_doc_build)
     """The requires_geos decorator always adapts the docstring."""
     wrapped = requires_geos(version)(func)
 
-    assert wrapped.__doc__ == expected_docstring.format(version=version, indent=" " * 4)
+    assert wrapped.__doc__ == expected_docstring(version=version, indent=" " * 4)
 
 
 @pytest.mark.parametrize("version", ["3.9.0", "3.10.0"])
@@ -120,7 +130,7 @@ def test_requires_geos_method(version, mocked_geos_version, sphinx_doc_build):
     """The requires_geos decorator adjusts methods docstrings correctly"""
     wrapped = requires_geos(version)(SomeClass.func)
 
-    assert wrapped.__doc__ == expected_docstring.format(version=version, indent=" " * 8)
+    assert wrapped.__doc__ == expected_docstring(version=version, indent=" " * 8)
 
 
 @multithreading_enabled


### PR DESCRIPTION
Fixes #1937.

I’m not thrilled with this, particularly with the unexplained `extra_indent`, but it does successfully match the behavior in Python 3.13.0a1.

For reference, here’s the current implementation of `_PyCompile_CleanDoc()`:

https://github.com/methane/cpython/blob/9c03215a3ee31462045b2c2ee162bdda30c54572/Python/compile.c#L7816