### PR TITLE
BLD/CLN: clean-up wheel build setup now numpy 2.0 final is out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,7 @@ jobs:
             GEOS_INCLUDE_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\include'
           CIBW_BEFORE_ALL: ./ci/install_geos.sh
           CIBW_BEFORE_ALL_WINDOWS: ci\install_geos.cmd
-          # TEMP don't use automated/isolated build environment, but manually
-          # install build dependencies so we can build with numpy 2.0
-          # once numpy 2.0 is out, this can be removed again
-          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-          CIBW_BEFORE_BUILD: pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy setuptools cython wheel
-          CIBW_BEFORE_BUILD_WINDOWS:
-            pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy setuptools cython wheel
-            pip install delvewheel
+          CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs shapely.tests


### PR DESCRIPTION
Partial revert of https://github.com/shapely/shapely/pull/1974, now that stable numpy 2.0 is out, we don't have to go through those extra hoops to get the 2.0rc prerelease installed in the wheel building process.

xref https://github.com/shapely/shapely/issues/1972