### PR TITLE
Add shapely.geometry.polygon.orient to __all__

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -10,7 +10,7 @@ from shapely.geometry.base import BaseGeometry
 from shapely.geometry.linestring import LineString
 from shapely.geometry.point import Point
 
-__all__ = ["Polygon", "LinearRing"]
+__all__ = ["orient", "Polygon", "LinearRing"]
 
 
 def _unpickle_linearring(wkb):


### PR DESCRIPTION
Add orient to `__all__` in polygon.py, supersedes #1805.

Fixes #722 where linting warnings like this appear:

> 'orient' is not declared in `__all__`