### PR TITLE
BUG: fix base geometry "project" to return Python float

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -834,7 +834,9 @@ class BaseGeometry(shapely.Geometry):
 
         Alias of `project`.
         """
-        return shapely.line_locate_point(self, other, normalized=normalized)
+        return _maybe_unpack(
+            shapely.line_locate_point(self, other, normalized=normalized)
+        )
 
     def project(self, other, normalized=False):
         """Returns the distance along this geometry to a point nearest the
@@ -845,7 +847,9 @@ class BaseGeometry(shapely.Geometry):
 
         Alias of `line_locate_point`.
         """
-        return shapely.line_locate_point(self, other, normalized=normalized)
+        return _maybe_unpack(
+            shapely.line_locate_point(self, other, normalized=normalized)
+        )
 
     def line_interpolate_point(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -163,6 +163,10 @@ def test_array_argument_binary_predicates(op):
     expected = np.array([getattr(polygon, op)(p) for p in points], dtype=bool)
     np.testing.assert_array_equal(result, expected)
 
+    # check scalar
+    result = getattr(polygon, op)(points[0])
+    assert type(result) is bool
+
 
 @pytest.mark.parametrize(
     "op, kwargs",
@@ -187,6 +191,10 @@ def test_array_argument_binary_predicates2(op, kwargs):
     expected = np.array([getattr(polygon, op)(p, **kwargs) for p in points], dtype=bool)
     np.testing.assert_array_equal(result, expected)
 
+    # check scalar
+    result = getattr(polygon, op)(points[0], **kwargs)
+    assert type(result) is bool
+
 
 @pytest.mark.parametrize(
     "op",
@@ -206,6 +214,10 @@ def test_array_argument_binary_geo(op):
     expected = np.array([getattr(box, op)(g) for g in polygons], dtype=object)
     assert_geometries_equal(result, expected)
 
+    # check scalar
+    result = getattr(box, op)(polygons[0])
+    assert isinstance(result, (Polygon, MultiPolygon))
+
 
 @pytest.mark.parametrize("op", ["distance", "hausdorff_distance"])
 def test_array_argument_float(op):
@@ -217,22 +229,41 @@ def test_array_argument_float(op):
     expected = np.array([getattr(polygon, op)(p) for p in points], dtype="float64")
     np.testing.assert_array_equal(result, expected)
 
+    # check scalar
+    result = getattr(polygon, op)(points[0])
+    assert type(result) is float
 
-def test_array_argument_linear():
+
+@pytest.mark.parametrize("op", ["line_interpolate_point", "interpolate"])
+def test_array_argument_linear_point(op):
     line = LineString([(0, 0), (0, 1), (1, 1)])
     distances = np.array([0, 0.5, 1])
-    result = line.line_interpolate_point(distances)
+
+    result = getattr(line, op)(distances)
     assert isinstance(result, np.ndarray)
     expected = np.array(
         [line.line_interpolate_point(d) for d in distances], dtype=object
     )
     assert_geometries_equal(result, expected)
 
+    # check scalar
+    result = getattr(line, op)(distances[0])
+    assert isinstance(result, Point)
+
+
+@pytest.mark.parametrize("op", ["line_locate_point", "project"])
+def test_array_argument_linear_float(op):
+    line = LineString([(0, 0), (0, 1), (1, 1)])
     points = shapely.points([(0, 0), (0.5, 0.5), (1, 1)])
-    result = line.line_locate_point(points)
+
+    result = getattr(line, op)(points)
     assert isinstance(result, np.ndarray)
     expected = np.array([line.line_locate_point(p) for p in points], dtype="float64")
     np.testing.assert_array_equal(result, expected)
+
+    # check scalar
+    result = getattr(line, op)(points[0])
+    assert type(result) is float
 
 
 def test_array_argument_buffer():
@@ -243,3 +274,7 @@ def test_array_argument_buffer():
     assert isinstance(result, np.ndarray)
     expected = np.array([point.buffer(d) for d in distances], dtype=object)
     assert_geometries_equal(result, expected)
+
+    # check scalar
+    result = point.buffer(distances[0])
+    assert isinstance(result, Polygon)


### PR DESCRIPTION
Similar to #2074, this PR restores [`line.project(point)`](https://shapely.readthedocs.io/en/stable/manual.html#object.project) to return a Python float, and not a NumPy float64 scalar.  It similarly changes `line_locate_point` as well.

This is more obvious with NumPy 2.0:
```pycon
>>> import shapely
>>> line = shapely.from_wkt("LINESTRING (0 0, 1 0)")
>>> point = shapely.from_wkt("POINT(0 1)")
>>> line.project(point)
np.float64(0.0)
>>> line.line_locate_point(point)
np.float64(0.0)
```
this PR changes the functions to return Python float(0.0) instead (or `0.0`).

Tests are improved to check other scalar results, and test `project` and `interpolate` function aliases too.