### PR TITLE
PERF: optimize coordinate access for scalar Point

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -24,6 +24,7 @@ from shapely._geos cimport (
     GEOSGeom_createPolygon_r,
     GEOSGeom_destroy_r,
     GEOSGeometry,
+    GEOSGeomGetX_r,
     GEOSGeomTypeId_r,
     GEOSGetExteriorRing_r,
     GEOSGetGeometryN_r,
@@ -392,6 +393,21 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
             geom_idx_1 += collection_size[coll_idx]
 
     return out
+
+
+def point_x(point):
+    cdef GEOSGeometry *geom = NULL
+    cdef double result
+
+    with get_geos_handle() as geos_handle:
+        if PyGEOS_GetGEOSGeometry(<PyObject *>point, &geom) == 0:
+            raise TypeError("One of the arguments is of incorrect type. "
+                            "Please provide only Geometry objects.")
+
+        if GEOSGeomGetX_r(geos_handle, geom, &result) == 0:
+            return  # GEOSException is raised by get_geos_handle
+
+    return result
 
 
 def _geom_factory(uintptr_t g):

--- a/shapely/_geos.pxd
+++ b/shapely/_geos.pxd
@@ -44,6 +44,7 @@ cdef extern from "geos_c.h":
     int GEOSCoordSeq_setZ_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
     int GEOSCoordSeq_getSize_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int* size) nogil
 
+    int GEOSGeomGetX_r(GEOSContextHandle_t handle, const GEOSGeometry *g, double *x)
 
 cdef class get_geos_handle:
     cdef GEOSContextHandle_t handle

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 import shapely
+from shapely import _geometry_helpers
 from shapely.errors import DimensionError
 from shapely.geometry.base import BaseGeometry
 
@@ -85,7 +86,7 @@ class Point(BaseGeometry):
     @property
     def x(self):
         """Return x coordinate."""
-        return shapely.get_x(self)
+        return _geometry_helpers.point_x(self)
 
     @property
     def y(self):


### PR DESCRIPTION
Illustration of what it would entail to optimize specifically the `Point.x` et al attributes for scalar points.

```python
In [1]: import shapely

In [2]: p = shapely.Point(12, 34)

In [3]: %timeit p.x
3.15 µs ± 3.46 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)    # <-- main
236 ns ± 0.164 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  # <-- PR
```

The reason this is so much faster is mostly from avoiding the ufunc machinery overhead.

While this is relatively little code for just those `x`/`y`/`z` attributes, the question is of course then "could we also speed up this other attribute .. ?", and we definitely don't want to end up reimplementing all ufuncs for scalar geometries.