### PR TITLE
RLS/CI: upgrade GEOS versions to latest minor, add more to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium
     environment:
-      GEOS_VERSION: 3.11.3
+      GEOS_VERSION: 3.11.4
       CIBUILDWHEEL: 1
       CIBW_BUILD: "cp*-manylinux_aarch64"
       CIBW_ENVIRONMENT_PASS_LINUX: "GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.11.3"
+      GEOS_VERSION: "3.11.4"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.6.6, 3.7.5, 3.8.4, 3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
+        geos: [3.6.6, 3.7.5, 3.8.4, 3.9.5, 3.10.6, 3.11.4, 3.12.2, main]
         include:
           # 2017
           - python: 3.7  # 3.6 is dropped
@@ -38,15 +38,24 @@ jobs:
             numpy: 1.21.3
           # 2022
           - python: "3.11"
-            geos: 3.11.3
+            geos: 3.11.4
             numpy: 1.23.4
             matplotlib: true
             doctest: true
             extra_pytest_args: "-W error"  # error on warnings
           # 2023
           - python: "3.12"
-            geos: 3.12.1
+            geos: 3.12.2
             numpy: 1.26.0
+          # 2024
+          - python: "3.13"
+            geos: 3.12.2
+            numpy: 2.0.0
+          # apple silicon
+          - os: macos-14
+            python: "3.12"
+            geos: 3.12.2
+            numpy: 2.0.0
           # dev
           - python: "3.12"
             geos: main
@@ -66,7 +75,7 @@ jobs:
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-20.04
             python: "pypy3.8"
-            geos: 3.11.3
+            geos: 3.11.4
             numpy: 1.23.4
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
             geos: 3.12.2
             numpy: 1.26.0
           # 2024
-          - python: "3.13"
+          - python: "3.12"  # update to "3.13" after binary wheels for numpy are available
             geos: 3.12.2
             numpy: 2.0.0
           # apple silicon
@@ -153,11 +153,11 @@ jobs:
           echo "LD_LIBRARY_PATH=${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
-      - name: Set environment variables (OSX)
+      - name: Set environment variables (macOS)
         run: |
           echo "${{ env.GEOS_INSTALL }}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'macos-13' }}
+        if: ${{ startsWith(matrix.os, 'macos') }}
 
       # Windows requires special treatment:
       # - geos-config does not exist, so we specify include and library paths
@@ -167,7 +167,7 @@ jobs:
           cp geosinstall/geos-${{ matrix.geos }}/bin/*.dll shapely
           echo 'GEOS_LIBRARY_PATH=${{ env.GEOS_INSTALL }}\lib' >> $GITHUB_ENV
           echo 'GEOS_INCLUDE_PATH=${{ env.GEOS_INSTALL }}\include' >> $GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: Build and install Shapely
         # for the numpy nightly build, we temporarily need to build without

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ if: (branch = main OR tag IS present) AND (type = push)
 
 env:
   global:
-  - GEOS_VERSION=3.11.3
+  - GEOS_VERSION=3.11.4
 
 cache:
   directories:

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -412,17 +412,18 @@ def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     --------
     >>> from shapely import GeometryCollection, LineString, MultiPoint, Polygon
     >>> points = MultiPoint([(50, 30), (60, 30), (100, 100)])
-    >>> delaunay_triangles(points)
-    <GEOMETRYCOLLECTION (POLYGON ((50 30, 60 30, 100 100, 50 30)))>
+    >>> delaunay_triangles(points).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
     >>> delaunay_triangles(points, only_edges=True)
     <MULTILINESTRING ((50 30, 100 100), (50 30, 60 30), ...>
     >>> delaunay_triangles(MultiPoint([(50, 30), (51, 30), (60, 30), (100, 100)]), \
-tolerance=2)
-    <GEOMETRYCOLLECTION (POLYGON ((50 30, 60 30, 100 100, 50 30)))>
-    >>> delaunay_triangles(Polygon([(50, 30), (60, 30), (100, 100), (50, 30)]))
-    <GEOMETRYCOLLECTION (POLYGON ((50 30, 60 30, 100 100, 50 30)))>
-    >>> delaunay_triangles(LineString([(50, 30), (60, 30), (100, 100)]))
-    <GEOMETRYCOLLECTION (POLYGON ((50 30, 60 30, 100 100, 50 30)))>
+tolerance=2).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
+    >>> delaunay_triangles(Polygon([(50, 30), (60, 30), (100, 100), (50, 30)]))\
+.normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
+    >>> delaunay_triangles(LineString([(50, 30), (60, 30), (100, 100)])).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
     >>> delaunay_triangles(GeometryCollection([]))
     <GEOMETRYCOLLECTION EMPTY>
     """


### PR DESCRIPTION
This upgrades a few components for CI testing and the GEOS version used in binary wheels for the shapely 2.0 maintenance branch.

- Shapely-2.0.5 is expected soon and will have GEOS 3.11.4; see [changes](https://github.com/libgeos/geos/blob/3.11.4/NEWS.md)
- Add a "2024" CI matrix entry with numpy-2.0.0 <s>and python-13 (currently beta)</s> (hold off until numpy has cp313 binary wheels)
- Add test with macos-14 for an apple silicon runner
- Fix doctests for geos-3.11.4 (and older 3.11.x)