### PR TITLE
DOC/RLS: starts changelog for 2.0.5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,19 @@
 Changes
 =======
 
+2.0.5 (2024-07-13)
+------------------
+
+Binary wheels on PyPI include GEOS 3.11.4 from 2024-06-05. Furthermore,
+universal2 wheels are removed for macOS since both x86_64 and arm64 wheels are
+provided.
+
+Bug fixes:
+
+- Fix Point x/y/z attributes to return Python floats (#2074).
+- Fix affinity for Apple silicon with NumPy 2.0 by reverting matmul, and
+  use direct matrix multiplication instead (#2085).
+
 2.0.4 (2024-04-16)
 ------------------
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "Please cite this software using these metadata."
 type: software
 title: Shapely
-version: "2.0.4"
-date-released: "2024-04-16"
+version: "2.0.5"
+date-released: "2024-07-13"
 doi: 10.5281/zenodo.5597138
 abstract: "Manipulation and analysis of geometric objects in the Cartesian plane."
 repository-artifact: https://pypi.org/project/Shapely

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -1,6 +1,24 @@
 Version 2.x
 ===========
 
+.. _version-2-0-5:
+
+Version 2.0.5 (2024-07-13)
+--------------------------
+
+Bug fixes:
+
+- Fix Point x/y/z attributes to return Python floats (#2074).
+- Fix affinity for Apple silicon with NumPy 2.0 by reverting matmul, and
+  use direct matrix multiplication instead (#2085).
+
+Packaging related:
+
+- Binary wheels on PyPI include GEOS 3.11.4 from 2024-06-05 (#2086).
+- universal2 wheels are removed for macOS since both x86_64 and arm64 wheels
+  are provided (#1990).
+- Replace pkg_resources, prepend numpy include dirs (#2071).
+
 .. _version-2-0-4:
 
 Version 2.0.4 (2024-04-16)


### PR DESCRIPTION
The next minor version of the 2.0.x series is anticipated sometime today.