### PR TITLE
REGR: ensure oriented_envelope (GEOS<3.12 code path) accepts array-like with ufunc protocol

### DIFF
--- a/shapely/algorithms/_oriented_envelope.py
+++ b/shapely/algorithms/_oriented_envelope.py
@@ -17,8 +17,6 @@ def _oriented_envelope_min_area(geometry, **kwargs):
     """
     if geometry is None:
         return None
-    if not hasattr(geometry, "geom_type"):
-        return np.array([_oriented_envelope_min_area(g) for g in geometry])
     if geometry.is_empty:
         return shapely.from_wkt("POLYGON EMPTY")
 
@@ -53,3 +51,8 @@ def _oriented_envelope_min_area(geometry, **kwargs):
     # check for the minimum area rectangle and return it
     transf_rect, inv_matrix = min(_transformed_rects(), key=lambda r: r[0].area)
     return affine_transform(transf_rect, inv_matrix)
+
+
+_oriented_envelope_min_area_vectorized = np.frompyfunc(
+    _oriented_envelope_min_area, 1, 1
+)

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from shapely import lib
 from shapely._enum import ParamEnum
-from shapely.algorithms._oriented_envelope import _oriented_envelope_min_area
+from shapely.algorithms._oriented_envelope import _oriented_envelope_min_area_vectorized
 from shapely.decorators import multithreading_enabled, requires_geos
 
 __all__ = [
@@ -1024,7 +1024,7 @@ def oriented_envelope(geometry, **kwargs):
     <POLYGON EMPTY>
     """
     if lib.geos_version < (3, 12, 0):
-        f = _oriented_envelope_min_area
+        f = _oriented_envelope_min_area_vectorized
     else:
         f = _oriented_envelope_geos
     return f(geometry, **kwargs)

--- a/shapely/tests/common.py
+++ b/shapely/tests/common.py
@@ -155,3 +155,34 @@ def equal_geometries_abnormally_yield_unequal(geom):
         if shapely.geos_version < (3, 13, 0) and geom.geom_type.startswith("Multi"):
             return True
     return False
+
+
+class ArrayLike:
+    """
+    Simple numpy Array like class that implements the
+    ufunc protocol.
+    """
+
+    def __init__(self, array):
+        self._array = np.asarray(array)
+
+    def __len__(self):
+        return len(self._array)
+
+    def __getitem(self, key):
+        return self._array[key]
+
+    def __iter__(self):
+        return self._array.__iter__()
+
+    def __array__(self):
+        return np.asarray(self._array)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if method == "__call__":
+            inputs = [
+                arg._array if isinstance(arg, self.__class__) else arg for arg in inputs
+            ]
+            return self.__class__(ufunc(*inputs, **kwargs))
+        else:
+            return NotImplemented

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -17,6 +17,7 @@ from shapely import (
 from shapely.testing import assert_geometries_equal
 from shapely.tests.common import (
     all_types,
+    ArrayLike,
     empty,
     empty_line_string,
     empty_point,
@@ -976,6 +977,17 @@ def test_oriented_envelope_pre_geos_312(geometry, expected):
     # to cover the C code for older GEOS versions
     actual = shapely.constructive._oriented_envelope_geos(geometry)
     assert_geometries_equal(actual, expected, normalize=True, tolerance=1e-3)
+
+
+def test_oriented_evelope_array_like():
+    # https://github.com/shapely/shapely/issues/1929
+    # because we have a custom python implementation, need to ensure this has
+    # the same capabilities as numpy ufuncs to work with array-likes
+    geometries = [Point(1, 1).buffer(1), Point(2, 2).buffer(1)]
+    actual = shapely.oriented_envelope(ArrayLike(geometries))
+    assert isinstance(actual, ArrayLike)
+    expected = shapely.oriented_envelope(geometries)
+    assert_geometries_equal(np.asarray(actual), expected)
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 11, 0), reason="GEOS < 3.11")


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/1929

In the end I thought to use `np.frompyfunc` and remove the manual iteration, instead of just fixing that single check for when to use the iteration code path. This ensures that it will work consistently with numpy in what it accepts (the kinds of array likes), and also that it will return the array like objects if those implement the numpy protocols (eg in shapely 2.0.1, calling this function on a geopandas.GeoSeries will also return a GeoSeries)