### PR TITLE
ENH: add has_m

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -914,14 +914,29 @@ example will be shown for each.
 
 .. attribute:: object.has_z
 
-  Returns ``True`` if the feature has not only `x` and `y`, but also `z`
-  coordinates for 3D (or so-called, 2.5D) geometries.
+  Returns ``True`` if the feature has `z` coordinates, either with XYZ or XYZM
+  coordinate types.
 
 .. code-block:: pycon
 
   >>> Point(0, 0).has_z
   False
   >>> Point(0, 0, 0).has_z
+  True
+
+.. attribute:: object.has_m
+
+  Returns ``True`` if the feature has `m` coordinates, either with XYM or XYZM
+  coordinate types.
+
+  `New in version 2.1 with GEOS 3.12`.
+
+.. code-block:: pycon
+
+  >>> Point(0, 0, 0).has_m
+  False
+  >>> from shapely import from_wkt
+  >>> from_wkt("POINT M (0 0 0)").has_m
   True
 
 .. attribute:: object.is_ccw

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -121,12 +121,18 @@ def get_dimensions(geometry, **kwargs):
 
 @multithreading_enabled
 def get_coordinate_dimension(geometry, **kwargs):
-    """Returns the dimensionality of the coordinates in a geometry (2 or 3).
+    """Returns the dimensionality of the coordinates in a geometry (2, 3 or 4).
 
-    Returns -1 for missing geometries (``None`` values).
+    The return value can be one of the following:
+
+    * Return 2 for geometries with XY coordinate types,
+    * Return 3 for XYZ or XYM coordinate types
+      (distinguished by :meth:`has_z` or :meth:`has_m`),
+    * Return 4 for XYZM coordinate types,
+    * Return -1 for missing geometries (``None`` values).
 
     Note that with GEOS < 3.12, if the first Z coordinate equals ``nan``, this function
-    will return ``2``.
+    will return ``2``. Geometries with M coordinates are supported with GEOS >= 3.12.
 
     Parameters
     ----------

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -619,9 +619,13 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def has_z(self):
-        """True if the geometry's coordinate sequence(s) have z values (are
-        3-dimensional)"""
+        """True if the geometry's coordinate sequence(s) have z values"""
         return bool(shapely.has_z(self))
+
+    @property
+    def has_m(self):
+        """True if the geometry's coordinate sequence(s) have m values"""
+        return bool(shapely.has_m(self))
 
     @property
     def is_empty(self):

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -7,6 +7,7 @@ from shapely.decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "has_z",
+    "has_m",
     "is_ccw",
     "is_closed",
     "is_empty",
