### PR TITLE
BUG: fix to_ragged_array for Points with missing values

### DIFF
--- a/shapely/_ragged_array.py
+++ b/shapely/_ragged_array.py
@@ -37,7 +37,7 @@ from shapely._geometry import (
     get_type_id,
 )
 from shapely.coordinates import get_coordinates
-from shapely.predicates import is_empty
+from shapely.predicates import is_empty, is_missing
 
 __all__ = ["to_ragged_array", "from_ragged_array"]
 
@@ -50,7 +50,8 @@ def _get_arrays_point(arr, include_z):
     coords = get_coordinates(arr, include_z=include_z)
 
     # empty points are represented by NaNs
-    empties = is_empty(arr)
+    # + missing geometries should also be present with some value
+    empties = is_empty(arr) | is_missing(arr)
     if empties.any():
         indices = np.nonzero(empties)[0]
         indices = indices - np.arange(len(indices))

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -110,18 +110,30 @@ def test_points():
             "POINT EMPTY",
             "POINT EMPTY",
             "POINT (4 4)",
+            None,
             "POINT EMPTY",
         ]
     )
     typ, result, offsets = shapely.to_ragged_array(arr)
     expected = np.array(
-        [[0, 0], [1, 1], [np.nan, np.nan], [np.nan, np.nan], [4, 4], [np.nan, np.nan]]
+        [
+            [0, 0],
+            [1, 1],
+            [np.nan, np.nan],
+            [np.nan, np.nan],
+            [4, 4],
+            [np.nan, np.nan],
+            [np.nan, np.nan],
+        ]
     )
     assert typ == shapely.GeometryType.POINT
+    assert len(result) == len(arr)
     assert_allclose(result, expected)
     assert len(offsets) == 0
 
     geoms = shapely.from_ragged_array(typ, result)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("POINT EMPTY")
     assert_geometries_equal(geoms, arr)
 
 
@@ -133,6 +145,7 @@ def test_linestrings():
             "LINESTRING EMPTY",
             "LINESTRING EMPTY",
             "LINESTRING (10 10, 20 20, 10 40)",
+            None,
             "LINESTRING EMPTY",
         ]
     )
@@ -151,13 +164,15 @@ def test_linestrings():
             [10.0, 40.0],
         ]
     )
-    expected_offsets = np.array([0, 3, 7, 7, 7, 10, 10])
+    expected_offsets = np.array([0, 3, 7, 7, 7, 10, 10, 10])
     assert typ == shapely.GeometryType.LINESTRING
     assert_allclose(coords, expected)
     assert len(offsets) == 1
     assert_allclose(offsets[0], expected_offsets)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("LINESTRING EMPTY")
     assert_geometries_equal(result, arr)
 
 
@@ -169,6 +184,7 @@ def test_polygons():
             "POLYGON EMPTY",
             "POLYGON EMPTY",
             "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
+            None,
             "POLYGON EMPTY",
         ]
     )
@@ -197,7 +213,7 @@ def test_polygons():
         ]
     )
     expected_offsets1 = np.array([0, 5, 10, 14, 19])
-    expected_offsets2 = np.array([0, 1, 3, 3, 3, 4, 4])
+    expected_offsets2 = np.array([0, 1, 3, 3, 3, 4, 4, 4])
 
     assert typ == shapely.GeometryType.POLYGON
     assert_allclose(coords, expected)
@@ -206,6 +222,8 @@ def test_polygons():
     assert_allclose(offsets[1], expected_offsets2)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("POLYGON EMPTY")
     assert_geometries_equal(result, arr)
 
 
@@ -217,6 +235,7 @@ def test_multipoints():
             "MULTIPOINT EMPTY",
             "MULTIPOINT EMPTY",
             "MULTIPOINT (30 10, 10 30, 40 40)",
+            None,
             "MULTIPOINT EMPTY",
         ]
     )
@@ -233,7 +252,7 @@ def test_multipoints():
             [40.0, 40.0],
         ]
     )
-    expected_offsets = np.array([0, 4, 5, 5, 5, 8, 8])
+    expected_offsets = np.array([0, 4, 5, 5, 5, 8, 8, 8])
 
     assert typ == shapely.GeometryType.MULTIPOINT
     assert_allclose(coords, expected)
