### PR TITLE
BLD: update build-system requires to use latest numpy instead of oldest-supported-numpy - build wheels with numpy 2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs shapely.tests
+          CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,17 +119,20 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
           CIBW_ENVIRONMENT_LINUX:
+            PIP_PRE=1
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}
             GEOS_CONFIG=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/bin/geos-config
             LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/lib
           CIBW_ENVIRONMENT_MACOS:
+            PIP_PRE=1
             GEOS_INSTALL=${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}
             GEOS_CONFIG=${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/bin/geos-config
             LDFLAGS=-Wl,-rpath,${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/lib
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
           CIBW_ENVIRONMENT_WINDOWS:
+            PIP_PRE=1
             GEOS_INSTALL='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}'
             GEOS_LIBRARY_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\lib'
             GEOS_INCLUDE_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\include'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,6 @@ jobs:
         # the standard build isolation based on build-system.requires, to
         # ensure we build against numpy nightly (numpy 2.0 compat)
         run: |
-          pip install -e .
           if [ -z "${{ matrix.numpy }}" ]; then
             pip install -e . --no-build-isolation
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,8 +161,16 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
 
       - name: Build and install Shapely
+        # for the numpy nightly build, we temporarily need to build without
+        # the standard build isolation based on build-system.requires, to
+        # ensure we build against numpy nightly (numpy 2.0 compat)
         run: |
           pip install -e .
+          if [ -z "${{ matrix.numpy }}" ]; then
+            pip install -e . --no-build-isolation
+          else
+            pip install -e .
+          fi
 
       - name: Overview of the Python environment (pip list)
         run: pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,12 @@
 [build-system]
 requires = [
     "Cython",
-    "oldest-supported-numpy",
+    # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
+    # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
+    # define).  For older Python versions (where NumPy 1.25 is not yet avaiable)
+    # continue using oldest-support-numpy.
+    "oldest-supported-numpy; python_version<'3.9'",
+    "numpy>=1.25; python_version>='3.9'",
     "setuptools>=61.0.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -38,7 +43,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.14,<2",
+    "numpy>=1.14,<3",
 ]
 
 [project.optional-dependencies]

--- a/shapely/testing.py
+++ b/shapely/testing.py
@@ -106,8 +106,8 @@ def assert_geometries_equal(
     if normalize:
         x = shapely.normalize(x)
         y = shapely.normalize(y)
-    x = np.array(x, copy=False)
-    y = np.array(y, copy=False)
+    x = np.asarray(x)
+    y = np.asarray(y)
 
     is_scalar = x.ndim == 0 or y.ndim == 0
 


### PR DESCRIPTION
See https://github.com/shapely/shapely/issues/1972 for overview of the numpy 2.0 compatibility. Now that there is a numpy 2.0 rc with a stable ABI, packages are encourages to make a new release that is compatible with the upcoming numpy 2.0 with compatible wheels.

This PR is to make the 2.0.x branch compatible with numpy 2.0 (for a 2.0.4 release), and is essentially a (partial) backport of

* https://github.com/shapely/shapely/pull/1974/
* https://github.com/shapely/shapely/pull/2007
* https://github.com/shapely/shapely/pull/1973