### PR TITLE
RLS/CI: upgrade GEOS versions to latest minor, add more to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium
     environment:
-      GEOS_VERSION: 3.12.1
+      GEOS_VERSION: 3.12.2
       CIBUILDWHEEL: 1
       CIBW_BUILD: "cp*-manylinux_aarch64"
       CIBW_ENVIRONMENT_PASS_LINUX: "GEOS_VERSION GEOS_INSTALL GEOS_CONFIG LD_LIBRARY_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.12.1"
+      GEOS_VERSION: "3.12.2"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.3, 3.12.1, main]
+        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.4, 3.12.2, main]
         include:
           # 2019
           - python: 3.8
@@ -30,16 +30,25 @@ jobs:
             numpy: 1.21.3
           # 2022
           - python: "3.11"
-            geos: 3.11.3
+            geos: 3.11.4
             numpy: 1.23.4
           # 2023
           - python: "3.12"
-            geos: 3.12.1
+            geos: 3.12.2
             numpy: 1.26.2
             matplotlib: true
             doctest: true
+          # 2024
+          - python: "3.12"  # update to "3.13" after binary wheels for numpy are available
+            geos: 3.12.2
+            numpy: 2.0.0
             # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
             extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
+          # apple silicon
+          - os: macos-14
+            python: "3.12"
+            geos: 3.12.2
+            numpy: 2.0.0
           # dev
           - python: "3.12"
             geos: main
@@ -54,12 +63,12 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: "3.11"
-            geos: 3.12.1
+            geos: 3.12.2
             numpy: 1.24.4
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-22.04
             python: "pypy3.8"
-            geos: 3.12.1
+            geos: 3.12.2
             numpy: 1.24.4
 
     env:
@@ -141,11 +150,11 @@ jobs:
           echo "LD_LIBRARY_PATH=${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
-      - name: Set environment variables (OSX)
+      - name: Set environment variables (macOS)
         run: |
           echo "${{ env.GEOS_INSTALL }}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${{ env.GEOS_INSTALL }}/lib" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'macos-13' }}
+        if: ${{ startsWith(matrix.os, 'macos') }}
 
       # Windows requires special treatment:
       # - geos-config does not exist, so we specify include and library paths
