### PR TITLE
DOC: update note for is_valid

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -169,7 +169,7 @@ In all constructors, numeric values are converted to type ``float``. In other
 words, ``Point(0, 0)`` and ``Point(0.0, 0.0)`` produce geometrically equivalent
 instances. Shapely does not check the topological simplicity or validity of
 instances when they are constructed as the cost is unwarranted in most cases.
-Validating factories are easily implemented using the :attr:``is_valid``
+Validating factories are easily implemented using the :attr:`~object.is_valid`
 predicate by users that require them.
 
 .. note::
@@ -1010,8 +1010,8 @@ Operations on non-simple `LineStrings` are fully supported by Shapely.
 
 .. note::
 
-   The validity test is meaningful only for `Polygons` and `MultiPolygons`.
-   ``True`` is always returned for other types of geometries.
+   The validity test is meaningful only for `Polygons`, `LinearRings`,
+   and some `LineStrings`. Other geometry types always return ``True``.
 
 A valid `Polygon` may not possess any overlapping exterior or interior rings. A
 valid `MultiPolygon` may not collect any overlapping polygons. Operations on


### PR DESCRIPTION
The `is_valid` property is more complicated than the manual suggests. For instance, there are invalid LineString and LinearRing types. See other [docs for PostGIS](https://postgis.net/docs/using_postgis_dbmanagement.html#Valid_Geometry) on the topic.

For more info from GEOS, see [`ValidationError.cpp`](https://github.com/libgeos/geos/blob/34b29f889987fc528b490491d5595bb3c791ea9e/src/operation/valid/TopologyValidationError.cpp#L32-L45) messages (and their enums from [`TopologyValidationError.h`](https://github.com/libgeos/geos/blob/34b29f889987fc528b490491d5595bb3c791ea9e/include/geos/operation/valid/TopologyValidationError.h#L42-L56)), and [`IsValidOpTest.cpp`](https://github.com/libgeos/geos/blob/34b29f889987fc528b490491d5595bb3c791ea9e/tests/unit/operation/valid/IsValidOpTest.cpp) for examples of valid/invalid geometries.