### PR TITLE
FIX: to_wkt with empty Z geometry arrays

### DIFF
--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -415,6 +415,15 @@ def test_to_wkt_none():
     assert shapely.to_wkt(None) is None
 
 
+def test_to_wkt_array_with_empty_z():
+    # See GH-2004
+    empty_wkt = ["POINT Z EMPTY", None, "POLYGON Z EMPTY"]
+    empty_geoms = shapely.from_wkt(empty_wkt)
+    if shapely.geos_version < (3, 9, 0):
+        empty_wkt = ["POINT EMPTY", None, "POLYGON EMPTY"]
+    assert list(shapely.to_wkt(empty_geoms)) == empty_wkt
+
+
 def test_to_wkt_exceptions():
     with pytest.raises(TypeError):
         shapely.to_wkt(1)

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3386,8 +3386,9 @@ static void to_wkt_func(char** args, const npy_intp* dimensions, const npy_intp*
         goto finish;
       }
       if (wkt != NULL) {
+        Py_XDECREF(*out);
         *out = PyUnicode_FromString(wkt);
-        goto finish;
+        continue;
       }
 
 #else


### PR DESCRIPTION
This fixes an issue while using `to_wkt` as a ufunc on an array with GEOS >= 3.9.0 with empty geometries. The issue (discovered with GH-2004) is that the WKT writer finishes sometimes too early while processing geometries.

For instance, using shapely 2.0.2 with GEOS 3.12.1 via conda-forge:
```python
import shapely

empty_geoms = shapely.from_wkt(["POINT Z EMPTY", "POINT Z EMPTY"])
list(shapely.to_wkt(empty_geoms))
# ['POINT Z EMPTY', None]
```

It also seems that there could be a missing `Py_XDECREF(*out);`, but I'd appreciate someone with Python C API expertise to weight in.

This can be backported to `maint-2.0` too.