### PR TITLE
BLD: replace pkg_resources, prepend numpy include dirs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ exclude MANIFEST.in
 include CITATION.cff CHANGES.txt CREDITS.txt LICENSE.txt README.rst
 include pyproject.toml versioneer.py
 recursive-include src *.c *.h
-recursive-include tests *.py
 recursive-include shapely *.pxd *.pyx
 recursive-exclude shapely *.c
 include docs/*.rst

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from pkg_resources import parse_version
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
 # ensure the current directory is on sys.path so versioneer can be imported
@@ -42,15 +41,13 @@ def get_geos_config(option):
     """
     cmd = os.environ.get("GEOS_CONFIG", "geos-config")
     try:
-        stdout, stderr = subprocess.Popen(
-            [cmd, option], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        ).communicate()
+        proc = subprocess.run([cmd, option], capture_output=True, text=True)
     except OSError:
         return
-    if stderr and not stdout:
-        log.warning("geos-config %s returned '%s'", option, stderr.decode().strip())
+    if proc.stderr and not proc.stdout:
+        log.warning("geos-config %s returned '%s'", option, proc.stderr.strip())
         return
-    result = stdout.decode().strip()
+    result = proc.stdout.strip()
     log.debug("geos-config %s returned '%s'", option, result)
     return result
 
@@ -86,11 +83,12 @@ def get_geos_paths():
         )
         return {}
 
-    if parse_version(geos_version) < parse_version(MIN_GEOS_VERSION):
+    def version_tuple(ver):
+        return tuple(int(itm) if itm.isnumeric() else itm for itm in ver.split("."))
+
+    if version_tuple(geos_version) < version_tuple(MIN_GEOS_VERSION):
         raise ImportError(
-            "GEOS version should be >={}, found {}".format(
-                MIN_GEOS_VERSION, geos_version
-            )
+            f"GEOS version should be >={MIN_GEOS_VERSION}, found {geos_version}"
         )
 
     libraries = []
@@ -133,7 +131,7 @@ class build_ext(_build_ext):
 
         import numpy
 
-        self.include_dirs.append(numpy.get_include())
+        self.include_dirs.insert(0, numpy.get_include())
 
 
 ext_modules = []


### PR DESCRIPTION
This PR replaces setuptools' deprecated [`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html) module with a simple function to compare versions as tuples.

Expressions like this should be fine: `assert version_tuple("3.8") < version_tuple("3.13.0dev")`

Other changes:

- Replace `subprocess.Popen` with simpler `subprocess.run`
- Prepend `numpy.get_include()` rather than append, otherwise system libs (e.g. [`/usr/include/python3.10`](https://packages.ubuntu.com/jammy/amd64/python3-numpy/filelist)) will take precedence over locally/venv installed libs. This is important while developing for new numpy 2.0 libs.
- The `tests` subdir was moved, so remove from MANIFEST.in