### PR TITLE
Fix a number of minor typos

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,7 +29,7 @@ Breaking changes in GEOS 3.12:
 
 - ``oriented_envelope`` / ``minimum_rotated_rectangle`` changed its implementation
   in GEOS 3.12. Be aware that results will change when updating GEOS. Coincidentally
-  the implemenation is similar to the shapely 1.x approach. (#1885)
+  the implementation is similar to the shapely 1.x approach. (#1885)
 - ``get_coordinate_dimension`` / ``has_z`` now considers geometries three dimensional if
   they have a NaN z coordinate. (#1885)
 - ``voronoi_polygons`` changed its output from a LINESTRING to a MULTILINESTRING in case

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ html_context = {
 
 
 # write dummy _reference.rst with all functions listed to ensure the reference/
-# stub pages are crated (the autogeneration of those stub pages by autosummary 
+# stub pages are created (the autogeneration of those stub pages by autosummary 
 # happens before the jinja rendering is done, and thus at that point the
 # autosummary directives do not yet contain the final content
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,8 +35,8 @@ nightly wheel packages::
     python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple shapely
 
 
-Installation from source with custom GEOS libary
-------------------------------------------------
+Installation from source with custom GEOS library
+-------------------------------------------------
 
 You may want to use a specific GEOS version or a GEOS distribution that is
 already present on your system (for compatibility with other modules that

--- a/docs/migration_pygeos.rst
+++ b/docs/migration_pygeos.rst
@@ -14,7 +14,7 @@ Therefore, everybody using PyGEOS is highly recommended to migrate to Shapely
 
 Generally speaking, this should be a smooth experience because all
 functionality of PyGEOS was added to Shapely. All vectorized functions
-availabe in ``pygeos`` have been added to the top-level ``shapely`` module,
+available in ``pygeos`` have been added to the top-level ``shapely`` module,
 with only minor differences (see below). Migrating from PyGEOS to Shapely 2.0
 can thus be done by replacing the ``pygeos`` import and module calls::
 
@@ -87,4 +87,4 @@ Other differences
 - The behaviour of ``union_all()`` / ``intersection_all()`` / ``symmetric_difference_all``
   was changed to return an empty GeometryCollection for an empty or all-None
   sequence as input (instead of returning None).
-- The ``radius`` keyword of the ``buffer()`` funtion was renamed to ``distance``.
+- The ``radius`` keyword of the ``buffer()`` function was renamed to ``distance``.

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -480,7 +480,7 @@ Methods to extract all parts or coordinates at once have been added:
 * The :func:`.get_rings` function, similar as ``get_parts`` but specifically
   to extract the rings of Polygon geometries.
 * The :func:`.get_coordinates` function to get all coordinates from a
-  geometry or array of goemetries as an array of floats.
+  geometry or array of geometries as an array of floats.
 
 Each of those three functions has an optional ``return_index`` keyword, which
 allows to also return the indexes of the original geometries in the source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "Cython",
     # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
     # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
-    # define).  For older Python versions (where NumPy 1.25 is not yet avaiable)
+    # define).  For older Python versions (where NumPy 1.25 is not yet available)
     # continue using oldest-support-numpy.
     "oldest-supported-numpy; python_version<'3.9'",
     "numpy>=1.25; python_version>='3.9'",

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -309,7 +309,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
     cdef int[:] collection_size = np.bincount(indices).astype(np.int32)
 
     # A temporary array for the geometries that will be given to CreateCollection.
-    # Its size equals max(collection_size) to accomodate the largest collection.
+    # Its size equals max(collection_size) to accommodate the largest collection.
     temp_geoms = np.empty(shape=(np.max(collection_size), ), dtype=np.intp)
     cdef np.intp_t[:] temp_geoms_view = temp_geoms
 

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -308,7 +308,7 @@ def polygons(geometries, holes=None, indices=None, out=None, **kwargs):
     >>> polygons([ring_1, ring_2], indices=[0, 0])[0]
     <POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6, 2 6))>
 
-    Missing input values (``None``) are skipd and may result in an
+    Missing input values (``None``) are skipped and may result in an
     empty polygon:
 
     >>> polygons(None)
@@ -413,7 +413,7 @@ def multipoints(geometries, indices=None, out=None, **kwargs):
     >>> multipoints([point_1, point_2, point_2], indices=[0, 0, 1]).tolist()
     [<MULTIPOINT ((1 1), (2 2))>, <MULTIPOINT ((2 2))>]
 
-    Missing input values (``None``) are skipd and may result in an
+    Missing input values (``None``) are skipped and may result in an
     empty multipoint:
 
     >>> multipoints([None])
@@ -588,7 +588,7 @@ def destroy_prepared(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
-        Geometries are changed inplace
+        Geometries are changed in-place
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -143,14 +143,14 @@ def to_wkb(
     ----------
     geometry : Geometry or array_like
     hex : bool, default False
-        If true, export the WKB as a hexidecimal string. The default is to
+        If true, export the WKB as a hexadecimal string. The default is to
         return a binary bytes object.
     output_dimension : int, default None
         The output dimension for the WKB. Supported values are 2, 3 and 4 for
         GEOS 3.12+. Default None will automatically choose 3 or 4, depending on
         the version of GEOS.
         Specifying 3 means that up to 3 dimensions will be written but 2D
-        geometries will still be represented as 2D in the WKB represenation.
+        geometries will still be represented as 2D in the WKB representation.
     byte_order : int, default -1
         Defaults to native machine byte order (-1). Use 0 to force big endian
         and 1 for little endian.

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -1,7 +1,7 @@
 """
 Plot single geometries using Matplotlib.
 
-Note: this module is experimental, and mainly targetting (interactive)
+Note: this module is experimental, and mainly targeting (interactive)
 exploration, debugging and illustration purposes.
 
 """
@@ -38,7 +38,7 @@ def patch_from_polygon(polygon, **kwargs):
     """
     Gets a Matplotlib patch from a (Multi)Polygon.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -69,7 +69,7 @@ def plot_polygon(
     """
     Plot a (Multi)Polygon.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -132,7 +132,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     """
     Plot a (Multi)LineString/LinearRing.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -144,7 +144,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     add_points : bool, default True
         If True, also plot the coordinates (vertices) as points.
     color : matplotlib color specification
-        Color for the line (edgecolor under the hood) and pointes.
+        Color for the line (edgecolor under the hood) and points.
     linewidth : float, default 2
         The line width for the polygon boundary.
     **kwargs

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -113,7 +113,7 @@ def is_ccw(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
-        This function will return False for non-linear goemetries and for
+        This function will return False for non-linear geometries and for
         lines with fewer than 4 points (including the closing point).
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.

--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -44,7 +44,7 @@ def get_tst_format_point_params():
             ("g", xy2, "POINT (-169.910918 -18.997564)", False),
             ("0.2g", xy2, "POINT (-169.91 -19)", False),
         ]
-    # without precsions test GEOS rounding_precision=-1; different than Python
+    # without precisions test GEOS rounding_precision=-1; different than Python
     test_list += [
         ("f", (1, 2), f"POINT ({1:.16f} {2:.16f})", False),
         ("F", xyz3, "POINT Z ({:.16f} {:.16f} {:.16f})".format(*xyz3), False),

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -274,7 +274,7 @@ def test_set_nan():
 
 def test_set_nan_same_objects():
     # You can't put identical objects in a set.
-    # x = float("nan"); set([x, x]) also retuns a set with 1 element
+    # x = float("nan"); set([x, x]) also returns a set with 1 element
     a = set([line_string_nan] * 10)
     assert len(a) == 1
 

--- a/shapely/tests/test_linear.py
+++ b/shapely/tests/test_linear.py
@@ -178,7 +178,7 @@ def test_shared_paths_non_linestring():
 
 
 def _prepare_input(geometry, prepare):
-    """Prepare without modifying inplace"""
+    """Prepare without modifying in-place"""
     if prepare:
         geometry = shapely.transform(geometry, lambda x: x)  # makes a copy
         shapely.prepare(geometry)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -205,7 +205,7 @@ def test_equals_exact_tolerance():
 def test_equals_exact_normalize():
     l1 = LineString([(0, 0), (1, 1)])
     l2 = LineString([(1, 1), (0, 0)])
-    # default requirs same order of coordinates
+    # default requires same order of coordinates
     assert not shapely.equals_exact(l1, l2)
     assert shapely.equals_exact(l1, l2, normalize=True)
 
@@ -356,7 +356,7 @@ def test_is_ccw(geom, expected):
 
 
 def _prepare_with_copy(geometry):
-    """Prepare without modifying inplace"""
+    """Prepare without modifying in-place"""
     geometry = shapely.transform(geometry, lambda x: x)  # makes a copy
     shapely.prepare(geometry)
     return geometry

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -18,14 +18,14 @@ SET_OPERATIONS = (
     shapely.intersection,
     shapely.symmetric_difference,
     shapely.union,
-    # shapely.coverage_union is tested seperately
+    # shapely.coverage_union is tested separately
 )
 
 REDUCE_SET_OPERATIONS = (
     (shapely.intersection_all, shapely.intersection),
     (shapely.symmetric_difference_all, shapely.symmetric_difference),
     (shapely.union_all, shapely.union),
-    #  shapely.coverage_union_all, shapely.coverage_union) is tested seperately
+    #  shapely.coverage_union_all, shapely.coverage_union) is tested separately
 )
 
 # operations that support fixed precision
@@ -270,7 +270,7 @@ def test_set_operation_prec_reduce_all_none(n, func, related_func):
 @pytest.mark.parametrize("n", range(1, 4))
 def test_coverage_union_reduce_1dim(n):
     """
-    This is tested seperately from other set operations as it expects only
+    This is tested separately from other set operations as it expects only
     non-overlapping polygons
     """
     test_data = [
@@ -304,7 +304,7 @@ def test_coverage_union_overlapping_inputs():
     other = Polygon([(1, 0), (0.9, 1), (2, 1), (2, 0), (1, 0)])
 
     if shapely.geos_version >= (3, 12, 0):
-        # Return mostly unchaged output
+        # Return mostly unchanged output
         result = shapely.coverage_union(polygon, other)
         expected = shapely.multipolygons([polygon, other])
         assert_geometries_equal(result, expected, normalize=True)

--- a/src/coords.c
+++ b/src/coords.c
@@ -371,7 +371,7 @@ npy_intp CountCoords(PyArrayObject* arr) {
       result = -1;
       goto finish;
     }
-    /* skip incase obj was None */
+    /* skip in case obj was None */
     if (geom == NULL) {
       continue;
     }
@@ -519,7 +519,7 @@ PyObject* SetCoords(PyArrayObject* geoms, PyArrayObject* coords) {
   PyObject* new_obj;
   GEOSGeometry *geom, *new_geom;
 
-  /* SetCoords acts implace: if the array is zero-sized, just return the
+  /* SetCoords acts in-place: if the array is zero-sized, just return the
   same object */
   if (PyArray_SIZE(geoms) == 0) {
     Py_INCREF((PyObject*)geoms);

--- a/src/geos.c
+++ b/src/geos.c
@@ -438,8 +438,8 @@ char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* g
 
 /* Checks whether the geometry is a 3D empty geometry and, if so, create the WKT string
  *
- * GEOS 3.9.* is able to distiguish 2D and 3D simple geometries (non-collections). But the
- * but the WKT serialization never writes a 3D empty geometry. This function fixes that.
+ * GEOS 3.9.* is able to distinguish 2D and 3D simple geometries (non-collections). But
+ * the WKT serialization never writes a 3D empty geometry. This function fixes that.
  * It only makes sense to use this for GEOS versions >= 3.9 && < 3.12.
  *
  * Pending GEOS ticket: https://trac.osgeo.org/geos/ticket/1129

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -128,7 +128,7 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     /* get the geometry */
     ptr = PyArray_GETPTR1((PyArrayObject*)arr, i);
     obj = *(GeometryObject**)ptr;
-    /* fail and cleanup incase obj was no geometry */
+    /* fail and cleanup in case obj was no geometry */
     if (!get_geom(obj, &geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
       GEOSSTRtree_destroy_r(ctx, tree);
@@ -974,7 +974,7 @@ static PyObject* STRtree_dwithin(STRtreeObject* self, PyObject* args) {
   index_vec_t src_indexes;
 
   // Addresses in tree geometries (_geoms) that overlap with expanded bboxes around
-  // intput geometries
+  // input geometries
   tree_geom_vec_t query_geoms;
 
   // Addresses in tree geometries (_geoms) that meet DistanceWithin predicate

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -522,7 +522,7 @@ static void* GetExteriorRing(void* context, void* geom) {
   return ret;
 }
 static void* get_exterior_ring_data[1] = {GetExteriorRing};
-/* the normalize funcion acts inplace */
+/* the normalize function acts in-place */
 static void* GEOSNormalize_r_with_clone(void* context, void* geom) {
   int ret;
   void* new_geom = GEOSGeom_clone_r(context, geom);
@@ -835,7 +835,7 @@ static void* GetGeometryN(void* context, void* geom, int n) {
   return ret;
 }
 static void* get_geometry_data[1] = {GetGeometryN};
-/* the set srid funcion acts inplace */
+/* the set srid function acts in-place */
 static void* GEOSSetSRID_r_with_clone(void* context, void* geom, int srid) {
   void* ret = GEOSGeom_clone_r(context, geom);
   if (ret == NULL) {
@@ -1309,7 +1309,7 @@ static void YY_d_func(char** args, const npy_intp* dimensions, const npy_intp* s
         errstate = PGERR_GEOS_EXCEPTION;
         goto finish;
       }
-      /* incase the outcome is 0.0, check the inputs for emptyness */
+      /* in case the outcome is 0.0, check the inputs for emptyness */
       if (*op1 == 0.0) {
         if (GEOSisEmpty_r(ctx, in1) || GEOSisEmpty_r(ctx, in2)) {
           *(double*)op1 = NPY_NAN;


### PR DESCRIPTION
Most are in comments; some are in user-visible places like changelogs and doc-strings.

I noticed a typo in a comment in `pyproject.toml` while updating the [`python-shapely` package](https://src.fedoraproject.org/rpms/python-shapely) in Fedora; I used [`codespell`](https://github.com/codespell-project/codespell) to help me find others.