### PR TITLE
DOC: LineStrings with zero length are invalid

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1023,14 +1023,9 @@ Operations on non-simple `LineStrings` are fully supported by Shapely.
 
   Returns ``True`` if a feature is "valid" in the sense of [1]_.
 
-.. note::
-
-   The validity test is meaningful only for `Polygons` and `MultiPolygons`.
-   ``True`` is always returned for other types of geometries.
-
 A valid `Polygon` may not possess any overlapping exterior or interior rings. A
-valid `MultiPolygon` may not collect any overlapping polygons. Operations on
-invalid features may fail.
+valid `MultiPolygon` may not collect any overlapping polygons. A valid `LineString`
+must have non-zero length. Operations on invalid features may fail.
 
 .. code-block:: pycon
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -14,8 +14,8 @@ class LineString(BaseGeometry):
     A geometry type composed of one or more line segments.
 
     A LineString is a one-dimensional feature and has a non-zero length but
-    zero area. It may approximate a curve and need not be straight. Unlike a
-    LinearRing, a LineString is not closed.
+    zero area. It may approximate a curve and need not be straight. A LineString may
+    be closed.
 
     Parameters
     ----------


### PR DESCRIPTION
The validity test is meaningful for more than Polygons and MultiPolygons, as LineStrings with zero length can be created and are invalid. This PR corrects the manual.