### PR TITLE
TST: move and consolidate Geometry __eq__ tests in geometry/test_equality.py

### DIFF
--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -18,16 +18,11 @@ def test_equality(geom):
     assert not (geom != transformed)
 
 
-@pytest.mark.parametrize("geom", all_non_empty_types)
-def test_inequality(geom):
-    transformed = shapely.transform(geom, lambda x: x + 1)
-    assert geom != transformed
-    assert not (geom == transformed)
-
-
 @pytest.mark.parametrize(
     "left, right",
-    [
+    # automated test cases with transformed coordinate values
+    [(geom, shapely.transform(geom, lambda x: x + 1)) for geom in all_non_empty_types]
+    + [
         # (slightly) different coordinate values
         (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (1, 2)])),
         (LineString([(0, 0), (1, 1)]), LineString([(0, 0), (1, 1 + 1e-12)])),
@@ -45,6 +40,7 @@ def test_inequality(geom):
 )
 def test_equality_false(left, right):
     assert left != right
+    assert not (left == right)
 
 
 with ignore_invalid():

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -232,40 +232,6 @@ def test_adapt_ptr_raises():
         point._geom += 1
 
 
-@pytest.mark.parametrize(
-    "geom", all_types + (shapely.points(np.nan, np.nan), empty_point)
-)
-def test_hash_same_equal(geom):
-    hash1 = hash(geom)
-    hash2 = hash(shapely.transform(geom, lambda x: x))
-    if (
-        geom.is_empty
-        and shapely.get_num_geometries(geom) > 0
-        and geom.geom_type not in {"MultiPoint", "Point"}
-        and shapely.geos_version < (3, 9, 0)
-    ):
-        # abnormal test for older GEOS version
-        assert hash1 != hash2, geom
-    else:
-        # normal test
-        assert hash1 == hash2, geom
-
-
-@pytest.mark.parametrize("geom", all_non_empty_types)
-def test_hash_same_not_equal(geom):
-    assert hash(geom) != hash(shapely.transform(geom, lambda x: x + 1))
-
-
-@pytest.mark.parametrize("geom", all_types)
-def test_eq(geom):
-    assert geom == shapely.transform(geom, lambda x: x)
-
-
-@pytest.mark.parametrize("geom", all_non_empty_types)
-def test_neq(geom):
-    assert geom != shapely.transform(geom, lambda x: x + 1)
-
-
 @pytest.mark.parametrize("geom", all_types)
 def test_set_unique(geom):
     a = {geom, shapely.transform(geom, lambda x: x)}

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -37,8 +37,6 @@ from shapely.tests.common import (
     polygon_z,
 )
 
-all_non_empty_types = np.array(all_types)[~shapely.is_empty(all_types)]
-
 
 def test_get_num_points():
     actual = shapely.get_num_points(all_types + (None,)).tolist()


### PR DESCRIPTION
The `test_eq` in `shapely/tests/test_geometry.py` is duplicated with `test_equality` in `shapely/tests/geometry/test_equality.py`

Deduplicating this, and also move the other equality (and hash) related tests in the former file to the latter, which already has more extensive tests on this topic.