### PR TITLE
Drop Python 3.8 support, require Python 3.9+

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Run black, flake8 and isort
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Run black, flake8 and isort
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
-          CIBW_TEST_SKIP: "cp38-macosx_arm64"
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
+        geos: [3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
         include:
-          # 2019
-          - python: 3.8
-            geos: 3.8.4
-            numpy: 1.17.3
           # 2020
           - python: 3.9
             geos: 3.9.5
@@ -48,17 +44,12 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: 3.8
-            geos: 3.8.4
-            numpy: 1.16.2
-          - os: windows-2019
-            architecture: x86
             python: "3.11"
             geos: 3.12.1
             numpy: 1.24.4
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-22.04
-            python: "pypy3.8"
+            python: "pypy3.9"
             geos: 3.12.1
             numpy: 1.24.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: focal
 language: python
-python: '3.8'
+python: '3.9'
 
 if: (branch = main OR tag IS present) AND (type = push)
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -55,7 +55,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    "pythons": ["3.9"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.16",
 ]

--- a/versioneer.py
+++ b/versioneer.py
@@ -10,7 +10,7 @@ The Versioneer
 * https://github.com/python-versioneer/python-versioneer
 * Brian Warner
 * License: Public Domain (Unlicense)
-* Compatible with: Python 3.7, 3.8, 3.9, 3.10 and pypy3
+* Compatible with: Python 3.9, 3.10, 3.11, 3.12 and pypy3
 * [![Latest Version][pypi-image]][pypi-url]
 * [![Build Status][travis-image]][travis-url]
 


### PR DESCRIPTION
With the migration to Shapely 2.0 successfully completed and Python 3.13 soon coming in, this seems like a good moment to drop Python 3.8 support. It's almost [end-of-life](https://endoflife.date/python) and [SPEC 0](https://scientific-python.org/specs/spec-0000/) already recommended dropping Python 3.8 over a year ago.

So this PR bumps the required Python version to 3.9, removes 3.8 from the CI and test files.

Of course this will only affect future releases from the main branch, existing releases and releases from maintenance branches (like `maint-2.0`) stay compatible with Python 3.8 and can continued to be used.