### PR TITLE
DOC: improve documentation of canonical form and set_precision

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -178,12 +178,16 @@ case of the format type character.
 
 Canonical form
 --------------
-When geometries are constructed, they are created according to some conventions:
+When operations are applied on geometries the result is returned according to some
+conventions.
 
-* the coordinates of exterior rings follow a clockwise orientation, interior rings
-  have a counter-clockwise orientation. This is the opposite of the OGC specifications
-  because the choice was made before this was included in the standard.
-* the starting point of rings is lower left.
-* collections are ordered by geometry type.
+As a general rule, the coordinates of exterior rings follow a clockwise orientation and
+interior rings have a counter-clockwise orientation. This is the opposite of the OGC
+specifications because the choice was made before this was included in the standard.
+
+The starting point of rings and the order of geometry types in a collection can be
+changed, but the result is undefined. When :func:`~shapely.normalize` is used though, it
+will make sure that the starting point of rings is lower left and that collections are
+ordered by geometry type.
 
 It is important to note that input geometries do not have to follow these conventions.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -182,7 +182,7 @@ When geometries are constructed, they are created according to some conventions:
 
 * the coordinates of exterior rings follow a clockwise orientation, interior rings
   have a counter-clockwise orientation. This is the opposite of the OGC specifications
-  because the choise was made before this was included in the standard.
+  because the choice was made before this was included in the standard.
 * the starting point of rings is lower left.
 * collections are ordered by geometry type.
 

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -181,13 +181,20 @@ Canonical form
 When operations are applied on geometries the result is returned according to some
 conventions.
 
-As a general rule, the coordinates of exterior rings follow a clockwise orientation and
-interior rings have a counter-clockwise orientation. This is the opposite of the OGC
-specifications because the choice was made before this was included in the standard.
+In most cases, geometries will be returned in "mild" canonical form:
 
-The starting point of rings and the order of geometry types in a collection can be
-changed, but the result is undefined. When :func:`~shapely.normalize` is used though, it
-will make sure that the starting point of rings is lower left and that collections are
-ordered by geometry type.
+- the coordinates of exterior rings follow a clockwise orientation and interior
+  rings have a counter-clockwise orientation. This is the opposite of the OGC
+  specifications because the choice was made before this was included in the standard.
+- the starting point of rings can be changed, but it is undefined
+- the order of geometry types in a collection can be changed, but the order is
+  undefined
+
+When :func:`~shapely.normalize` is used, the "strict" canonical form is applied:
+
+- the coordinates of exterior rings follow a clockwise orientation and interior
+  rings have a counter-clockwise orientation
+- the starting point of rings is lower left
+- elements in collections are ordered by geometry type
 
 It is important to note that input geometries do not have to follow these conventions.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -173,3 +173,17 @@ specified, rounding precision will be disabled showing full precision.
 Format types ``'x'`` and ``'X'`` show a hex-encoded string representation of
 WKB or Well-Known Binary, with the case of the output matched the
 case of the format type character.
+
+.. _canonical-form:
+
+Canonical form
+--------------
+When geometries are constructed, they are created according to some conventions:
+
+* the coordinates of exterior rings follow a clockwise orientation, interior rings
+  have a counter-clockwise orientation. This is the opposite of the OGC specifications
+  because the choise was made before this was included in the standard.
+* the starting point of rings is lower left.
+* collections are ordered by geometry type.
+
+It is important to note that input geometries do not have to follow these conventions.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -181,7 +181,8 @@ Canonical form
 When operations are applied on geometries the result is returned according to some
 conventions.
 
-In most cases, geometries will be returned in "mild" canonical form:
+In most cases, geometries will be returned in "mild" canonical form. There is no goal
+to keep this form stable, so it is expected to change in future versions of GEOS:
 
 - the coordinates of exterior rings follow a clockwise orientation and interior
   rings have a counter-clockwise orientation. This is the opposite of the OGC
@@ -190,7 +191,9 @@ In most cases, geometries will be returned in "mild" canonical form:
 - the order of geometry types in a collection can be changed, but the order is
   undefined
 
-When :func:`~shapely.normalize` is used, the "strict" canonical form is applied:
+When :func:`~shapely.normalize` is used, the "strict" canonical form is applied. This
+type of normalization is meant to be stable, so changes to it will be avoided if
+possible:
 
 - the coordinates of exterior rings follow a clockwise orientation and interior
   rings have a counter-clockwise orientation

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -178,26 +178,33 @@ case of the format type character.
 
 Canonical form
 --------------
-When operations are applied on geometries the result is returned according to some
-conventions.
+When operations are applied on geometries the result is returned according to
+some conventions.
 
-In most cases, geometries will be returned in "mild" canonical form. There is no goal
-to keep this form stable, so it is expected to change in future versions of GEOS:
+In most cases, geometries will be returned in "mild" canonical form. There is no
+goal to keep this form stable, so it is expected to change in future versions of
+GEOS:
 
 - the coordinates of exterior rings follow a clockwise orientation and interior
   rings have a counter-clockwise orientation. This is the opposite of the OGC
