### PR TITLE
DOC: document how to install nightly wheels

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,6 +25,15 @@ Shapely is available on the conda-forge channel. Install as follows::
 
     $ conda install shapely --channel conda-forge
 
+Installation of the development version using nightly wheels
+------------------------------------------------------------
+
+If you want to test the latest development version of Shapely, the easiest way
+to get this version is by installing it from the Scientific Python index of
+nightly wheel packages::
+
+    python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple shapely
+
 
 Installation from source with custom GEOS libary
 ------------------------------------------------


### PR DESCRIPTION
Follow-up on https://github.com/shapely/shapely/pull/1997 / https://github.com/shapely/shapely/pull/1998.

I still need to update the tags to make this actually work. Currently, those wheels have versions like 2.0.1+78 (after 2.0.1, we branched for maint-2.0).
To make this more usable (so the wheels have a version number that is considered higher than the released version 2.0.3, and gets preferred by pip when specifying the index), I think we will have to add a `2.1.0.dev0` tag to the main branch (e.g. on the commit just after we branched maint-2.0)