@@ -155,7 +164,7 @@ jobs:
           cp geosinstall/geos-${{ matrix.geos }}/bin/*.dll shapely
           echo 'GEOS_LIBRARY_PATH=${{ env.GEOS_INSTALL }}\lib' >> $GITHUB_ENV
           echo 'GEOS_INCLUDE_PATH=${{ env.GEOS_INSTALL }}\include' >> $GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: Build and install Shapely
         # for the numpy nightly build, we temporarily need to build without

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,11 @@ jobs:
             numpy: 1.26.2
             matplotlib: true
             doctest: true
-          # 2024
-          - python: "3.12"  # update to "3.13" after binary wheels for numpy are available
-            geos: 3.12.2
-            numpy: 2.0.0
-            # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
-            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
+            extra_pytest_args: "-W error"  # error on warnings
+          # 2024 -- wait until Python 3.13 with binary wheels for numpy are available
+          # - python: "3.13"
+          #   geos: 3.13.0
+          #   numpy: 2.0.0
           # apple silicon
           - os: macos-14
             python: "3.12"
@@ -52,8 +51,7 @@ jobs:
           # dev
           - python: "3.12"
             geos: main
-            # extra ignore for dateutil Python 3.12 warning fixed upstream (waiting on release 2.8.3+)
-            extra_pytest_args: "-W error -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning" # error on warnings
+            extra_pytest_args: "-W error"  # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
@@ -129,6 +127,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --disable-pip-version-check --upgrade pip
+          pip config set global.progress_bar off
           pip install --upgrade wheel setuptools
           if [ -z "${{ matrix.numpy }}" ]; then
             pip install --upgrade --pre Cython pytest pytest-cov coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ if: (branch = main OR tag IS present) AND (type = push)
 
 env:
   global:
-  - GEOS_VERSION=3.12.1
+  - GEOS_VERSION=3.12.2
 
 cache:
   directories:

--- a/ci/install_geos.cmd
+++ b/ci/install_geos.cmd
@@ -30,7 +30,7 @@ IF %ERRORLEVEL% NEQ 0 exit /B 2
 cmake --build .
 IF %ERRORLEVEL% NEQ 0 exit /B 3
 ctest --output-on-failure .
-IF %ERRORLEVEL% NEQ 0 exit /B 4
+:: IF %ERRORLEVEL% NEQ 0 exit /B 4
 cmake --install .
 IF %ERRORLEVEL% NEQ 0 exit /B 5
 

--- a/ci/install_geos.cmd
+++ b/ci/install_geos.cmd
@@ -6,22 +6,32 @@
 
 if exist %GEOS_INSTALL% (
   echo Using cached %GEOS_INSTALL%
-) else (
-  echo Building %GEOS_INSTALL%
-
-  curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
-  7z x geos-%GEOS_VERSION%.tar.bz2
-  7z x geos-%GEOS_VERSION%.tar
-  cd geos-%GEOS_VERSION% || exit /B 1
-
-  pip install ninja cmake
-  cmake --version
-
-  mkdir build
-  cd build
-  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOS_INSTALL% .. || exit /B 2
-  cmake --build . || exit /B 3
-  ctest . || exit /B 4
-  cmake --install . || exit /B 5
-  cd ..
+  exit /B 0
 )
+
+echo Building %GEOS_INSTALL%
+
+curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
+7z x geos-%GEOS_VERSION%.tar.bz2
+7z x geos-%GEOS_VERSION%.tar
+cd geos-%GEOS_VERSION% || exit /B 1
+
+pip install ninja cmake
+cmake --version
+
+md build
+cd build
+cmake -GNinja ^
+  -D CMAKE_BUILD_TYPE=Release ^
+  -D BUILD_SHARED_LIBS=ON ^
+  -D CMAKE_INSTALL_PREFIX=%GEOS_INSTALL% ^
+  ..
+IF %ERRORLEVEL% NEQ 0 exit /B 2
+cmake --build .
+IF %ERRORLEVEL% NEQ 0 exit /B 3
+ctest --output-on-failure .
+IF %ERRORLEVEL% NEQ 0 exit /B 4
+cmake --install .
+IF %ERRORLEVEL% NEQ 0 exit /B 5
+
+cd ..

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -57,7 +57,6 @@ build_geos(){
         -D CMAKE_INSTALL_PREFIX=${GEOS_INSTALL} \
         -D CMAKE_INSTALL_LIBDIR=lib \
         -D CMAKE_INSTALL_NAME_DIR=${GEOS_INSTALL}/lib \
-        -D CMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
         ${BUILD_TESTING} \
         ..
     cmake --build . -j 4

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -53,10 +53,11 @@ build_geos(){
             BUILD_TESTING="-DBUILD_TESTING=OFF";;
     esac
     cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=${GEOS_INSTALL} \
-        -DCMAKE_INSTALL_LIBDIR=lib \
-        -DCMAKE_INSTALL_NAME_DIR=${GEOS_INSTALL}/lib \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D CMAKE_INSTALL_PREFIX=${GEOS_INSTALL} \
+        -D CMAKE_INSTALL_LIBDIR=lib \
+        -D CMAKE_INSTALL_NAME_DIR=${GEOS_INSTALL}/lib \
+        -D CMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
         ${BUILD_TESTING} \
         ..
     cmake --build . -j 4

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -831,7 +831,7 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     >>> set_precision(LineString([(0, 0), (0, 0.1), (0, 1), (1, 1)]), 1.0)
     <LINESTRING (0 0, 0 1, 1 1)>
     >>> set_precision(LineString([(0, 0), (0, 0.1), (0.1, 0.1)]), 1.0, mode="valid_output")
-    <LINESTRING Z EMPTY>
+    <LINESTRING EMPTY>
     >>> set_precision(LineString([(0, 0), (0, 0.1), (0.1, 0.1)]), 1.0, mode="pointwise")
     <LINESTRING (0 0, 0 0, 0 0)>
     >>> set_precision(LineString([(0, 0), (0, 0.1), (0.1, 0.1)]), 1.0, mode="keep_collapsed")

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -413,17 +413,18 @@ def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     --------
     >>> from shapely import GeometryCollection, LineString, MultiPoint, Polygon
     >>> points = MultiPoint([(50, 30), (60, 30), (100, 100)])
-    >>> delaunay_triangles(points)
-    <GEOMETRYCOLLECTION (POLYGON ((100 100, 50 30, 60 30, 100 100)))>
+    >>> delaunay_triangles(points).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
     >>> delaunay_triangles(points, only_edges=True)
     <MULTILINESTRING ((50 30, 100 100), (50 30, 60 30), ...>
     >>> delaunay_triangles(MultiPoint([(50, 30), (51, 30), (60, 30), (100, 100)]), \
-tolerance=2)
-    <GEOMETRYCOLLECTION (POLYGON ((100 100, 50 30, 60 30, 100 100)))>
-    >>> delaunay_triangles(Polygon([(50, 30), (60, 30), (100, 100), (50, 30)]))
-    <GEOMETRYCOLLECTION (POLYGON ((100 100, 50 30, 60 30, 100 100)))>
-    >>> delaunay_triangles(LineString([(50, 30), (60, 30), (100, 100)]))
-    <GEOMETRYCOLLECTION (POLYGON ((100 100, 50 30, 60 30, 100 100)))>
+tolerance=2).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
+    >>> delaunay_triangles(Polygon([(50, 30), (60, 30), (100, 100), (50, 30)]))\
+.normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
+    >>> delaunay_triangles(LineString([(50, 30), (60, 30), (100, 100)])).normalize()
+    <GEOMETRYCOLLECTION (POLYGON ((50 30, 100 100, 60 30, 50 30)))>
     >>> delaunay_triangles(GeometryCollection([]))
     <GEOMETRYCOLLECTION EMPTY>
     """


### PR DESCRIPTION
This PR upgrades a few components for CI testing and the GEOS version used in binary wheels. It is similar to #2086 but for the `main` branch.

- <s>Add a "2024" CI matrix entry with numpy-2.0.0</s> (it's not so easy to insert another matrix entry for GEOS=3.12.2, so wait on this)
- Add test with macos-14 for an apple silicon runner
- Remove extra ignore for dateutil Python 3.12 warning in CI
- Fix properly catching ERRORLEVEL on Windows, but don't fail if tests fail (they are disabled for POSIX)
- Fix doctests to work with GEOS 3.12.2
- <s>Change GEOS install to use [`CMAKE_PLATFORM_NO_VERSIONED_SONAME=ON`](https://cmake.org/cmake/help/latest/variable/CMAKE_PLATFORM_NO_VERSIONED_SONAME.html), which will remove the soversion number from the internal library included with the binary wheel.</s>