@@ -40,7 +41,7 @@ __all__ = [
 
 @multithreading_enabled
 def has_z(geometry, **kwargs):
-    """Returns True if a geometry has a Z coordinate.
+    """Returns True if a geometry has Z coordinates.
 
     Note that for GEOS < 3.12 this function returns False if the (first) Z coordinate
     equals NaN.
@@ -53,7 +54,7 @@ def has_z(geometry, **kwargs):
 
     See also
     --------
-    get_coordinate_dimension
+    get_coordinate_dimension, has_m
 
     Examples
     --------
@@ -66,6 +67,36 @@ def has_z(geometry, **kwargs):
     False
     """
     return lib.has_z(geometry, **kwargs)
+
+
+@multithreading_enabled
+@requires_geos("3.12.0")
+def has_m(geometry, **kwargs):
+    """Returns True if a geometry has M coordinates.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+    **kwargs
+        See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    See also
+    --------
+    get_coordinate_dimension, has_z
+
+    Examples
+    --------
+    >>> from shapely import from_wkt
+    >>> has_m(from_wkt("POINT (0 0)"))
+    False
+    >>> has_m(from_wkt("POINT Z (0 0 0)"))
+    False
+    >>> has_m(from_wkt("POINT M (0 0 0)"))
+    True
+    >>> has_m(from_wkt("POINT ZM (0 0 0 0)"))
+    True
+    """
+    return lib.has_m(geometry, **kwargs)
 
 
 @multithreading_enabled

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1028,7 +1028,7 @@ def test_from_wkb_point_empty_m(wkb, expected_type):
     assert shapely.get_type_id(geom) == expected_type
     assert shapely.get_coordinate_dimension(geom) == 3
     assert not shapely.has_z(geom)
-    # TODO: assert shapely.has_m(geom)
+    assert shapely.has_m(geom)
 
 
 @pytest.mark.skipif(
@@ -1053,7 +1053,7 @@ def test_from_wkb_point_empty_zm(wkb, expected_type):
     assert shapely.get_type_id(geom) == expected_type
     assert shapely.get_coordinate_dimension(geom) == 4
     assert shapely.has_z(geom)
-    # TODO: assert shapely.has_m(geom)
+    assert shapely.has_m(geom)
 
 
 def test_to_wkb_point_empty_srid():
@@ -1077,10 +1077,10 @@ def test_pickle_z(geom):
     pickled = pickle.dumps(geom)
     actual = pickle.loads(pickled)
     assert_geometries_equal(actual, geom, tolerance=0)
-    if actual.is_empty:
-        pass  # GEOSHasZ with EMPTY geometries is inconsistent
-    else:
+    if not actual.is_empty:  # GEOSHasZ with EMPTY geometries is inconsistent
         assert actual.has_z
+    if shapely.geos_version >= (3, 12, 0):
+        assert not actual.has_m
 
 
 @pytest.mark.skipif(
@@ -1095,7 +1095,8 @@ def test_pickle_m(geom):
     actual = pickle.loads(pickled)
     assert_geometries_equal(actual, geom, tolerance=0)
     assert not actual.has_z
-    # TODO: assert actual.has_m
+    if not actual.is_empty:  # GEOSHasM with EMPTY geometries is inconsistent
+        assert actual.has_m
 
 
 @pytest.mark.skipif(
@@ -1109,11 +1110,9 @@ def test_pickle_zm(geom):
     pickled = pickle.dumps(geom)
     actual = pickle.loads(pickled)
     assert_geometries_equal(actual, geom, tolerance=0)
-    if actual.is_empty:
-        pass  # GEOSHasZ with EMPTY geometries is inconsistent
-    else:
+    if not actual.is_empty:  # GEOSHasZ with EMPTY geometries is inconsistent
         assert actual.has_z
-    # TODO: assert actual.has_m
+        assert actual.has_m
 
 
 @pytest.mark.parametrize("geom", all_types + (point_z, empty_point))

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -263,7 +263,7 @@ def test_has_m_all_types_m(geometry):
     reason="M coordinates not supported with GEOS < 3.12",
 )
 @pytest.mark.parametrize("geometry", all_types_zm)
-def test_has_m_all_types_zm(geometry):
+def test_has_z_has_m_all_types_zm(geometry):
     if shapely.is_empty(geometry):
         pytest.skip("GEOSHasZ with EMPTY geometries is inconsistent")
     assert shapely.has_z(geometry)

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -121,6 +121,9 @@ static char GEOSisSimpleAllTypes_r(void* context, void* geom) {
 static void* is_simple_data[1] = {GEOSisSimpleAllTypes_r};
 static void* is_ring_data[1] = {GEOSisRing_r};
 static void* has_z_data[1] = {GEOSHasZ_r};
+#if GEOS_SINCE_3_12_0
+static void* has_m_data[1] = {GEOSHasM_r};
+#endif
 /* the GEOSisClosed_r function fails on non-linestrings */
 static char GEOSisClosedAllTypes_r(void* context, void* geom) {
   int type = GEOSGeomTypeId_r(context, geom);
@@ -3829,6 +3832,10 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_Yd_Y(remove_repeated_points);
   DEFINE_Y_Y(line_merge_directed);
   DEFINE_CUSTOM(concave_hull, 3);
+#endif
+
+#if GEOS_SINCE_3_12_0
+  DEFINE_Y_b(has_m);
 #endif
 
   Py_DECREF(ufunc);


### PR DESCRIPTION
Add a basic `has_m` unary predicate function, available with GEOS >= 3.12.0.

#### Other changes to note
* Update some related docs for `get_coordinate_dimension`
* Add `has_z` to `UNARY_PREDICATES` for shapely/tests/test_predicates.py