### PR TITLE
Fix uploading of nightly wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,11 +156,21 @@ jobs:
           path: ./wheelhouse/*.whl
           retention-days: 5
 
-      - name: Upload nightly wheels
-        if: github.repository_owner == 'shapely' && github.ref == 'refs/heads/main'
+  nightly_upload:
+    name: Upload nightly wheels
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'shapely' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+      - name: Upload wheels to Anaconda Cloud
         uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
         with:
-          artifacts_path: wheelhouse
+          artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_ORG_UPLOAD_TOKEN}}
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     name: Upload nightly wheels
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'shapely' && github.ref == 'refs/heads/main'
+    if: github.repository == 'shapely/shapely'  # && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     name: Upload nightly wheels
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    if: github.repository == 'shapely/shapely'  # && github.ref == 'refs/heads/main'
+    if: github.repository == 'shapely/shapely' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Follow-up on https://github.com/shapely/shapely/pull/1997, as apparently the action only works on ubuntu, so we need to run it once after all wheels builds succeeded