@@ -241,6 +260,8 @@ def test_multipoints():
     assert_allclose(offsets[0], expected_offsets)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("MULTIPOINT EMPTY")
     assert_geometries_equal(result, arr)
 
 
@@ -252,6 +273,7 @@ def test_multilinestrings():
             "MULTILINESTRING EMPTY",
             "MULTILINESTRING EMPTY",
             "MULTILINESTRING ((35 10, 45 45), (15 40, 10 20), (30 10, 10 30, 40 40))",
+            None,
             "MULTILINESTRING EMPTY",
         ]
     )
@@ -278,7 +300,7 @@ def test_multilinestrings():
         ]
     )
     expected_offsets1 = np.array([0, 3, 6, 10, 12, 14, 17])
-    expected_offsets2 = np.array([0, 1, 3, 3, 3, 6, 6])
+    expected_offsets2 = np.array([0, 1, 3, 3, 3, 6, 6, 6])
 
     assert typ == shapely.GeometryType.MULTILINESTRING
     assert_allclose(coords, expected)
@@ -287,6 +309,8 @@ def test_multilinestrings():
     assert_allclose(offsets[1], expected_offsets2)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("MULTILINESTRING EMPTY")
     assert_geometries_equal(result, arr)
 
 
@@ -298,6 +322,7 @@ def test_multipolygons():
             "MULTIPOLYGON EMPTY",
             "MULTIPOLYGON EMPTY",
             "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)))",
+            None,
             "MULTIPOLYGON EMPTY",
         ]
     )
@@ -335,7 +360,7 @@ def test_multipolygons():
     )
     expected_offsets1 = np.array([0, 5, 9, 13, 19, 23, 27])
     expected_offsets2 = np.array([0, 2, 3, 5, 6])
-    expected_offsets3 = np.array([0, 1, 3, 3, 3, 4, 4])
+    expected_offsets3 = np.array([0, 1, 3, 3, 3, 4, 4, 4])
 
     assert typ == shapely.GeometryType.MULTIPOLYGON
     assert_allclose(coords, expected)
@@ -345,6 +370,8 @@ def test_multipolygons():
     assert_allclose(offsets[2], expected_offsets3)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
+    # in a roundtrip, missing geometries come back as empty
+    arr[-2] = shapely.from_wkt("MULTIPOLYGON EMPTY")
     assert_geometries_equal(result, arr)
 
 


### PR DESCRIPTION
Currently, if you have missing values (`None`) in an array of Points and convert it to a ragged array, the resulting array is not of the same length as the input:

```
>>> import shapely
>>> arr = shapely.from_wkt(["POINT (1 1)", None, "POINT (3 3)"])
>>> shapely.to_ragged_array(arr)[1]
 array([[1., 1.],
        [3., 3.]])
```

while in case of _empty_ points we ensure to insert NaNs in the resulting array:

```
>>> arr = shapely.from_wkt(["POINT (1 1)", "POINT EMPTY", "POINT (3 3)"])
>>> shapely.to_ragged_array(arr)[1]
 array([[ 1.,  1.],
        [nan, nan],
        [ 3.,  3.]])
```

This is buggy. First, it makes it awkward to roundtrip or use the resulting values to convert to (Geo)Arrow data, because for Points (which uses a fixed size list type in Arrow), we assume the ragged array is of exactly the same length. Second, once you have a mixture of missing and empty geometries, this actually also just fails and raises an error in our implementation.

The fix is to also insert NaNs for missing points, just as we already do for empty points (`get_coordinates`, which is used under the hood, drops both empty and missing points). 
That means that in a naive roundtrip, the missing points will come back as empty points. But 1) that is consistent with other geometry types (all other types work with offsets, where there is no increment in the offset for both empty of missing geometry, and thus this also roundtrips as empty), and 2) if you want to full roundtrip supporting missing values with the current interface, you need to keep track of a validity mask separately.

The fix is only for Points, there is a bigger diff in the tests because I added tests for all geometry types (but no behaviour change there, it's just testing current behaviour).