### PR TITLE
DOC: fix version shown on readthedocs (take 2)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ build:
   jobs:
     post_checkout:
       # we need the tags for versioneer to work
+      - git fetch origin --depth 150
       - git fetch --tags
     pre_install:
       # to avoid "dirty" version


### PR DESCRIPTION
https://github.com/shapely/shapely/pull/1914 is no longer working to get the tags (I suppose because the checkout depth is by default only 50)