-  specifications because the choice was made before this was included in the standard.
-- the starting point of rings can be changed, but it is undefined
+  specifications because the choice was made before this was included in the
+  standard.
+- the starting point of rings can be changed in the output, but the exact order
+  is undefined and should not be relied upon
 - the order of geometry types in a collection can be changed, but the order is
   undefined
 
-When :func:`~shapely.normalize` is used, the "strict" canonical form is applied. This
-type of normalization is meant to be stable, so changes to it will be avoided if
-possible:
+When :func:`~shapely.normalize` is used, the "strict" canonical form is applied.
+This type of normalization is meant to be stable, so changes to it will be
+avoided if possible:
 
 - the coordinates of exterior rings follow a clockwise orientation and interior
   rings have a counter-clockwise orientation
 - the starting point of rings is lower left
-- elements in collections are ordered by geometry type
+- elements in collections are ordered by geometry type: by descending dimension
+  and multi-types first (MultiPolygon, Polygon, MultiLineString, LineString,
+  MultiPoint, Point). Multiple elements from the same type are ordered from
+  right to left and from top to bottom.
 
-It is important to note that input geometries do not have to follow these conventions.
+It is important to note that input geometries do not have to follow these
+conventions.

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -725,11 +725,13 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
-    Coordinates will be rounded if a precision grid is less precise than the
-    input geometry. Duplicated vertices will be dropped from lines and
-    polygons for grid sizes greater than 0. Line and polygon geometries may
-    collapse to empty geometries if all vertices are closer together than
-    grid_size. Z values, if present, will not be modified.
+    Coordinates will be rounded if a precision grid is less precise than the input
+    geometry. Duplicated vertices will be dropped from lines and polygons for grid sizes
+    greater than 0. Line and polygon geometries may collapse to empty geometries if all
+    vertices are closer together than ``grid_size``. Spikes or sections in Polygons
+    narrower than ``grid_size`` after rounding the vertices will be removed, which can
+    lead to MultiPolygons or empty geometries. Z values, if present, will not be
+    modified.
 
     Notes:
 
@@ -750,7 +752,8 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
         value is more precise than input geometry, the input geometry will
         not be modified.
     mode :  {'valid_output', 'pointwise', 'keep_collapsed'}, default 'valid_output'
-        This parameter determines how to handle invalid output geometries. There are three modes:
+        This parameter determines the way a precision reduction is applied on the
+        geometry. There are three modes:
 
         1. `'valid_output'` (default):  The output is always valid. Collapsed geometry elements
            (including both polygons and lines) are removed. Duplicate vertices are removed.

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -732,6 +732,7 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     grid_size. Z values, if present, will not be modified.
 
     Notes:
+
     * subsequent operations will always be performed in the precision of
       the geometry with higher precision (smaller "grid_size"). That same
       precision will be attached to the operation outputs.

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -731,13 +731,13 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
-    Coordinates will be rounded if a precision grid is less precise than the input
-    geometry. Duplicated vertices will be dropped from lines and polygons for grid sizes
-    greater than 0. Line and polygon geometries may collapse to empty geometries if all
-    vertices are closer together than ``grid_size``. Spikes or sections in Polygons
-    narrower than ``grid_size`` after rounding the vertices will be removed, which can
-    lead to MultiPolygons or empty geometries. Z values, if present, will not be
-    modified.
+    Coordinates will be rounded if the precision grid specified is less precise than the
+    input geometry. Duplicated vertices will be dropped from lines and polygons for grid
+    sizes greater than 0. Line and polygon geometries may collapse to empty geometries
+    if all vertices are closer together than ``grid_size`` or if a polygon becomes
+    significantly narrower than ``grid_size``. Spikes or sections in polygons narrower
+    than ``grid_size`` after rounding the vertices will be removed, which can lead to
+    multipolygons or empty geometries. Z values, if present, will not be modified.
 
     Notes:
 

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -738,7 +738,7 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
       precision will be attached to the operation outputs.
     * input geometries should be geometrically valid; unexpected results may
       occur if input geometries are not.
-    * the geometry returned will be in :ref:`canonical form <canonical-form>`.
+    * the geometry returned will be in :ref:`mild canonical form <canonical-form>`.
     * returns None if geometry is None.
 
     Parameters

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -731,22 +731,25 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
-    Coordinates will be rounded if the precision grid specified is less precise than the
-    input geometry. Duplicated vertices will be dropped from lines and polygons for grid
-    sizes greater than 0. Line and polygon geometries may collapse to empty geometries
-    if all vertices are closer together than ``grid_size`` or if a polygon becomes
-    significantly narrower than ``grid_size``. Spikes or sections in polygons narrower
-    than ``grid_size`` after rounding the vertices will be removed, which can lead to
-    multipolygons or empty geometries. Z values, if present, will not be modified.
+    Coordinates will be rounded if the precision grid specified is less precise
+    than the input geometry. Duplicated vertices will be dropped from lines and
+    polygons for grid sizes greater than 0. Line and polygon geometries may
+    collapse to empty geometries if all vertices are closer together than
+    ``grid_size`` or if a polygon becomes significantly narrower than
+    ``grid_size``. Spikes or sections in polygons narrower than ``grid_size``
+    after rounding the vertices will be removed, which can lead to multipolygons
+    or empty geometries. Z values, if present, will not be modified.
 
     Notes:
 
