### PR TITLE
RLS/BLD: use native Apple Silicon macOS for arm64 wheels; remove universal2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,9 @@ jobs:
         - os: macos-11
           arch: x86_64
           cmake_osx_architectures: x86_64
-        - os: macos-11
+        - os: macos-14
           arch: arm64
           cmake_osx_architectures: arm64
-        - os: macos-11
-          arch: universal2
-          cmake_osx_architectures: "x86_64;arm64"
 
     steps:
       - name: Checkout source
@@ -119,6 +116,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
+          CIBW_TEST_SKIP: "cp38-macosx_arm64"
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}


### PR DESCRIPTION
Use native Apple Silicon macOS runners ([described here](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)) to build arm64 wheels.

Also, remove `universal2` wheels, since I think it's fine to have separate `x86_64` builds for macOS.