### PR TITLE
FIX: fix WKT for empty M and ZM geometries

### DIFF
--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -593,9 +593,6 @@ def test_repr_point_z_empty():
     assert repr(empty_point_z) == "<POINT Z EMPTY>"
 
 
-@pytest.mark.xfail(
-    reason="TODO: fix WKT for empty M and ZM geometries; see GH-2004", strict=True
-)
 @pytest.mark.skipif(
     shapely.geos_version < (3, 12, 0),
     reason="M coordinates not supported with GEOS < 3.12",

--- a/src/geos.c
+++ b/src/geos.c
@@ -434,13 +434,13 @@ char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* g
 }
 #endif  // !GEOS_SINCE_3_13_0
 
-#if GEOS_SINCE_3_9_0
+#if GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
 
 /* Checks whether the geometry is a 3D empty geometry and, if so, create the WKT string
  *
  * GEOS 3.9.* is able to distiguish 2D and 3D simple geometries (non-collections). But the
  * but the WKT serialization never writes a 3D empty geometry. This function fixes that.
- * It only makes sense to use this for GEOS versions >= 3.9.
+ * It only makes sense to use this for GEOS versions >= 3.9 && < 3.12.
  *
  * Pending GEOS ticket: https://trac.osgeo.org/geos/ticket/1129
  *
@@ -500,7 +500,7 @@ char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom, char** w
   return PGERR_SUCCESS;
 }
 
-#endif  // GEOS_SINCE_3_9_0
+#endif  // GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
 
 /* GEOSInterpolate_r and GEOSInterpolateNormalized_r segfault on empty
  * geometries and also on collections with the first geometry empty.

--- a/src/geos.h
+++ b/src/geos.h
@@ -177,10 +177,10 @@ extern char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom)
 #if !GEOS_SINCE_3_13_0
 extern char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* geom, int dimension);
 #endif  // !GEOS_SINCE_3_13_0
-#if GEOS_SINCE_3_9_0
+#if GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
 extern char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom,
                                   char** wkt);
-#endif  // GEOS_SINCE_3_9_0
+#endif  // GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
 extern char geos_interpolate_checker(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 
 extern int init_geos(PyObject* m);

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -94,19 +94,20 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
   }
 #endif  // !GEOS_SINCE_3_13_0
 
-#if GEOS_SINCE_3_9_0
+#if !GEOS_SINCE_3_9_0
+  // Before GEOS 3.9.0, there was as segfault on e.g. MULTIPOINT (1 1, EMPTY)
+  errstate = check_to_wkt_compatible(ctx, geom);
+  if (errstate != PGERR_SUCCESS) {
+    goto finish;
+  }
+#elif !GEOS_SINCE_3_12_0
+  // Since GEOS 3.9.0 and before 3.12.0 further handling required
   errstate = wkt_empty_3d_geometry(ctx, geom, &wkt);
   if (errstate != PGERR_SUCCESS) {
     goto finish;
   }
   if (wkt != NULL) {
     result = PyUnicode_FromString(wkt);
-    goto finish;
-  }
-#else
-  // Before GEOS 3.9.0, there was as segfault on e.g. MULTIPOINT (1 1, EMPTY)
-  errstate = check_to_wkt_compatible(ctx, geom);
-  if (errstate != PGERR_SUCCESS) {
     goto finish;
   }
 #endif


### PR DESCRIPTION
This uses `wkt_empty_3d_geometry` only for GEOS >= 3.9.0 and < 3.12.0, otherwise it is not defined or used.

Closes #2004