### PR TITLE
COMPAT: fix assert_geometries_equal to work with numpy 2.0 copy changes

### DIFF
--- a/shapely/testing.py
+++ b/shapely/testing.py
@@ -106,8 +106,8 @@ def assert_geometries_equal(
     if normalize:
         x = shapely.normalize(x)
         y = shapely.normalize(y)
-    x = np.array(x, copy=False)
-    y = np.array(y, copy=False)
+    x = np.asarray(x)
+    y = np.asarray(y)
 
     is_scalar = x.ndim == 0 or y.ndim == 0
 


### PR DESCRIPTION
Recent change in numpy main with different semantics for the `copy` keyword, where `copy=False` will now guarantee (instead of try) to not make a copy, and thus raise an error when it cannot create the array without allocating data.