### PR TITLE
Corrected documentation on `intersects` predicate

### DIFF
--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -780,7 +780,7 @@ def equals(a, b, **kwargs):
 def intersects(a, b, **kwargs):
     """Returns True if A and B share any portion of space.
 
-    Intersects implies that overlaps, touches and within are True.
+    Intersects implies that overlaps, touches, or within are True.
 
     Parameters
     ----------


### PR DESCRIPTION
Added Oxford comma and flipped 'and' to 'or' in "Intersects implies that overlaps, touches and within are True."

The previous phrasing was definitely a false statement, as per this example:

```
>>> import shapely                                                                                                                                                                                                                                                                                                                                                                         
>>> line = shapely.LineString([(0, 0), (1, 1)])                                                                                                                                                                                                                                                                                                                                            
>>> line2 = shapely.LineString([(0, 2), (2, 0)])
>>> shapely.intersects(line, line2)                                                                                                                                                                                                                                                                                                                                                        
True                                                                                                                                                                                                                                                                                                                                                                                       
>>> shapely.within(line, line2)                                                                                                                                                                                                                                                                                                                                                            
False
```

I assume it was a typo and what was intended was to indicate that at least one of (overlaps, touches, within) is True if `intersects` is True.