### PR TITLE
BLD: use geos INSTALL_NAME_DIR for MacOS instead of specifying custom LDFLAGS with rpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,6 @@ jobs:
           CIBW_ENVIRONMENT_MACOS:
             GEOS_INSTALL=${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}
             GEOS_CONFIG=${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/bin/geos-config
-            LDFLAGS=-Wl,-rpath,${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/lib
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
           CIBW_ENVIRONMENT_WINDOWS:

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -56,6 +56,7 @@ build_geos(){
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=${GEOS_INSTALL} \
         -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_INSTALL_NAME_DIR=${GEOS_INSTALL}/lib \
         ${BUILD_TESTING} \
         ..
     cmake --build . -j 4


### PR DESCRIPTION
_If_ this works, it might be a bit cleaner (from https://github.com/isciences/exactextract/pull/87)