### PR TITLE
ENH: add copy=None to CoordinateSequence.__array__

### DIFF
--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -46,8 +46,13 @@ class CoordinateSequence:
         else:
             raise TypeError("key must be an index or slice")
 
-    def __array__(self, dtype=None):
-        return self._coords
+    def __array__(self, dtype=None, copy=None):
+        if copy is False:
+            raise ValueError("`copy=False` isn't supported. A copy is always created.")
+        elif copy is True:
+            return self._coords.copy()
+        else:
+            return self._coords
 
     @property
     def xy(self):

--- a/shapely/tests/geometry/test_coords.py
+++ b/shapely/tests/geometry/test_coords.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from shapely import LineString
+from shapely.tests.common import line_string, line_string_z, point, point_z
 
 
 class TestCoords:
@@ -84,3 +85,18 @@ class TestXY:
         assert list(x) == [0.0, 1.0]
         assert len(y) == 2
         assert list(y) == [0.0, 1.0]
+
+
+@pytest.mark.parametrize("geom", [point, point_z, line_string, line_string_z])
+def test_coords_array_copy(geom):
+    """Test CoordinateSequence.__array__ method."""
+    coord_seq = geom.coords
+    assert np.array(coord_seq) is not np.array(coord_seq)
+    assert np.array(coord_seq, copy=True) is not np.array(coord_seq, copy=True)
+
+    # Behaviour of copy=False is different between NumPy 1.x and 2.x
+    if int(np.version.short_version.split(".", 1)[0]) >= 2:
+        with pytest.raises(ValueError, match="A copy is always created"):
+            np.array(coord_seq, copy=False)
+    else:
+        assert np.array(coord_seq, copy=False) is np.array(coord_seq, copy=False)


### PR DESCRIPTION
Recent CI failures have picked up a recent NumPy 2.0 change, noted in the migration guide under ["Adapting to changes in the copy keyword"](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword).

A simple fix appears to be to simply add `copy=None` to the `__array__` signature. This value is not used by the method.

---

[Here is an example failure](https://github.com/shapely/shapely/actions/runs/9070802200/job/24923285344#step:16:178):
```
________________________ TestCoords.test_data_promotion ________________________

self = <shapely.tests.geometry.test_coords.TestCoords object at 0x7f6bbc72fb90>

    def test_data_promotion(self):
        coords = np.array([[12, 34], [56, 78]], dtype=np.float32)
>       processed_coords = np.array(LineString(coords).coords)
E       DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.

shapely/tests/geometry/test_coords.py:16: DeprecationWarning
```

Note that test failures with macos in this PR are unrelated.