### PR TITLE
Fix incompatible pointer type passed to GEOSPolygonize_r

### DIFF
--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2160,7 +2160,7 @@ static void polygonize_func(char** args, const npy_intp* dimensions, const npy_i
 
   GEOS_INIT;
 
-  GEOSGeometry** geoms = malloc(sizeof(void*) * dimensions[1]);
+  const GEOSGeometry** geoms = malloc(sizeof(void*) * dimensions[1]);
   if (geoms == NULL) {
     errstate = PGERR_NO_MALLOC;
     goto finish;


### PR DESCRIPTION
Fixes the following warning by improving `const`-correctness:

```
  src/ufuncs.c: In function ‘polygonize_func’:
  src/ufuncs.c:2205:51: warning: passing argument 2 of ‘GEOSPolygonize_r’ from incompatible pointer type [-Wincompatible-pointer-types]
   2205 |     GEOSGeometry* ret_ptr = GEOSPolygonize_r(ctx, geoms, n_geoms);
        |                                                   ^~~~~
        |                                                   |
        |                                                   GEOSGeometry ** {aka struct GEOSGeom_t **}
  In file included from src/geos.h:15,
                   from src/ufuncs.c:16:
  /usr/include/geos_c.h:979:31: note: expected ‘const GEOSGeometry * const*’ {aka ‘const struct GEOSGeom_t * const*’} but argument is of type ‘GEOSGeometry **’ {aka ‘struct GEOSGeom_t **’}
    979 |     const GEOSGeometry *const geoms[],
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

With Fedora Linux’s [PortingToModernC](https://fedoraproject.org/wiki/Changes/PortingToModernC) initiative, further described in [this mailing list message](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/GKCRXZESHSCCEKED2N5GNQ7GH32VSK2X/), this warning will become an error.