### PR TITLE
CI: use macos-13 for tests to run x64 python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           echo "${{ env.GEOS_INSTALL }}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-13' }}
 
       # Windows requires special treatment:
       # - geos-config does not exist, so we specify include and library paths

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
         geos: [3.8.4, 3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
         include:


### PR DESCRIPTION
Installing python with a x64 architecture stopped working with `macos-latest` (https://github.com/actions/setup-python/issues/855#issuecomment-2096792205), so as a quick workaround specifically asking for macos-13 runner instead (longer term we should check how to run with latest macos, but that requires changing the set up of the `architecture` matrix entry a bit)