-    * subsequent operations will always be performed in the precision of
-      the geometry with higher precision (smaller "grid_size"). That same
-      precision will be attached to the operation outputs.
+    * subsequent operations will always be performed in the precision of the
+      geometry with higher precision (smaller "grid_size"). That same precision
+      will be attached to the operation outputs.
     * input geometries should be geometrically valid; unexpected results may
       occur if input geometries are not.
-    * the geometry returned will be in :ref:`mild canonical form <canonical-form>`.
+    * the geometry returned will be in
+      :ref:`mild canonical form <canonical-form>`, and the order of vertices can
+      change and should not be relied upon.
     * returns None if geometry is None.
 
     Parameters
@@ -758,22 +761,24 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
         value is more precise than input geometry, the input geometry will
         not be modified.
     mode :  {'valid_output', 'pointwise', 'keep_collapsed'}, default 'valid_output'
-        This parameter determines the way a precision reduction is applied on the
-        geometry. There are three modes:
+        This parameter determines the way a precision reduction is applied on
+        the geometry. There are three modes:
 
-        1. `'valid_output'` (default):  The output is always valid. Collapsed geometry elements
-           (including both polygons and lines) are removed. Duplicate vertices are removed.
-        2. `'pointwise'`: Precision reduction is performed pointwise. Output geometry
-           may be invalid due to collapse or self-intersection. Duplicate vertices are not
-           removed. In GEOS this option is called NO_TOPO.
+        1. `'valid_output'` (default):  The output is always valid. Collapsed
+           geometry elements (including both polygons and lines) are removed.
+           Duplicate vertices are removed.
+        2. `'pointwise'`: Precision reduction is performed pointwise. Output
+           geometry may be invalid due to collapse or self-intersection.
+           Duplicate vertices are not removed. In GEOS this option is called
+           NO_TOPO.
 
            .. note::
 
-             'pointwise' mode requires at least GEOS 3.10. It is accepted in earlier versions,
-             but the results may be unexpected.
-        3. `'keep_collapsed'`: Like the default mode, except that collapsed linear geometry
-           elements are preserved. Collapsed polygonal input elements are removed. Duplicate
-           vertices are removed.
+             'pointwise' mode requires at least GEOS 3.10. It is accepted in
+             earlier versions, but the results may be unexpected.
+        3. `'keep_collapsed'`: Like the default mode, except that collapsed
+           linear geometry elements are preserved. Collapsed polygonal input
+           elements are removed. Duplicate vertices are removed.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -731,14 +731,14 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     collapse to empty geometries if all vertices are closer together than
     grid_size. Z values, if present, will not be modified.
 
-    Note: subsequent operations will always be performed in the precision of
-    the geometry with higher precision (smaller "grid_size"). That same
-    precision will be attached to the operation outputs.
-
-    Also note: input geometries should be geometrically valid; unexpected
-    results may occur if input geometries are not.
-
-    Returns None if geometry is None.
+    Notes:
+    * subsequent operations will always be performed in the precision of
+      the geometry with higher precision (smaller "grid_size"). That same
+      precision will be attached to the operation outputs.
+    * input geometries should be geometrically valid; unexpected results may
+      occur if input geometries are not.
+    * the geometry returned will be in :ref:`canonical form <canonical-form>`.
+    * returns None if geometry is None.
 
     Parameters
     ----------

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -533,9 +533,9 @@ def make_valid(geometry, **kwargs):
 def normalize(geometry, **kwargs):
     """Converts Geometry to normal form (or canonical form).
 
-    This method orders the coordinates, rings of a polygon and parts of
-    multi geometries consistently. Typically useful for testing purposes
-    (for example in combination with ``equals_exact``).
+    In :ref:`canonical form <canonical-form>`, the coordinates, rings of a polygon and
+    parts of multi geometries are ordered consistently. Typically useful for testing
+    purposes (for example in combination with ``equals_exact``).
 
     Parameters
     ----------

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -592,9 +592,9 @@ def make_valid(geometry, method="linework", keep_collapsed=True, **kwargs):
 
 @multithreading_enabled
 def normalize(geometry, **kwargs):
-    """Converts Geometry to normal form (or canonical form).
+    """Converts Geometry to strict normal form (or canonical form).
 
-    In :ref:`canonical form <canonical-form>`, the coordinates, rings of a polygon and
+    In :ref:`strict canonical form <canonical-form>`, the coordinates, rings of a polygon and
     parts of multi geometries are ordered consistently. Typically useful for testing
     purposes (for example in combination with ``equals_exact``).
 


### PR DESCRIPTION
Improvements to `set_precision` documentation:
- it changes the order of points,... which doesn't seem to be expected to happen. So better to mention this explicitly in its documentation.
- some more clarification on what `set_precision` does, e.g. the collapsing of narrow parts of polygons.

The "canonical form" also isn't documented in detail... so this PR tries to solve this as well.

Resolves #1950 
Resolves #1952