### PR TITLE
DOC: add versionadded note to new functions or keywords for 2.1

### DIFF
--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -539,10 +539,14 @@ def make_valid(geometry, method="linework", keep_collapsed=True, **kwargs):
     method : {'linework', 'structure'}, default 'linework'
         Algorithm to use when repairing geometry. 'structure'
         requires GEOS >= 3.10.
+
+        .. versionadded:: 2.1.0
     keep_collapsed : bool, default True
         For the 'structure' method, True will keep components that have collapsed into a
         lower dimensionality. For example, a ring collapsing to a line, or a line
         collapsing to a point. Must be True for the 'linework' method.
+
+        .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -1027,7 +1031,9 @@ def voronoi_polygons(
     ordered : bool or array_like, default False
         If set to True, polygons within the GeometryCollection will be ordered
         according to the order of the input vertices. Note that this may slow
-        down the computation. Requires GEOS >= 3.12.0
+        down the computation. Requires GEOS >= 3.12.0.
+
+        .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -44,6 +44,8 @@ def transform(
         one-dimensional arrays (x, y and optional z) instead of a single
         two-dimensional array.
 
+        .. versionadded:: 2.1.0
+
     See Also
     --------
     has_z : Returns a copy of a geometry array with a function applied to its

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -71,6 +71,8 @@ def points(
         - 'error': if any NaN or Inf is detected in the coordinates, a ValueError
           is raised. This option ensures that the created geometries have all
           finite coordinate values.
+
+        .. versionadded:: 2.1.0
     out : ndarray, optional
         An array (with dtype object) to output the geometries into.
     **kwargs
@@ -141,6 +143,8 @@ def linestrings(
           is raised. This option ensures that the created geometries have all
           finite coordinate values.
 
+          .. versionadded:: 2.1.0
+
     out : ndarray, optional
         An array (with dtype object) to output the geometries into.
     **kwargs
@@ -210,6 +214,9 @@ def linearrings(
         - 'error': if any NaN or Inf is detected in the coordinates, a ValueError
           is raised. This option ensures that the created geometries have all
           finite coordinate values.
+
+        .. versionadded:: 2.1.0
+
     out : ndarray, optional
         An array (with dtype object) to output the geometries into.
     **kwargs

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -758,6 +758,8 @@ class BaseGeometry(shapely.Geometry):
             If True, normalize the two geometries so that the coordinates are
             in the same order.
 
+            .. versionadded:: 2.1.0
+
         Examples
         --------
         >>> LineString(

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -74,6 +74,8 @@ def has_z(geometry, **kwargs):
 def has_m(geometry, **kwargs):
     """Returns True if a geometry has M coordinates.
 
+    .. versionadded:: 2.1.0
+
     Parameters
     ----------
     geometry : Geometry or array_like
@@ -980,6 +982,8 @@ def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
     normalize : bool, optional (default: False)
         If True, normalize the two geometries so that the coordinates are
         in the same order.
+
+        .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 


### PR DESCRIPTION
xref https://github.com/shapely/shapely/issues/1994#issuecomment-1987266626

With the upcoming 2.0 release, I think it will be nice to start documenting more explicitly when keywords or entire functions are new (I think it will be normal to require any >= 2, and when doing that you can only use features that already existed in 2.0).

Sphinx has a `versionadded` directive for this, and so this PR is adding that to the relevant places for 2.1.

If we like this, we should also try to think about doing this directly in PRs adding the new features.