### PR TITLE
CI: Update macos-11 image to macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         - os: windows-2019
           arch: AMD64
           msvc_arch: x64
-        - os: macos-11
+        - os: macos-13
           arch: x86_64
           cmake_osx_architectures: x86_64
         - os: macos-14


### PR DESCRIPTION
According to the 2024 GitHub Actions macOS runner image roadmap, macos-11 is removed. Macos-12 will be deprecated next month, so it could make sense to jump to macos-13.