### PR TITLE
Backports from main towards 2.0.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         if: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,9 @@ jobs:
         - os: macos-13
           arch: x86_64
           cmake_osx_architectures: x86_64
-        - os: macos-11
+        - os: macos-14
           arch: arm64
           cmake_osx_architectures: arm64
-        - os: macos-11
-          arch: universal2
-          cmake_osx_architectures: "x86_64;arm64"
 
     steps:
       - name: Checkout source
@@ -118,6 +115,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
+          CIBW_TEST_SKIP: "cp38-macosx_arm64"
           CIBW_ENVIRONMENT_LINUX:
             PIP_PRE=1
             GEOS_VERSION=${{ env.GEOS_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         - os: windows-2019
           arch: AMD64
           msvc_arch: x64
-        - os: macos-11
+        - os: macos-13
           arch: x86_64
           cmake_osx_architectures: x86_64
         - os: macos-11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
         geos: [3.6.6, 3.7.5, 3.8.4, 3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
         include:
@@ -148,7 +148,7 @@ jobs:
         run: |
           echo "${{ env.GEOS_INSTALL }}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-13' }}
 
       # Windows requires special treatment:
       # - geos-config does not exist, so we specify include and library paths

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ exclude MANIFEST.in
 include CITATION.cff CHANGES.txt CREDITS.txt LICENSE.txt README.rst
 include pyproject.toml versioneer.py
 recursive-include src *.c *.h
-recursive-include tests *.py
 recursive-include shapely *.pxd *.pyx
 recursive-exclude shapely *.c
 include docs/*.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ html_context = {
 
 
 # write dummy _reference.rst with all functions listed to ensure the reference/
-# stub pages are crated (the autogeneration of those stub pages by autosummary 
+# stub pages are created (the autogeneration of those stub pages by autosummary 
 # happens before the jinja rendering is done, and thus at that point the
 # autosummary directives do not yet contain the final content
 

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -173,3 +173,38 @@ specified, rounding precision will be disabled showing full precision.
 Format types ``'x'`` and ``'X'`` show a hex-encoded string representation of
 WKB or Well-Known Binary, with the case of the output matched the
 case of the format type character.
+
+.. _canonical-form:
+
+Canonical form
+--------------
+When operations are applied on geometries the result is returned according to
+some conventions.
+
+In most cases, geometries will be returned in "mild" canonical form. There is no
+goal to keep this form stable, so it is expected to change in future versions of
+GEOS:
+
+- the coordinates of exterior rings follow a clockwise orientation and interior
+  rings have a counter-clockwise orientation. This is the opposite of the OGC
+  specifications because the choice was made before this was included in the
+  standard.
+- the starting point of rings can be changed in the output, but the exact order
+  is undefined and should not be relied upon
+- the order of geometry types in a collection can be changed, but the order is
+  undefined
+
+When :func:`~shapely.normalize` is used, the "strict" canonical form is applied.
+This type of normalization is meant to be stable, so changes to it will be
+avoided if possible:
+
+- the coordinates of exterior rings follow a clockwise orientation and interior
+  rings have a counter-clockwise orientation
+- the starting point of rings is lower left
+- elements in collections are ordered by geometry type: by descending dimension
+  and multi-types first (MultiPolygon, Polygon, MultiLineString, LineString,
+  MultiPoint, Point). Multiple elements from the same type are ordered from
+  right to left and from top to bottom.
+
+It is important to note that input geometries do not have to follow these
+conventions.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,8 +26,8 @@ Shapely is available on the conda-forge channel. Install as follows::
     $ conda install shapely --channel conda-forge
 
 
-Installation from source with custom GEOS libary
-------------------------------------------------
+Installation from source with custom GEOS library
+-------------------------------------------------
 
 You may want to use a specific GEOS version or a GEOS distribution that is
 already present on your system (for compatibility with other modules that

--- a/docs/migration_pygeos.rst
+++ b/docs/migration_pygeos.rst
@@ -14,7 +14,7 @@ Therefore, everybody using PyGEOS is highly recommended to migrate to Shapely
 
 Generally speaking, this should be a smooth experience because all
 functionality of PyGEOS was added to Shapely. All vectorized functions
-availabe in ``pygeos`` have been added to the top-level ``shapely`` module,
+available in ``pygeos`` have been added to the top-level ``shapely`` module,
 with only minor differences (see below). Migrating from PyGEOS to Shapely 2.0
 can thus be done by replacing the ``pygeos`` import and module calls::
 
@@ -87,4 +87,4 @@ Other differences
 - The behaviour of ``union_all()`` / ``intersection_all()`` / ``symmetric_difference_all``
   was changed to return an empty GeometryCollection for an empty or all-None
   sequence as input (instead of returning None).
-- The ``radius`` keyword of the ``buffer()`` funtion was renamed to ``distance``.
+- The ``radius`` keyword of the ``buffer()`` function was renamed to ``distance``.

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -451,7 +451,7 @@ Methods to extract all parts or coordinates at once have been added:
 * The :func:`.get_rings` function, similar as ``get_parts`` but specifically
   to extract the rings of Polygon geometries.
 * The :func:`.get_coordinates` function to get all coordinates from a
-  geometry or array of goemetries as an array of floats.
+  geometry or array of geometries as an array of floats.
 
 Each of those three functions has an optional ``return_index`` keyword, which
 allows to also return the indexes of the original geometries in the source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "Cython",
     # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
     # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
-    # define).  For older Python versions (where NumPy 1.25 is not yet avaiable)
+    # define).  For older Python versions (where NumPy 1.25 is not yet available)
     # continue using oldest-support-numpy.
     "oldest-supported-numpy; python_version<'3.9'",
     "numpy>=1.25; python_version>='3.9'",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from pkg_resources import parse_version
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
 # ensure the current directory is on sys.path so versioneer can be imported
@@ -42,15 +41,13 @@ def get_geos_config(option):
     """
     cmd = os.environ.get("GEOS_CONFIG", "geos-config")
     try:
-        stdout, stderr = subprocess.Popen(
-            [cmd, option], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        ).communicate()
+        proc = subprocess.run([cmd, option], capture_output=True, text=True)
     except OSError:
         return
-    if stderr and not stdout:
-        log.warning("geos-config %s returned '%s'", option, stderr.decode().strip())
+    if proc.stderr and not proc.stdout:
+        log.warning("geos-config %s returned '%s'", option, proc.stderr.strip())
         return
-    result = stdout.decode().strip()
+    result = proc.stdout.strip()
     log.debug("geos-config %s returned '%s'", option, result)
     return result
 
@@ -86,11 +83,12 @@ def get_geos_paths():
         )
         return {}
 
-    if parse_version(geos_version) < parse_version(MIN_GEOS_VERSION):
+    def version_tuple(ver):
+        return tuple(int(itm) if itm.isnumeric() else itm for itm in ver.split("."))
+
+    if version_tuple(geos_version) < version_tuple(MIN_GEOS_VERSION):
         raise ImportError(
-            "GEOS version should be >={}, found {}".format(
-                MIN_GEOS_VERSION, geos_version
-            )
+            f"GEOS version should be >={MIN_GEOS_VERSION}, found {geos_version}"
         )
 
     libraries = []
@@ -133,7 +131,7 @@ class build_ext(_build_ext):
 
         import numpy
 
-        self.include_dirs.append(numpy.get_include())
+        self.include_dirs.insert(0, numpy.get_include())
 
 
 ext_modules = []

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -728,20 +728,26 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
-    Coordinates will be rounded if a precision grid is less precise than the
-    input geometry. Duplicated vertices will be dropped from lines and
+    Coordinates will be rounded if the precision grid specified is less precise
+    than the input geometry. Duplicated vertices will be dropped from lines and
     polygons for grid sizes greater than 0. Line and polygon geometries may
     collapse to empty geometries if all vertices are closer together than
-    grid_size. Z values, if present, will not be modified.
+    ``grid_size`` or if a polygon becomes significantly narrower than
+    ``grid_size``. Spikes or sections in polygons narrower than ``grid_size``
+    after rounding the vertices will be removed, which can lead to multipolygons
+    or empty geometries. Z values, if present, will not be modified.
 
-    Note: subsequent operations will always be performed in the precision of
-    the geometry with higher precision (smaller "grid_size"). That same
-    precision will be attached to the operation outputs.
+    Notes:
 
-    Also note: input geometries should be geometrically valid; unexpected
-    results may occur if input geometries are not.
-
-    Returns None if geometry is None.
+    * subsequent operations will always be performed in the precision of the
+      geometry with higher precision (smaller "grid_size"). That same precision
+      will be attached to the operation outputs.
+    * input geometries should be geometrically valid; unexpected results may
+      occur if input geometries are not.
+    * the geometry returned will be in
+      :ref:`mild canonical form <canonical-form>`, and the order of vertices can
+      change and should not be relied upon.
+    * returns None if geometry is None.
 
     Parameters
     ----------
@@ -752,21 +758,24 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
         value is more precise than input geometry, the input geometry will
         not be modified.
     mode :  {'valid_output', 'pointwise', 'keep_collapsed'}, default 'valid_output'
-        This parameter determines how to handle invalid output geometries. There are three modes:
+        This parameter determines the way a precision reduction is applied on
+        the geometry. There are three modes:
 
-        1. `'valid_output'` (default):  The output is always valid. Collapsed geometry elements
-           (including both polygons and lines) are removed. Duplicate vertices are removed.
-        2. `'pointwise'`: Precision reduction is performed pointwise. Output geometry
-           may be invalid due to collapse or self-intersection. Duplicate vertices are not
-           removed. In GEOS this option is called NO_TOPO.
+        1. `'valid_output'` (default):  The output is always valid. Collapsed
+           geometry elements (including both polygons and lines) are removed.
+           Duplicate vertices are removed.
+        2. `'pointwise'`: Precision reduction is performed pointwise. Output
+           geometry may be invalid due to collapse or self-intersection.
+           Duplicate vertices are not removed. In GEOS this option is called
+           NO_TOPO.
 
            .. note::
 
-             'pointwise' mode requires at least GEOS 3.10. It is accepted in earlier versions,
-             but the results may be unexpected.
-        3. `'keep_collapsed'`: Like the default mode, except that collapsed linear geometry
-           elements are preserved. Collapsed polygonal input elements are removed. Duplicate
-           vertices are removed.
+             'pointwise' mode requires at least GEOS 3.10. It is accepted in
+             earlier versions, but the results may be unexpected.
+        3. `'keep_collapsed'`: Like the default mode, except that collapsed
+           linear geometry elements are preserved. Collapsed polygonal input
+           elements are removed. Duplicate vertices are removed.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -302,7 +302,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7, obj
     cdef int[:] collection_size = np.bincount(indices).astype(np.int32)
 
     # A temporary array for the geometries that will be given to CreateCollection.
-    # Its size equals max(collection_size) to accomodate the largest collection.
+    # Its size equals max(collection_size) to accommodate the largest collection.
     temp_geoms = np.empty(shape=(np.max(collection_size), ), dtype=np.intp)
     cdef np.intp_t[:] temp_geoms_view = temp_geoms
 

--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -61,15 +61,31 @@ def affine_transform(geom, matrix):
             ndim = 2
     else:
         raise ValueError("'matrix' expects either 6 or 12 coefficients")
-    if ndim == 2:
-        A = np.array([[a, b], [d, e]], dtype=float)
-        off = np.array([xoff, yoff], dtype=float)
-    else:
-        A = np.array([[a, b, c], [d, e, f], [g, h, i]], dtype=float)
-        off = np.array([xoff, yoff, zoff], dtype=float)
+
+    # if ndim == 2:
+    #     A = np.array([[a, b], [d, e]], dtype=float)
+    #     off = np.array([xoff, yoff], dtype=float)
+    # else:
+    #     A = np.array([[a, b, c], [d, e, f], [g, h, i]], dtype=float)
+    #     off = np.array([xoff, yoff, zoff], dtype=float)
 
     def _affine_coords(coords):
-        return np.matmul(A, coords.T).T + off
+        # These are equivalent, but unfortunately not robust
+        #   result = np.matmul(coords, A.T) + off
+        #   result = np.matmul(A, coords.T).T + off
+        # Therefore, manual matrix multiplication is needed
+        if ndim == 2:
+            x, y = coords.T
+            xp = a * x + b * y + xoff
+            yp = d * x + e * y + yoff
+            result = np.stack([xp, yp]).T
+        elif ndim == 3:
+            x, y, z = coords.T
+            xp = a * x + b * y + c * z + xoff
+            yp = d * x + e * y + f * z + yoff
+            zp = g * x + h * y + i * z + zoff
+            result = np.stack([xp, yp, zp]).T
+        return result
 
     return shapely.transform(geom, _affine_coords, include_z=ndim == 3)
 

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -533,11 +533,11 @@ def make_valid(geometry, **kwargs):
 
 @multithreading_enabled
 def normalize(geometry, **kwargs):
-    """Converts Geometry to normal form (or canonical form).
+    """Converts Geometry to strict normal form (or canonical form).
 
-    This method orders the coordinates, rings of a polygon and parts of
-    multi geometries consistently. Typically useful for testing purposes
-    (for example in combination with ``equals_exact``).
+    In :ref:`strict canonical form <canonical-form>`, the coordinates, rings of a polygon and
+    parts of multi geometries are ordered consistently. Typically useful for testing
+    purposes (for example in combination with ``equals_exact``).
 
     Parameters
     ----------

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -46,8 +46,13 @@ class CoordinateSequence:
         else:
             raise TypeError("key must be an index or slice")
 
-    def __array__(self, dtype=None):
-        return self._coords
+    def __array__(self, dtype=None, copy=None):
+        if copy is False:
+            raise ValueError("`copy=False` isn't supported. A copy is always created.")
+        elif copy is True:
+            return self._coords.copy()
+        else:
+            return self._coords
 
     @property
     def xy(self):

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -511,7 +511,7 @@ def destroy_prepared(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
-        Geometries are changed inplace
+        Geometries are changed in-place
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -85,12 +85,12 @@ class Point(BaseGeometry):
     @property
     def x(self):
         """Return x coordinate."""
-        return shapely.get_x(self)
+        return float(shapely.get_x(self))
 
     @property
     def y(self):
         """Return y coordinate."""
-        return shapely.get_y(self)
+        return float(shapely.get_y(self))
 
     @property
     def z(self):

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -139,12 +139,12 @@ def to_wkb(
     ----------
     geometry : Geometry or array_like
     hex : bool, default False
-        If true, export the WKB as a hexidecimal string. The default is to
+        If true, export the WKB as a hexadecimal string. The default is to
         return a binary bytes object.
     output_dimension : int, default 3
         The output dimension for the WKB. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
-        geometries will still be represented as 2D in the WKB represenation.
+        geometries will still be represented as 2D in the WKB representation.
     byte_order : int, default -1
         Defaults to native machine byte order (-1). Use 0 to force big endian
         and 1 for little endian.

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -1,7 +1,7 @@
 """
 Plot single geometries using Matplotlib.
 
-Note: this module is experimental, and mainly targetting (interactive)
+Note: this module is experimental, and mainly targeting (interactive)
 exploration, debugging and illustration purposes.
 
 """
@@ -38,7 +38,7 @@ def patch_from_polygon(polygon, **kwargs):
     """
     Gets a Matplotlib patch from a (Multi)Polygon.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -69,7 +69,7 @@ def plot_polygon(
     """
     Plot a (Multi)Polygon.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -132,7 +132,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     """
     Plot a (Multi)LineString/LinearRing.
 
-    Note: this function is experimental, and mainly targetting (interactive)
+    Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
 
     Parameters
@@ -144,7 +144,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     add_points : bool, default True
         If True, also plot the coordinates (vertices) as points.
     color : matplotlib color specification
-        Color for the line (edgecolor under the hood) and pointes.
+        Color for the line (edgecolor under the hood) and points.
     linewidth : float, default 2
         The line width for the polygon boundary.
     **kwargs

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -81,7 +81,7 @@ def is_ccw(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
-        This function will return False for non-linear goemetries and for
+        This function will return False for non-linear geometries and for
         lines with fewer than 4 points (including the closing point).
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -748,7 +748,7 @@ def equals(a, b, **kwargs):
 def intersects(a, b, **kwargs):
     """Returns True if A and B share any portion of space.
 
-    Intersects implies that overlaps, touches and within are True.
+    Intersects implies that overlaps, touches, covers, or within are True.
 
     Parameters
     ----------

--- a/shapely/tests/geometry/test_coords.py
+++ b/shapely/tests/geometry/test_coords.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from shapely import LineString
+from shapely.tests.common import line_string, line_string_z, point, point_z
 
 
 class TestCoords:
@@ -84,3 +85,18 @@ class TestXY:
         assert list(x) == [0.0, 1.0]
         assert len(y) == 2
         assert list(y) == [0.0, 1.0]
+
+
+@pytest.mark.parametrize("geom", [point, point_z, line_string, line_string_z])
+def test_coords_array_copy(geom):
+    """Test CoordinateSequence.__array__ method."""
+    coord_seq = geom.coords
+    assert np.array(coord_seq) is not np.array(coord_seq)
+    assert np.array(coord_seq, copy=True) is not np.array(coord_seq, copy=True)
+
+    # Behaviour of copy=False is different between NumPy 1.x and 2.x
+    if int(np.version.short_version.split(".", 1)[0]) >= 2:
+        with pytest.raises(ValueError, match="A copy is always created"):
+            np.array(coord_seq, copy=False)
+    else:
+        assert np.array(coord_seq, copy=False) is np.array(coord_seq, copy=False)

--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -47,7 +47,7 @@ def test_format_point():
             ("g", xy2, "POINT (-169.910918 -18.997564)", False),
             ("0.2g", xy2, "POINT (-169.91 -19)", False),
         ]
-    # without precsions test GEOS rounding_precision=-1; different than Python
+    # without precisions test GEOS rounding_precision=-1; different than Python
     test_list += [
         ("f", (1, 2), f"POINT ({1:.16f} {2:.16f})", False),
         ("F", xyz3, "POINT Z ({:.16f} {:.16f} {:.16f})".format(*xyz3), False),

--- a/shapely/tests/geometry/test_point.py
+++ b/shapely/tests/geometry/test_point.py
@@ -101,7 +101,9 @@ class TestPoint:
         # Test 2D points
         p = Point(1.0, 2.0)
         assert p.x == 1.0
+        assert type(p.x) is float
         assert p.y == 2.0
+        assert type(p.y) is float
         assert p.coords[:] == [(1.0, 2.0)]
         assert str(p) == p.wkt
         assert p.has_z is False
@@ -114,6 +116,7 @@ class TestPoint:
         assert str(p) == p.wkt
         assert p.has_z is True
         assert p.z == 3.0
+        assert type(p.z) is float
 
         # Coordinate access
         p = Point((3.0, 4.0))

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -255,7 +255,7 @@ def test_set_nan():
 
 def test_set_nan_same_objects():
     # You can't put identical objects in a set.
-    # x = float("nan"); set([x, x]) also retuns a set with 1 element
+    # x = float("nan"); set([x, x]) also returns a set with 1 element
     a = set([line_string_nan] * 10)
     assert len(a) == 1
 

--- a/shapely/tests/test_linear.py
+++ b/shapely/tests/test_linear.py
@@ -178,7 +178,7 @@ def test_shared_paths_non_linestring():
 
 
 def _prepare_input(geometry, prepare):
-    """Prepare without modifying inplace"""
+    """Prepare without modifying in-place"""
     if prepare:
         geometry = shapely.transform(geometry, lambda x: x)  # makes a copy
         shapely.prepare(geometry)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -298,7 +298,7 @@ def test_is_ccw(geom, expected):
 
 
 def _prepare_with_copy(geometry):
-    """Prepare without modifying inplace"""
+    """Prepare without modifying in-place"""
     geometry = shapely.transform(geometry, lambda x: x)  # makes a copy
     shapely.prepare(geometry)
     return geometry

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -22,14 +22,14 @@ SET_OPERATIONS = (
     shapely.intersection,
     shapely.symmetric_difference,
     shapely.union,
-    # shapely.coverage_union is tested seperately
+    # shapely.coverage_union is tested separately
 )
 
 REDUCE_SET_OPERATIONS = (
     (shapely.intersection_all, shapely.intersection),
     (shapely.symmetric_difference_all, shapely.symmetric_difference),
     (shapely.union_all, shapely.union),
-    #  shapely.coverage_union_all, shapely.coverage_union) is tested seperately
+    #  shapely.coverage_union_all, shapely.coverage_union) is tested separately
 )
 
 # operations that support fixed precision
@@ -277,7 +277,7 @@ def test_set_operation_prec_reduce_all_none(n, func, related_func):
 @pytest.mark.parametrize("n", range(1, 4))
 def test_coverage_union_reduce_1dim(n):
     """
-    This is tested seperately from other set operations as it differs in two ways:
+    This is tested separately from other set operations as it differs in two ways:
       1. It expects only non-overlapping polygons
       2. It expects GEOS 3.8.0+
     """
@@ -314,7 +314,7 @@ def test_coverage_union_overlapping_inputs():
     other = Polygon([(1, 0), (0.9, 1), (2, 1), (2, 0), (1, 0)])
 
     if shapely.geos_version >= (3, 12, 0):
-        # Return mostly unchaged output
+        # Return mostly unchanged output
         result = shapely.coverage_union(polygon, other)
         expected = shapely.multipolygons([polygon, other])
         assert_geometries_equal(result, expected, normalize=True)

--- a/src/coords.c
+++ b/src/coords.c
@@ -371,7 +371,7 @@ npy_intp CountCoords(PyArrayObject* arr) {
       result = -1;
       goto finish;
     }
-    /* skip incase obj was None */
+    /* skip in case obj was None */
     if (geom == NULL) {
       continue;
     }
@@ -519,7 +519,7 @@ PyObject* SetCoords(PyArrayObject* geoms, PyArrayObject* coords) {
   PyObject* new_obj;
   GEOSGeometry *geom, *new_geom;
 
-  /* SetCoords acts implace: if the array is zero-sized, just return the
+  /* SetCoords acts in-place: if the array is zero-sized, just return the
   same object */
   if (PyArray_SIZE(geoms) == 0) {
     Py_INCREF((PyObject*)geoms);

--- a/src/geos.c
+++ b/src/geos.c
@@ -306,7 +306,7 @@ char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
 
 /* Checks whether the geometry is a 3D empty geometry and, if so, create the WKT string
  *
- * GEOS 3.9.* is able to distiguish 2D and 3D simple geometries (non-collections). But the
+ * GEOS 3.9.* is able to distinguish 2D and 3D simple geometries (non-collections). But the
  * but the WKT serialization never writes a 3D empty geometry. This function fixes that.
  * It only makes sense to use this for GEOS versions >= 3.9.
  *

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -128,7 +128,7 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     /* get the geometry */
     ptr = PyArray_GETPTR1((PyArrayObject*)arr, i);
     obj = *(GeometryObject**)ptr;
-    /* fail and cleanup incase obj was no geometry */
+    /* fail and cleanup in case obj was no geometry */
     if (!get_geom(obj, &geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
       GEOSSTRtree_destroy_r(ctx, tree);
@@ -977,7 +977,7 @@ static PyObject* STRtree_dwithin(STRtreeObject* self, PyObject* args) {
   index_vec_t src_indexes;
 
   // Addresses in tree geometries (_geoms) that overlap with expanded bboxes around
-  // intput geometries
+  // input geometries
   tree_geom_vec_t query_geoms;
 
   // Addresses in tree geometries (_geoms) that meet DistanceWithin predicate

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -522,7 +522,7 @@ static void* GetExteriorRing(void* context, void* geom) {
   return ret;
 }
 static void* get_exterior_ring_data[1] = {GetExteriorRing};
-/* the normalize funcion acts inplace */
+/* the normalize function acts in-place */
 static void* GEOSNormalize_r_with_clone(void* context, void* geom) {
   int ret;
   void* new_geom = GEOSGeom_clone_r(context, geom);
@@ -841,7 +841,7 @@ static void* GetGeometryN(void* context, void* geom, int n) {
   return ret;
 }
 static void* get_geometry_data[1] = {GetGeometryN};
-/* the set srid funcion acts inplace */
+/* the set srid function acts in-place */
 static void* GEOSSetSRID_r_with_clone(void* context, void* geom, int srid) {
   void* ret = GEOSGeom_clone_r(context, geom);
   if (ret == NULL) {
@@ -1310,7 +1310,7 @@ static void YY_d_func(char** args, const npy_intp* dimensions, const npy_intp* s
         errstate = PGERR_GEOS_EXCEPTION;
         goto finish;
       }
-      /* incase the outcome is 0.0, check the inputs for emptyness */
+      /* in case the outcome is 0.0, check the inputs for emptyness */
       if (*op1 == 0.0) {
         if (GEOSisEmpty_r(ctx, in1) || GEOSisEmpty_r(ctx, in2)) {
           *(double*)op1 = NPY_NAN;


### PR DESCRIPTION
This PR cherry-picks a series of commits since [2.0.4](https://github.com/shapely/shapely/releases/tag/2.0.4) from the main branch to the maint-2.0 branch.

Some commits needed some manual edits.