### PR TITLE
COMPAT: Add a numpy<2 pin to install requirements for 2.0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Build the Linux aarch64 wheels.
           command: |
-            python3 -m pip install --user cibuildwheel==2.16.2
+            python3 -m pip install --user cibuildwheel==2.16.5
             echo 'export GEOS_INSTALL=~/linux-aarch64-wheels/geosinstall/geos-"$GEOS_VERSION"' >> "$BASH_ENV"
             echo 'export GEOS_CONFIG="$GEOS_INSTALL"/bin/geos-config' >> "$BASH_ENV"
             echo 'export LD_LIBRARY_PATH="$GEOS_INSTALL"/lib' >> "$BASH_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.14,<2'",
+    "numpy>=1.14,<2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.14, <2'",
+    "numpy>=1.14,<2'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.14",
+    "numpy>=1.14, <2'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
See https://github.com/shapely/shapely/issues/1972 for the details.

Current Shapely wheels for 2.0.x (and for an upcoming 2.0.3 release) are not compatible with future numpy 2.0 packages (if you install shapely now in an environment with nightly numpy, it fails to import), therefore it is recommended to add this upper pin now for releases. 
We will keep the more flexible pin on the development branch, assuming by the time we release shapely 2.1, numpy 2.0 will be out and we can build shapely 2.0 to be compatible with all numpy versions. 