### PR TITLE
MAINT: apply pydocstyle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,4 @@ repos:
     hooks:
       - id: ruff-format
       - id: ruff
+        args: ['--fix']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ select = [
     # isort
     "I",
     # pydocstyle
-    #"D",
+    "D",
 ]
 
 ignore = [

--- a/shapely/__init__.py
+++ b/shapely/__init__.py
@@ -1,3 +1,5 @@
+"""Shapely geometry objects, predicates, and operations."""
+
 from shapely.lib import GEOSException
 from shapely.lib import Geometry
 from shapely.lib import geos_version, geos_version_string

--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 class GeometryType(IntEnum):
-    """The enumeration of GEOS geometry types"""
+    """The enumeration of GEOS geometry types."""
 
     MISSING = -1
     POINT = 0
@@ -54,8 +54,9 @@ class GeometryType(IntEnum):
 
 @multithreading_enabled
 def get_type_id(geometry, **kwargs):
-    """Returns the type ID of a geometry.
+    """Return the type ID of a geometry.
 
+    Possible values are:
     - None (missing) is -1
     - POINT is 0
     - LINESTRING is 1
@@ -69,10 +70,11 @@ def get_type_id(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the type ID of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     GeometryType
 
@@ -83,13 +85,14 @@ def get_type_id(geometry, **kwargs):
     1
     >>> get_type_id([Point(1, 2), Point(2, 3)]).tolist()
     [0, 0]
+
     """
     return lib.get_type_id(geometry, **kwargs)
 
 
 @multithreading_enabled
 def get_dimensions(geometry, **kwargs):
-    """Returns the inherent dimensionality of a geometry.
+    """Return the inherent dimensionality of a geometry.
 
     The inherent dimension is 0 for points, 1 for linestrings and linearrings,
     and 2 for polygons. For geometrycollections it is the max of the containing
@@ -98,6 +101,7 @@ def get_dimensions(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the dimensionality of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -123,7 +127,7 @@ def get_dimensions(geometry, **kwargs):
 
 @multithreading_enabled
 def get_coordinate_dimension(geometry, **kwargs):
-    """Returns the dimensionality of the coordinates in a geometry (2, 3 or 4).
+    """Return the dimensionality of the coordinates in a geometry (2, 3 or 4).
 
     The return value can be one of the following:
 
@@ -139,6 +143,7 @@ def get_coordinate_dimension(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the coordinate dimension of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -151,19 +156,21 @@ def get_coordinate_dimension(geometry, **kwargs):
     3
     >>> get_coordinate_dimension(None)
     -1
+
     """
     return lib.get_coordinate_dimension(geometry, **kwargs)
 
 
 @multithreading_enabled
 def get_num_coordinates(geometry, **kwargs):
-    """Returns the total number of coordinates in a geometry.
+    """Return the total number of coordinates in a geometry.
 
     Returns 0 for not-a-geometry values.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the number of coordinates of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -182,23 +189,25 @@ def get_num_coordinates(geometry, **kwargs):
     3
     >>> get_num_coordinates(None)
     0
+
     """
     return lib.get_num_coordinates(geometry, **kwargs)
 
 
 @multithreading_enabled
 def get_srid(geometry, **kwargs):
-    """Returns the SRID of a geometry.
+    """Return the SRID of a geometry.
 
     Returns -1 for not-a-geometry values.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the SRID of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     set_srid
 
@@ -211,22 +220,25 @@ def get_srid(geometry, **kwargs):
     >>> with_srid = set_srid(point, 4326)
     >>> get_srid(with_srid)
     4326
+
     """
     return lib.get_srid(geometry, **kwargs)
 
 
 @multithreading_enabled
 def set_srid(geometry, srid, **kwargs):
-    """Returns a geometry with its SRID set.
+    """Return a geometry with its SRID set.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to set the SRID of.
     srid : int
+        The SRID to set on the geometry.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_srid
 
@@ -239,6 +251,7 @@ def set_srid(geometry, srid, **kwargs):
     >>> with_srid = set_srid(point, 4326)
     >>> get_srid(with_srid)
     4326
+
     """
     return lib.set_srid(geometry, np.intc(srid), **kwargs)
 
@@ -248,7 +261,7 @@ def set_srid(geometry, srid, **kwargs):
 
 @multithreading_enabled
 def get_x(point, **kwargs):
-    """Returns the x-coordinate of a point
+    """Return the x-coordinate of a point.
 
     Parameters
     ----------
@@ -257,7 +270,7 @@ def get_x(point, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_y, get_z, get_m
 
@@ -268,13 +281,14 @@ def get_x(point, **kwargs):
     1.0
     >>> get_x(MultiPoint([(1, 1), (1, 2)]))
     nan
+
     """
     return lib.get_x(point, **kwargs)
 
 
 @multithreading_enabled
 def get_y(point, **kwargs):
-    """Returns the y-coordinate of a point
+    """Return the y-coordinate of a point.
 
     Parameters
     ----------
@@ -283,7 +297,7 @@ def get_y(point, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_x, get_z, get_m
 
@@ -294,13 +308,14 @@ def get_y(point, **kwargs):
     2.0
     >>> get_y(MultiPoint([(1, 1), (1, 2)]))
     nan
+
     """
     return lib.get_y(point, **kwargs)
 
 
 @multithreading_enabled
 def get_z(point, **kwargs):
-    """Returns the z-coordinate of a point.
+    """Return the z-coordinate of a point.
 
     Parameters
     ----------
@@ -310,7 +325,7 @@ def get_z(point, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_x, get_y, get_m
 
@@ -323,6 +338,7 @@ def get_z(point, **kwargs):
     nan
     >>> get_z(MultiPoint([(1, 1, 1), (2, 2, 2)]))
     nan
+
     """
     return lib.get_z(point, **kwargs)
 
@@ -330,7 +346,7 @@ def get_z(point, **kwargs):
 @multithreading_enabled
 @requires_geos("3.12.0")
 def get_m(point, **kwargs):
-    """Returns the m-coordinate of a point.
+    """Return the m-coordinate of a point.
 
     .. versionadded:: 2.1.0
 
@@ -342,7 +358,7 @@ def get_m(point, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_x, get_y, get_z
 
@@ -357,6 +373,7 @@ def get_m(point, **kwargs):
     nan
     >>> get_m(from_wkt("MULTIPOINT M ((1 1 1), (2 2 2))"))
     nan
+
     """
     return lib.get_m(point, **kwargs)
 
@@ -366,17 +383,18 @@ def get_m(point, **kwargs):
 
 @multithreading_enabled
 def get_point(geometry, index, **kwargs):
-    """Returns the nth point of a linestring or linearring.
+    """Return the nth point of a linestring or linearring.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the point of.
     index : int or array_like
         Negative values count from the end of the linestring backwards.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_num_points
 
@@ -391,7 +409,7 @@ def get_point(geometry, index, **kwargs):
     >>> get_point(line, [0, 3]).tolist()
     [<POINT (0 0)>, <POINT (3 3)>]
 
-    The functcion works the same for LinearRing input:
+    The function works the same for LinearRing input:
 
     >>> get_point(LinearRing([(0, 0), (1, 1), (2, 2), (0, 0)]), 1)
     <POINT (1 1)>
@@ -402,25 +420,26 @@ def get_point(geometry, index, **kwargs):
     True
     >>> get_point(Point(1, 1), 0) is None
     True
+
     """
     return lib.get_point(geometry, np.intc(index), **kwargs)
 
 
 @multithreading_enabled
 def get_num_points(geometry, **kwargs):
-    """Returns number of points in a linestring or linearring.
+    """Return the number of points in a linestring or linearring.
 
-    Returns 0 for not-a-geometry values.
+    Returns 0 for not-a-geometry values. The number of points in geometries
+    other than linestring or linearring equals zero.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        The number of points in geometries other than linestring or linearring
-        equals zero.
+        Geometry or geometries to get the number of points of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_point
     get_num_geometries
@@ -434,6 +453,7 @@ def get_num_points(geometry, **kwargs):
     0
     >>> get_num_points(None)
     0
+
     """
     return lib.get_num_points(geometry, **kwargs)
 
@@ -443,15 +463,16 @@ def get_num_points(geometry, **kwargs):
 
 @multithreading_enabled
 def get_exterior_ring(geometry, **kwargs):
-    """Returns the exterior ring of a polygon.
+    """Return the exterior ring of a polygon.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the exterior ring of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_interior_ring
 
@@ -462,23 +483,25 @@ def get_exterior_ring(geometry, **kwargs):
     <LINEARRING (0 0, 0 10, 10 10, 10 0, 0 0)>
     >>> get_exterior_ring(Point(1, 1)) is None
     True
+
     """
     return lib.get_exterior_ring(geometry, **kwargs)
 
 
 @multithreading_enabled
 def get_interior_ring(geometry, index, **kwargs):
-    """Returns the nth interior ring of a polygon.
+    """Return the nth interior ring of a polygon.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the interior ring of.
     index : int or array_like
         Negative values count from the end of the interior rings backwards.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_exterior_ring
     get_num_interior_rings
@@ -499,24 +522,25 @@ def get_interior_ring(geometry, index, **kwargs):
     True
     >>> get_interior_ring(Point(0, 0), 0) is None
     True
+
     """
     return lib.get_interior_ring(geometry, np.intc(index), **kwargs)
 
 
 @multithreading_enabled
 def get_num_interior_rings(geometry, **kwargs):
-    """Returns number of internal rings in a polygon
+    """Return number of internal rings in a polygon.
 
     Returns 0 for not-a-geometry values.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        The number of interior rings in non-polygons equals zero.
+        Geometry or geometries to get the number of interior rings of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_exterior_ring
     get_interior_ring
@@ -537,6 +561,7 @@ def get_num_interior_rings(geometry, **kwargs):
     0
     >>> get_num_interior_rings(None)
     0
+
     """
     return lib.get_num_interior_rings(geometry, **kwargs)
 
@@ -546,11 +571,12 @@ def get_num_interior_rings(geometry, **kwargs):
 
 @multithreading_enabled
 def get_geometry(geometry, index, **kwargs):
-    """Returns the nth geometry from a collection of geometries.
+    """Return the nth geometry from a collection of geometries.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the nth geometry of.
     index : int or array_like
         Negative values count from the end of the collection backwards.
     **kwargs
@@ -561,7 +587,7 @@ def get_geometry(geometry, index, **kwargs):
     - simple geometries act as length-1 collections
     - out-of-range values return None
 
-    See also
+    See Also
     --------
     get_num_geometries, get_parts
 
@@ -579,30 +605,35 @@ def get_geometry(geometry, index, **kwargs):
     <POINT (1 1)>
     >>> get_geometry(Point(1, 1), 1) is None
     True
+
     """
     return lib.get_geometry(geometry, np.intc(index), **kwargs)
 
 
 def get_parts(geometry, return_index=False):
-    """Gets parts of each GeometryCollection or Multi* geometry object; returns
-    a copy of each geometry in the GeometryCollection or Multi* geometry object.
+    """Get parts of each GeometryCollection or Multi* geometry object.
 
-    Note: This does not return the individual parts of Multi* geometry objects in
-    a GeometryCollection.  You may need to call this function multiple times to
-    return individual parts of Multi* geometry objects in a GeometryCollection.
+    A copy of each geometry in the GeometryCollection or Multi* geometry object
+    is returned.
+
+    Note: This does not return the individual parts of Multi* geometry objects
+    in a GeometryCollection. You may need to call this function multiple times
+    to return individual parts of Multi* geometry objects in a
+    GeometryCollection.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the parts of.
     return_index : bool, default False
-        If True, will return a tuple of ndarrays of (parts, indexes), where indexes
-        are the indexes of the original geometries in the source array.
+        If True, will return a tuple of ndarrays of (parts, indexes), where
+        indexes are the indexes of the original geometries in the source array.
 
     Returns
     -------
     ndarray of parts or tuple of (parts, indexes)
 
-    See also
+    See Also
     --------
     get_geometry, get_rings
 
@@ -617,6 +648,7 @@ return_index=True)
     [<POINT (0 1)>, <POINT (4 5)>, <POINT (6 7)>]
     >>> index.tolist()
     [0, 1, 1]
+
     """
     geometry = np.asarray(geometry, dtype=np.object_)
     geometry = np.atleast_1d(geometry)
@@ -631,7 +663,7 @@ return_index=True)
 
 
 def get_rings(geometry, return_index=False):
-    """Gets rings of Polygon geometry object.
+    """Get rings of Polygon geometry object.
 
     For each Polygon, the first returned ring is always the exterior ring
     and potential subsequent rings are interior rings.
@@ -642,6 +674,7 @@ def get_rings(geometry, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the rings of.
     return_index : bool, default False
         If True, will return a tuple of ndarrays of (rings, indexes), where
         indexes are the indexes of the original geometries in the source array.
@@ -650,7 +683,7 @@ def get_rings(geometry, return_index=False):
     -------
     ndarray of rings or tuple of (rings, indexes)
 
-    See also
+    See Also
     --------
     get_exterior_ring, get_interior_ring, get_parts
 
@@ -675,6 +708,7 @@ def get_rings(geometry, return_index=False):
      <LINEARRING (2 2, 2 4, 4 4, 4 2, 2 2)>]
     >>> index.tolist()
     [0, 1, 1]
+
     """
     geometry = np.asarray(geometry, dtype=np.object_)
     geometry = np.atleast_1d(geometry)
@@ -690,19 +724,19 @@ def get_rings(geometry, return_index=False):
 
 @multithreading_enabled
 def get_num_geometries(geometry, **kwargs):
-    """Returns number of geometries in a collection.
+    """Return number of geometries in a collection.
 
-    Returns 0 for not-a-geometry values.
+    Returns 0 for not-a-geometry values. The number of geometries in points,
+    linestrings, linearrings and polygons equals one.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        The number of geometries in points, linestrings, linearrings and
-        polygons equals one.
+        Geometry or geometries to get the number of geometries of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_num_points
     get_geometry
@@ -716,6 +750,7 @@ def get_num_geometries(geometry, **kwargs):
     1
     >>> get_num_geometries(None)
     0
+
     """
     return lib.get_num_geometries(geometry, **kwargs)
 
@@ -733,10 +768,11 @@ def get_precision(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the precision of.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     set_precision
 
@@ -751,6 +787,7 @@ def get_precision(geometry, **kwargs):
     1.0
     >>> get_precision(None)
     nan
+
     """
     return lib.get_precision(geometry, **kwargs)
 
@@ -763,7 +800,7 @@ class SetPrecisionMode(ParamEnum):
 
 @multithreading_enabled
 def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
-    """Returns geometry with the precision set to a precision grid size.
+    """Return geometry with the precision set to a precision grid size.
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
@@ -776,8 +813,8 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     after rounding the vertices will be removed, which can lead to multipolygons
     or empty geometries. Z values, if present, will not be modified.
 
-    Notes:
-
+    Notes
+    -----
     * subsequent operations will always be performed in the precision of the
       geometry with higher precision (smaller "grid_size"). That same precision
       will be attached to the operation outputs.
@@ -791,12 +828,13 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to set the precision of.
     grid_size : float
         Precision grid size. If 0, will use double precision (will not modify
         geometry if precision grid size was not previously set). If this
         value is more precise than input geometry, the input geometry will
         not be modified.
-    mode :  {'valid_output', 'pointwise', 'keep_collapsed'}, default 'valid_output'
+    mode : {'valid_output', 'pointwise', 'keep_collapsed'}, default 'valid_output'
         This parameter determines the way a precision reduction is applied on
         the geometry. There are three modes:
 
@@ -818,7 +856,7 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_precision
 
@@ -839,6 +877,7 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
     <LINESTRING (0 0, 0 0)>
     >>> set_precision(None, 1.0) is None
     True
+
     """  # noqa: E501
     if isinstance(mode, str):
         mode = SetPrecisionMode.get_value(mode)
@@ -855,11 +894,12 @@ def set_precision(geometry, grid_size, mode="valid_output", **kwargs):
 
 @multithreading_enabled
 def force_2d(geometry, **kwargs):
-    """Forces the dimensionality of a geometry to 2D.
+    """Force the dimensionality of a geometry to 2D.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to force to 2D.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -876,13 +916,14 @@ def force_2d(geometry, **kwargs):
     <POLYGON EMPTY>
     >>> force_2d(None) is None
     True
+
     """
     return lib.force_2d(geometry, **kwargs)
 
 
 @multithreading_enabled
 def force_3d(geometry, z=0.0, **kwargs):
-    """Forces the dimensionality of a geometry to 3D.
+    """Force the dimensionality of a geometry to 3D.
 
     2D geometries will get the provided Z coordinate; Z coordinates of 3D geometries
     are unchanged (unless they are nan).
@@ -893,7 +934,9 @@ def force_3d(geometry, z=0.0, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to force to 3D.
     z : float or array_like, default 0.0
+        The Z coordinate value to set on the geometry.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -908,6 +951,7 @@ def force_3d(geometry, z=0.0, **kwargs):
     <LINESTRING Z (0 0 0, 0 1 0, 1 1 0)>
     >>> force_3d(None) is None
     True
+
     """
     if np.isnan(z).any():
         raise ValueError("It is not allowed to set the Z coordinate to NaN.")

--- a/shapely/_ragged_array.py
+++ b/shapely/_ragged_array.py
@@ -1,10 +1,8 @@
-"""
-This modules provides a conversion to / from a ragged (or "jagged") array
-representation of the geometries.
+"""Provides a conversion to / from a ragged array representation of geometries.
 
-A ragged array is an irregular array of arrays of which each element can have
-a different length. As a result, such an array cannot be represented as a
-standard, rectangular nD array.
+A ragged (or "jagged") array is an irregular array of arrays of which each
+element can havea  different length. As a result, such an array cannot be
+represented as a standard, rectangular nD array.
 The coordinates of geometries can be represented as arrays of arrays of
 coordinate pairs (possibly multiple levels of nesting, depending on the
 geometry type).
@@ -139,9 +137,7 @@ def _get_arrays_multipolygon(arr, include_z):
 
 
 def to_ragged_array(geometries, include_z=None):
-    """
-    Converts geometries to a ragged array representation using a contiguous
-    array of coordinates and offset arrays.
+    """Convert geometries to a ragged array representation.
 
     This function converts an array of geometries to a ragged array
     (i.e. irregular array of arrays) of coordinates, represented in memory
@@ -188,7 +184,7 @@ def to_ragged_array(geometries, include_z=None):
     treated as multi types.
     GeometryCollections and other mixed geometry types are not supported.
 
-    See also
+    See Also
     --------
     from_ragged_array
 
@@ -401,9 +397,7 @@ def _multipolygons_from_flatcoords(coords, offsets1, offsets2, offsets3):
 
 
 def from_ragged_array(geometry_type, coords, offsets=None):
-    """
-    Creates geometries from a contiguous array of coordinates
-    and offset arrays.
+    """Create geometries from a contiguous array of coordinates and offset arrays.
 
     This function creates geometries from the ragged array representation
     as returned by ``to_ragged_array``.

--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -91,7 +91,7 @@ def affine_transform(geom, matrix):
 
 
 def interpret_origin(geom, origin, ndim):
-    """Returns interpreted coordinate tuple for origin parameter.
+    """Return interpreted coordinate tuple for origin parameter.
 
     This is a helper function for other transform functions.
 
@@ -124,7 +124,7 @@ def interpret_origin(geom, origin, ndim):
 
 
 def rotate(geom, angle, origin="center", use_radians=False):
-    r"""Returns a rotated geometry on a 2D plane.
+    r"""Return a rotated geometry on a 2D plane.
 
     The angle of rotation can be specified in either degrees (default) or
     radians by setting ``use_radians=True``. Positive angles are
@@ -167,7 +167,7 @@ def rotate(geom, angle, origin="center", use_radians=False):
 
 
 def scale(geom, xfact=1.0, yfact=1.0, zfact=1.0, origin="center"):
-    r"""Returns a scaled geometry, scaled by factors along each dimension.
+    r"""Return a scaled geometry, scaled by factors along each dimension.
 
     The point of origin can be a keyword 'center' for the 2D bounding box
     center (default), 'centroid' for the geometry's 2D centroid, a Point
@@ -202,7 +202,7 @@ def scale(geom, xfact=1.0, yfact=1.0, zfact=1.0, origin="center"):
 
 
 def skew(geom, xs=0.0, ys=0.0, origin="center", use_radians=False):
-    r"""Returns a skewed geometry, sheared by angles along x and y dimensions.
+    r"""Return a skewed geometry, sheared by angles along x and y dimensions.
 
     The shear angle can be specified in either degrees (default) or radians
     by setting ``use_radians=True``.
@@ -245,7 +245,7 @@ def skew(geom, xs=0.0, ys=0.0, origin="center", use_radians=False):
 
 
 def translate(geom, xoff=0.0, yoff=0.0, zoff=0.0):
-    r"""Returns a translated geometry shifted by offsets along each dimension.
+    r"""Return a translated geometry shifted by offsets along each dimension.
 
     The general 3D affine transformation matrix for translation is:
 

--- a/shapely/algorithms/__init__.py
+++ b/shapely/algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Algorithms implemented in Shapely."""

--- a/shapely/algorithms/_oriented_envelope.py
+++ b/shapely/algorithms/_oriented_envelope.py
@@ -8,9 +8,7 @@ from shapely.affinity import affine_transform
 
 
 def _oriented_envelope_min_area(geometry, **kwargs):
-    """
-    Computes the oriented envelope (minimum rotated rectangle) that encloses
-    an input geometry.
+    """Compute the oriented envelope (minimum rotated rectangle).
 
     This is a fallback implementation for GEOS < 3.12 to have the correct
     minimum area behaviour.

--- a/shapely/algorithms/cga.py
+++ b/shapely/algorithms/cga.py
@@ -1,11 +1,14 @@
+"""Shapely CGA algorithms."""
+
 import numpy as np
 
 import shapely
 
 
 def signed_area(ring):
-    """Return the signed area enclosed by a ring in linear time using the
-    algorithm at: https://web.archive.org/web/20080209143651/http://cgafaq.info:80/wiki/Polygon_Area
+    """Return the signed area enclosed by a ring in linear time.
+
+    Algorithm used: https://web.archive.org/web/20080209143651/http://cgafaq.info:80/wiki/Polygon_Area
     """
     coords = np.array(ring.coords)[:, :2]
     xs, ys = np.vstack([coords, coords[1]]).T
@@ -13,5 +16,5 @@ def signed_area(ring):
 
 
 def is_ccw_impl(name=None):
-    """Predicate implementation"""
+    """Predicate implementation."""
     return shapely.is_ccw

--- a/shapely/algorithms/polylabel.py
+++ b/shapely/algorithms/polylabel.py
@@ -1,3 +1,5 @@
+"""Provides functions for finding the pole of inaccessibility for a given polygon."""
+
 from heapq import heappop, heappush
 
 from shapely.errors import TopologicalError
@@ -5,14 +7,28 @@ from shapely.geometry import Point
 
 
 class Cell:
-    """A `Cell`'s centroid property is a potential solution to finding the pole
-    of inaccessibility for a given polygon. Rich comparison operators are used
-    for sorting `Cell` objects in a priority queue based on the potential
-    maximum distance of any theoretical point within a cell to a given
-    polygon's exterior boundary.
+    """A `Cell`'s centroid is a potential solution to find the pole of inaccessibility.
+
+    Rich comparison operators are used for sorting `Cell` objects in a priority
+    queue based on the potential maximum distance of any theoretical point
+    within a cell to a given polygon's exterior boundary.
     """
 
     def __init__(self, x, y, h, polygon):
+        """Initialize a Cell object.
+
+        Parameters
+        ----------
+        x : float
+            The x-coordinate of the cell centroid.
+        y : float
+            The y-coordinate of the cell centroid.
+        h : float
+            Half of the cell size.
+        polygon : shapely.geometry.Polygon
+            The polygon associated with the cell.
+
+        """
         self.x = x
         self.y = y
         self.h = h  # half of cell size
@@ -26,27 +42,34 @@ class Cell:
 
     # rich comparison operators for sorting in minimum priority queue
     def __lt__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance > other.max_distance
 
     def __le__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance >= other.max_distance
 
     def __eq__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance == other.max_distance
 
     def __ne__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance != other.max_distance
 
     def __gt__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance < other.max_distance
 
     def __ge__(self, other):
+        """Compare Cell objects based on their maximum distance."""
         return self.max_distance <= other.max_distance
 
     def _dist(self, polygon):
-        """Signed distance from Cell centroid to polygon outline. The returned
-        value is negative if the point is outside of the polygon exterior
-        boundary.
+        """Signed distance from Cell centroid to polygon outline.
+
+        The returned value is negative if the point is outside of the polygon
+        exterior boundary.
         """
         inside = polygon.contains(self.centroid)
         distance = self.centroid.distance(polygon.exterior)
@@ -58,12 +81,14 @@ class Cell:
 
 
 def polylabel(polygon, tolerance=1.0):
-    """Finds pole of inaccessibility for a given polygon. Based on
-    Vladimir Agafonkin's https://github.com/mapbox/polylabel
+    """Find pole of inaccessibility for a given polygon.
+
+    Based on Vladimir Agafonkin's https://github.com/mapbox/polylabel
 
     Parameters
     ----------
     polygon : shapely.geometry.Polygon
+        Polygon for which to find the pole of inaccessibility.
     tolerance : int or float, optional
                 `tolerance` represents the highest resolution in units of the
                 input geometry that will be considered for a solution. (default
@@ -87,6 +112,7 @@ def polylabel(polygon, tolerance=1.0):
     ... (-100, -20), (-150, -200)]).buffer(100)
     >>> polylabel(polygon, tolerance=10).wkt
     'POINT (59.35615556364569 121.83919629746435)'
+
     """
     if not polygon.is_valid:
         raise TopologicalError("Invalid polygon")

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -1,3 +1,5 @@
+"""Methods that operate on the coordinates of geometries."""
+
 from typing import Optional
 
 import numpy as np
@@ -14,8 +16,7 @@ def transform(
     include_z: Optional[bool] = False,
     interleaved: bool = True,
 ):
-    """Returns a copy of a geometry array with a function applied to its
-    coordinates.
+    """Apply a function to the coordinates of a geometry.
 
     With the default of ``include_z=False``, all returned geometries will be
     two-dimensional; the third dimension will be discarded, if present.
@@ -25,6 +26,7 @@ def transform(
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to transform.
     transformation : function
         A function that transforms a (N, 2) or (N, 3) ndarray of float64 to
         another (N, 2) or (N, 3) ndarray of float64.
@@ -48,8 +50,7 @@ def transform(
 
     See Also
     --------
-    has_z : Returns a copy of a geometry array with a function applied to its
-        coordinates.
+    has_z
 
     Examples
     --------
@@ -90,6 +91,7 @@ def transform(
     >>> transformer = Transformer.from_crs(4326, 32618, always_xy=True)
     >>> transform(Point(-75, 50), transformer.transform, interleaved=False)
     <POINT (500000 5538630.703)>
+
     """  # noqa: E501
     geometry_arr = np.array(geometry, dtype=np.object_)  # makes a copy
     if include_z is None:
@@ -133,11 +135,12 @@ def transform(
 
 
 def count_coordinates(geometry):
-    """Counts the number of coordinate pairs in a geometry array.
+    """Count the number of coordinate pairs in a geometry array.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to count the coordinates of.
 
     Examples
     --------
@@ -150,12 +153,13 @@ def count_coordinates(geometry):
     0
     >>> count_coordinates([Point(0, 0), None])
     1
+
     """
     return lib.count_coordinates(np.asarray(geometry, dtype=np.object_))
 
 
 def get_coordinates(geometry, include_z=False, return_index=False):
-    """Gets coordinates from a geometry array as an array of floats.
+    """Get coordinates from a geometry array as an array of floats.
 
     The shape of the returned array is (N, 2), with N being the number of
     coordinate pairs. With the default of ``include_z=False``, three-dimensional
@@ -165,6 +169,7 @@ def get_coordinates(geometry, include_z=False, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to get the coordinates of.
     include_z : bool, default False
         If, True include the third dimension in the output. If a geometry
         has no third dimension, the z-coordinates will be NaN.
@@ -196,6 +201,7 @@ def get_coordinates(geometry, include_z=False, return_index=False):
     >>> coordinates, index = get_coordinates(geometries, return_index=True)
     >>> coordinates.tolist(), index.tolist()
     ([[2.0, 2.0], [4.0, 4.0], [0.0, 0.0]], [0, 0, 1])
+
     """
     return lib.get_coordinates(
         np.asarray(geometry, dtype=np.object_), include_z, return_index
@@ -219,7 +225,9 @@ def set_coordinates(geometry, coordinates):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to set the coordinates of.
     coordinates: array_like
+        An array of coordinates to set.
 
     See Also
     --------
@@ -243,6 +251,7 @@ def set_coordinates(geometry, coordinates):
     <POINT (1 1)>
     >>> set_coordinates(Point(0, 0, 0), [[1, 1, 1]])
     <POINT Z (1 1 1)>
+
     """  # noqa: E501
     geometry_arr = np.asarray(geometry, dtype=np.object_)
     coordinates = np.atleast_2d(np.asarray(coordinates)).astype(np.float64)

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -1,15 +1,13 @@
-"""Coordinate sequence utilities"""
+"""Coordinate sequence utilities."""
 
 from array import array
 
 
 class CoordinateSequence:
-    """
-    Iterative access to coordinate tuples from the parent geometry's coordinate
-    sequence.
+    """Access to coordinate tuples from the parent geometry's coordinate sequence.
 
     Example:
-
+    -------
       >>> from shapely.wkt import loads
       >>> g = loads('POINT (0.0 0.0)')
       >>> list(g.coords)
@@ -18,16 +16,44 @@ class CoordinateSequence:
     """
 
     def __init__(self, coords):
+        """Initialize the CoordinateSequence.
+
+        Args:
+        ----
+            coords : array
+                The coordinate array.
+
+        """
         self._coords = coords
 
     def __len__(self):
+        """Return the length of the CoordinateSequence.
+
+        Returns
+        -------
+            int: The length of the CoordinateSequence.
+
+        """
         return self._coords.shape[0]
 
     def __iter__(self):
+        """Iterate over the CoordinateSequence."""
         for i in range(self.__len__()):
             yield tuple(self._coords[i].tolist())
 
     def __getitem__(self, key):
+        """Get the item at the specified index or slice.
+
+        Args:
+        ----
+            key : int or slice
+                The index or slice.
+
+        Returns:
+        -------
+            tuple or list: The item at the specified index or slice.
+
+        """
         m = self.__len__()
         if isinstance(key, int):
             if key + m < 0 or key >= m:
@@ -47,6 +73,25 @@ class CoordinateSequence:
             raise TypeError("key must be an index or slice")
 
     def __array__(self, dtype=None, copy=None):
+        """Return a copy of the coordinate array.
+
+        Args:
+        ----
+            dtype : data-type, optional
+                The desired data-type for the array.
+            copy : bool, optional
+                If True (default), a copy of the array is returned.
+                If False, the array is returned as-is.
+
+        Returns:
+        -------
+            array : The coordinate array.
+
+        Raises:
+        ------
+            ValueError : If `copy=False` is specified.
+
+        """
         if copy is False:
             raise ValueError("`copy=False` isn't supported. A copy is always created.")
         elif copy is True:
@@ -56,7 +101,7 @@ class CoordinateSequence:
 
     @property
     def xy(self):
-        """X and Y arrays"""
+        """X and Y arrays."""
         m = self.__len__()
         x = array("d")
         y = array("d")

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -1,3 +1,5 @@
+"""Methods to create geometries."""
+
 import numpy as np
 
 from shapely import Geometry, GeometryType, lib
@@ -50,7 +52,9 @@ def points(
         An array of coordinate tuples (2- or 3-dimensional) or, if ``y`` is
         provided, an array of x coordinates.
     y : array_like, optional
+        An array of y coordinates.
     z : array_like, optional
+        An array of z coordinates.
     indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
@@ -88,12 +92,12 @@ def points(
 
     Notes
     -----
-
     - GEOS 3.10, 3.11 and 3.12 automatically converts POINT (nan nan) to POINT EMPTY.
     - GEOS 3.10 and 3.11 will transform a 3D point to 2D if its Z coordinate is NaN.
     - Usage of the ``y`` and ``z`` arguments will prevents lazy evaluation in
       ``dask``. Instead provide the coordinates as an array with shape
       ``(..., 2)`` or ``(..., 3)`` using only the ``coords`` argument.
+
     """
     coords = _xyz_to_coords(coords, y, z)
     if isinstance(handle_nan, str):
@@ -119,9 +123,11 @@ def linestrings(
     ----------
     coords : array_like
         An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
-        is provided, an array of lists of x coordinates
+        is provided, an array of lists of x coordinates.
     y : array_like, optional
+        An array of y coordinates.
     z : array_like, optional
+        An array of z coordinates.
     indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
@@ -164,6 +170,7 @@ def linestrings(
     - Usage of the ``y`` and ``z`` arguments will prevents lazy evaluation in
       ``dask``. Instead provide the coordinates as a ``(..., 2)`` or
       ``(..., 3)`` array using only ``coords``.
+
     """  # noqa: E501
     coords = _xyz_to_coords(coords, y, z)
     if isinstance(handle_nan, str):
@@ -194,7 +201,9 @@ def linearrings(
         An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
         is provided, an array of lists of x coordinates
     y : array_like, optional
+        An array of y coordinates.
     z : array_like, optional
+        An array of z coordinates.
     indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
@@ -225,7 +234,7 @@ def linearrings(
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
-    See also
+    See Also
     --------
     linestrings
 
@@ -241,6 +250,7 @@ def linearrings(
     - Usage of the ``y`` and ``z`` arguments will prevents lazy evaluation in
       ``dask``. Instead provide the coordinates as a ``(..., 2)`` or
       ``(..., 3)`` array using only ``coords``.
+
     """
     coords = _xyz_to_coords(coords, y, z)
     if isinstance(handle_nan, str):
@@ -321,6 +331,7 @@ def polygons(geometries, holes=None, indices=None, out=None, **kwargs):
     <POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
     >>> polygons([ring_1, None], indices=[0, 0])[0]
     <POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+
     """
     geometries = np.asarray(geometries)
     if not isinstance(geometries, Geometry) and np.issubdtype(
@@ -352,10 +363,14 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
 
     Parameters
     ----------
-    xmin : array_like
-    ymin : array_like
-    xmax : array_like
-    ymax : array_like
+    xmin : float or array_like
+        Float or array of minimum x coordinates.
+    ymin : float or array_like
+        Float or array of minimum y coordinates.
+    xmax : float or array_like
+        Float or array of maximum x coordinates.
+    ymax : float or array_like
+        Float or array of maximum y coordinates.
     ccw : bool, default True
         If True, box will be created in counterclockwise direction starting
         from bottom right coordinate (xmax, ymin).
@@ -377,7 +392,7 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
 
 @multithreading_enabled
 def multipoints(geometries, indices=None, out=None, **kwargs):
-    """Create multipoints from arrays of points
+    """Create multipoints from arrays of points.
 
     Parameters
     ----------
@@ -426,6 +441,7 @@ def multipoints(geometries, indices=None, out=None, **kwargs):
     [<MULTIPOINT ((1 1))>]
     >>> multipoints([point_1, None], indices=[0, 1]).tolist()
     [<MULTIPOINT ((1 1))>, <MULTIPOINT EMPTY>]
+
     """
     typ = GeometryType.MULTIPOINT
     geometries = np.asarray(geometries)
@@ -441,7 +457,7 @@ def multipoints(geometries, indices=None, out=None, **kwargs):
 
 @multithreading_enabled
 def multilinestrings(geometries, indices=None, out=None, **kwargs):
-    """Create multilinestrings from arrays of linestrings
+    """Create multilinestrings from arrays of linestrings.
 
     Parameters
     ----------
@@ -459,9 +475,10 @@ def multilinestrings(geometries, indices=None, out=None, **kwargs):
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
-    See also
+    See Also
     --------
     multipoints
+
     """
     typ = GeometryType.MULTILINESTRING
     geometries = np.asarray(geometries)
@@ -478,7 +495,7 @@ def multilinestrings(geometries, indices=None, out=None, **kwargs):
 
 @multithreading_enabled
 def multipolygons(geometries, indices=None, out=None, **kwargs):
-    """Create multipolygons from arrays of polygons
+    """Create multipolygons from arrays of polygons.
 
     Parameters
     ----------
@@ -496,9 +513,10 @@ def multipolygons(geometries, indices=None, out=None, **kwargs):
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
-    See also
+    See Also
     --------
     multipoints
+
     """
     typ = GeometryType.MULTIPOLYGON
     geometries = np.asarray(geometries)
@@ -514,12 +532,12 @@ def multipolygons(geometries, indices=None, out=None, **kwargs):
 
 @multithreading_enabled
 def geometrycollections(geometries, indices=None, out=None, **kwargs):
-    """Create geometrycollections from arrays of geometries
+    """Create geometrycollections from arrays of geometries.
 
     Parameters
     ----------
     geometries : array_like
-        An array of geometries
+        An array of geometries.
     indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
@@ -532,9 +550,10 @@ def geometrycollections(geometries, indices=None, out=None, **kwargs):
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
-    See also
+    See Also
     --------
     multipoints
+
     """
     typ = GeometryType.GEOMETRYCOLLECTION
     if indices is None:
@@ -567,7 +586,7 @@ def prepare(geometry, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_prepared : Identify whether a geometry is prepared already.
     destroy_prepared : Destroy the prepared part of a geometry.
@@ -579,6 +598,7 @@ def prepare(geometry, **kwargs):
     >>> prepare(poly)
     >>> contains_properly(poly, [Point(0.0, 0.0), Point(0.5, 0.5)]).tolist()
     [False, True]
+
     """
     lib.prepare(geometry, **kwargs)
 
@@ -597,9 +617,10 @@ def destroy_prepared(geometry, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     prepare
+
     """
     lib.destroy_prepared(geometry, **kwargs)
 
@@ -625,6 +646,7 @@ def empty(shape, geom_type=None, order="C"):
     [[None, None, None], [None, None, None]]
     >>> empty(2, geom_type=GeometryType.POINT).tolist()
     [<POINT EMPTY>, <POINT EMPTY>]
+
     """
     if geom_type is None:
         return np.empty(shape, dtype=object, order=order)

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -1,3 +1,5 @@
+"""Decorators for Shapely functions."""
+
 import os
 from functools import wraps
 
@@ -8,12 +10,16 @@ from shapely.errors import UnsupportedGEOSVersionError
 
 
 class requires_geos:
+    """Decorator to require a minimum GEOS version."""
+
     def __init__(self, version):
+        """Create a decorator that requires a minimum GEOS version."""
         if version.count(".") != 2:
             raise ValueError("Version must be <major>.<minor>.<patch> format")
         self.version = tuple(int(x) for x in version.split("."))
 
     def __call__(self, func):
+        """Return the wrapped function."""
         is_compatible = lib.geos_version >= self.version
         is_doc_build = os.environ.get("SPHINX_DOC_BUILD") == "1"  # set in docs/conf.py
         if is_compatible and not is_doc_build:
@@ -53,11 +59,13 @@ class requires_geos:
 
 
 def multithreading_enabled(func):
-    """Prepare multithreading by setting the writable flags of object type
-    ndarrays to False.
+    """Enable multithreading.
+
+    To do this, the writable flags of object type ndarrays are set to False.
 
     NB: multithreading also requires the GIL to be released, which is done in
-    the C extension (ufuncs.c)."""
+    the C extension (ufuncs.c).
+    """
 
     @wraps(func)
     def wrapped(*args, **kwargs):

--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -6,7 +6,7 @@ from shapely.lib import GEOSException, ShapelyError, _setup_signal_checks  # noq
 
 
 def setup_signal_checks(interval=10000):
-    """This enables Python signal checks in the ufunc inner loops.
+    """Enable Python signal checks in the ufunc inner loops.
 
     Doing so allows termination (using CTRL+C) of operations on large arrays of
     vectors.
@@ -24,6 +24,7 @@ def setup_signal_checks(interval=10000):
     For more information on signals consult the Python docs:
 
     https://docs.python.org/3/library/signal.html
+
     """
     if interval <= 0:
         raise ValueError("Signal checks interval must be greater than zero.")
@@ -44,10 +45,7 @@ class TopologicalError(ShapelyError):
 
 
 class ShapelyDeprecationWarning(FutureWarning):
-    """
-    Warning for features that will be removed or behaviour that will be
-    changed in a future release.
-    """
+    """Warning for features that will be removed or changed in a future release."""
 
 
 class EmptyPartError(ShapelyError):
@@ -55,10 +53,7 @@ class EmptyPartError(ShapelyError):
 
 
 class GeometryTypeError(ShapelyError):
-    """
-    An error raised when the type of the geometry in question is
-    unrecognized or inappropriate.
-    """
+    """An error raised when the geometry has an unrecognized or inappropriate type."""
 
 
 def __getattr__(name):

--- a/shapely/geometry/__init__.py
+++ b/shapely/geometry/__init__.py
@@ -1,4 +1,4 @@
-"""Geometry classes and factories"""
+"""Geometry classes and factories."""
 
 from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 from shapely.geometry.collection import GeometryCollection

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -1,4 +1,4 @@
-"""Base geometry class and utilities
+"""Base geometry class and utilities.
 
 Note: a third, z, coordinate value may be used when constructing
 geometry objects, but has no effect on geometric analysis. All
@@ -30,8 +30,7 @@ GEOMETRY_TYPES = [
 
 
 def geom_factory(g, parent=None):
-    """
-    Creates a Shapely geometry instance from a pointer to a GEOS geometry.
+    """Create a Shapely geometry instance from a pointer to a GEOS geometry.
 
     .. warning::
         The GEOS library used to create the the GEOS geometry pointer
@@ -51,7 +50,7 @@ def geom_factory(g, parent=None):
 
 
 def dump_coords(geom):
-    """Dump coordinates of a geometry in the same order as data packing"""
+    """Dump coordinates of a geometry in the same order as data packing."""
     if not isinstance(geom, BaseGeometry):
         raise ValueError(
             "Must be instance of a geometry class; found " + geom.__class__.__name__
@@ -77,26 +76,32 @@ def _maybe_unpack(result):
 
 
 class CAP_STYLE:
+    """Buffer cap styles."""
+
     round = BufferCapStyle.round
     flat = BufferCapStyle.flat
     square = BufferCapStyle.square
 
 
 class JOIN_STYLE:
+    """Buffer join styles."""
+
     round = BufferJoinStyle.round
     mitre = BufferJoinStyle.mitre
     bevel = BufferJoinStyle.bevel
 
 
 class BaseGeometry(shapely.Geometry):
-    """
-    Provides GEOS spatial predicates and topological operations.
-
-    """
+    """Provides GEOS spatial predicates and topological operations."""
 
     __slots__ = []
 
     def __new__(self):
+        """Directly calling the base class 'BaseGeometry()' is deprecated.
+
+        This will raise an error in the future. To create an empty geometry,
+        use one of the subclasses instead, for example 'GeometryCollection()'
+        """
         warn(
             "Directly calling the base class 'BaseGeometry()' is deprecated, and "
             "will raise an error in the future. To create an empty geometry, "
@@ -111,9 +116,11 @@ class BaseGeometry(shapely.Geometry):
         return shapely.get_coordinate_dimension(self)
 
     def __bool__(self):
+        """Return True if the geometry is not empty, else False."""
         return self.is_empty is False
 
     def __nonzero__(self):
+        """Return True if the geometry is not empty, else False."""
         return self.__bool__()
 
     def __format__(self, format_spec):
@@ -162,6 +169,7 @@ class BaseGeometry(shapely.Geometry):
             return res
 
     def __repr__(self):
+        """Return a string representation of the geometry."""
         try:
             wkt = super().__str__()
         except (GEOSException, ValueError):
@@ -176,27 +184,34 @@ class BaseGeometry(shapely.Geometry):
         return f"<{wkt}>"
 
     def __str__(self):
+        """Return a string representation of the geometry."""
         return self.wkt
 
     def __reduce__(self):
+        """Pickle support."""
         return (shapely.from_wkb, (shapely.to_wkb(self, include_srid=True),))
 
     # Operators
     # ---------
 
     def __and__(self, other):
+        """Return the intersection of the geometries."""
         return self.intersection(other)
 
     def __or__(self, other):
+        """Return the union of the geometries."""
         return self.union(other)
 
     def __sub__(self, other):
+        """Return the difference of the geometries."""
         return self.difference(other)
 
     def __xor__(self, other):
+        """Return the symmetric difference of the geometries."""
         return self.symmetric_difference(other)
 
     def __eq__(self, other):
+        """Return True if geometries are equal, else False."""
         if not isinstance(other, BaseGeometry):
             return NotImplemented
         # equal_nan=False is the default, but not yet available for older numpy
@@ -207,11 +222,13 @@ class BaseGeometry(shapely.Geometry):
         )
 
     def __ne__(self, other):
+        """Return True if geometries are not equal, else False."""
         if not isinstance(other, BaseGeometry):
             return NotImplemented
         return not self.__eq__(other)
 
     def __hash__(self):
+        """Return the hash value of the geometry."""
         return super().__hash__()
 
     # Coordinate access
@@ -219,26 +236,31 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def coords(self):
-        """Access to geometry's coordinates (CoordinateSequence)"""
+        """Access to geometry's coordinates (CoordinateSequence)."""
         coords_array = shapely.get_coordinates(self, include_z=self.has_z)
         return CoordinateSequence(coords_array)
 
     @property
     def xy(self):
-        """Separate arrays of X and Y coordinate values"""
+        """Separate arrays of X and Y coordinate values."""
         raise NotImplementedError
 
     # Python feature protocol
 
     @property
     def __geo_interface__(self):
-        """Dictionary representation of the geometry"""
+        """Dictionary representation of the geometry."""
         raise NotImplementedError
 
     # Type of geometry and its representations
     # ----------------------------------------
 
     def geometryType(self):
+        """Get the geometry type (deprecated).
+
+        It will be removed in the future. You can use the 'geom_type' attribute
+        instead.
+        """
         warn(
             "The 'GeometryType()' method is deprecated, and will be removed in "
             "the future. You can use the 'geom_type' attribute instead.",
@@ -249,6 +271,11 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def type(self):
+        """Get the geometry type (deprecated).
+
+        It will be removed in the future. You can use the 'geom_type' attribute
+        instead.
+        """
         warn(
             "The 'type' attribute is deprecated, and will be removed in "
             "the future. You can use the 'geom_type' attribute instead.",
@@ -259,26 +286,26 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def wkt(self):
-        """WKT representation of the geometry"""
+        """WKT representation of the geometry."""
         # TODO(shapely-2.0) keep default of not trimming?
         return shapely.to_wkt(self, rounding_precision=-1)
 
     @property
     def wkb(self):
-        """WKB representation of the geometry"""
+        """WKB representation of the geometry."""
         return shapely.to_wkb(self)
 
     @property
     def wkb_hex(self):
-        """WKB hex representation of the geometry"""
+        """WKB hex representation of the geometry."""
         return shapely.to_wkb(self, hex=True)
 
     def svg(self, scale_factor=1.0, **kwargs):
-        """Raises NotImplementedError"""
+        """Raise NotImplementedError."""
         raise NotImplementedError
 
     def _repr_svg_(self):
-        """SVG representation for iPython notebook"""
+        """SVG representation for iPython notebook."""
         svg_top = (
             '<svg xmlns="http://www.w3.org/2000/svg" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" '
@@ -318,7 +345,7 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def geom_type(self):
-        """Name of the geometry's type, such as 'Point'"""
+        """Name of the geometry's type, such as 'Point'."""
         return GEOMETRY_TYPES[shapely.get_type_id(self)]
 
     # Real-valued properties and methods
@@ -326,26 +353,25 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def area(self):
-        """Unitless area of the geometry (float)"""
+        """Unitless area of the geometry (float)."""
         return float(shapely.area(self))
 
     def distance(self, other):
-        """Unitless distance to other geometry (float)"""
+        """Unitless distance to other geometry (float)."""
         return _maybe_unpack(shapely.distance(self, other))
 
     def hausdorff_distance(self, other):
-        """Unitless hausdorff distance to other geometry (float)"""
+        """Unitless hausdorff distance to other geometry (float)."""
         return _maybe_unpack(shapely.hausdorff_distance(self, other))
 
     @property
     def length(self):
-        """Unitless length of the geometry (float)"""
+        """Unitless length of the geometry (float)."""
         return float(shapely.length(self))
 
     @property
     def minimum_clearance(self):
-        """Unitless distance by which a node could be moved to produce an
-        invalid geometry (float)"""
+        """Unitless distance a node can be moved to produce an invalid geometry (float)."""  # noqa: E501
         return float(shapely.minimum_clearance(self))
 
     # Topological properties
@@ -353,7 +379,7 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def boundary(self):
-        """Returns a lower dimension geometry that bounds the object
+        """Return a lower dimension geometry that bounds the object.
 
         The boundary of a polygon is a line, the boundary of a line is a
         collection of points. The boundary of a point is an empty (null)
@@ -363,23 +389,23 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def bounds(self):
-        """Returns minimum bounding region (minx, miny, maxx, maxy)"""
+        """Return minimum bounding region (minx, miny, maxx, maxy)."""
         return tuple(shapely.bounds(self).tolist())
 
     @property
     def centroid(self):
-        """Returns the geometric center of the object"""
+        """Return the geometric center of the object."""
         return shapely.centroid(self)
 
     def point_on_surface(self):
-        """Returns a point guaranteed to be within the object, cheaply.
+        """Return a point guaranteed to be within the object, cheaply.
 
         Alias of `representative_point`.
         """
         return shapely.point_on_surface(self)
 
     def representative_point(self):
-        """Returns a point guaranteed to be within the object, cheaply.
+        """Return a point guaranteed to be within the object, cheaply.
 
         Alias of `point_on_surface`.
         """
@@ -387,8 +413,10 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def convex_hull(self):
-        """Imagine an elastic band stretched around the geometry: that's a
-        convex hull, more or less
+        """Return the convex hull of the geometry.
+
+        Imagine an elastic band stretched around the geometry: that's a convex
+        hull, more or less.
 
         The convex hull of a three member multipoint, for example, is a
         triangular polygon.
@@ -397,14 +425,12 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def envelope(self):
-        """A figure that envelopes the geometry"""
+        """A figure that envelopes the geometry."""
         return shapely.envelope(self)
 
     @property
     def oriented_envelope(self):
-        """
-        Returns the oriented envelope (minimum rotated rectangle) that
-        encloses the geometry.
+        """Return the oriented envelope (minimum rotated rectangle) of a geometry.
 
         Unlike envelope this rectangle is not constrained to be parallel to the
         coordinate axes. If the convex hull of the object is a degenerate (line
@@ -416,9 +442,7 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def minimum_rotated_rectangle(self):
-        """
-        Returns the oriented envelope (minimum rotated rectangle) that
-        encloses the geometry.
+        """Return the oriented envelope (minimum rotated rectangle) of the geometry.
 
         Unlike `envelope` this rectangle is not constrained to be parallel to the
         coordinate axes. If the convex hull of the object is a degenerate (line
@@ -438,8 +462,7 @@ class BaseGeometry(shapely.Geometry):
         single_sided=False,
         **kwargs,
     ):
-        """Get a geometry that represents all points within a distance
-        of this geometry.
+        """Get a geometry that represents all points within a distance of this geometry.
 
         A positive distance produces a dilation, a negative distance an
         erosion. A very small or zero distance may sometimes be used to
@@ -490,6 +513,8 @@ class BaseGeometry(shapely.Geometry):
             CAP_FLAT.
         quadsegs : int, optional
             Deprecated alias for `quad_segs`.
+        kwargs : dict, optional
+            For backwards compatibility, will be ignored.
 
         Returns
         -------
@@ -558,8 +583,7 @@ class BaseGeometry(shapely.Geometry):
         )
 
     def simplify(self, tolerance, preserve_topology=True):
-        """Returns a simplified geometry produced by the Douglas-Peucker
-        algorithm
+        """Return a simplified geometry produced by the Douglas-Peucker algorithm.
 
         Coordinates of the simplified geometry will be no more than the
         tolerance distance from the original. Unless the topology preserving
@@ -569,7 +593,7 @@ class BaseGeometry(shapely.Geometry):
         return shapely.simplify(self, tolerance, preserve_topology=preserve_topology)
 
     def normalize(self):
-        """Converts geometry to normal form (or canonical form).
+        """Convert geometry to normal form (or canonical form).
 
         This method orders the coordinates, rings of a polygon and parts of
         multi geometries consistently. Typically useful for testing purposes
@@ -581,6 +605,7 @@ class BaseGeometry(shapely.Geometry):
         >>> line = MultiLineString([[(0, 0), (1, 1)], [(3, 3), (2, 2)]])
         >>> line.normalize()
         <MULTILINESTRING ((2 2, 3 3), (0 0, 1 1))>
+
         """
         return shapely.normalize(self)
 
@@ -588,32 +613,28 @@ class BaseGeometry(shapely.Geometry):
     # ---------------------------
 
     def difference(self, other, grid_size=None):
-        """
-        Returns the difference of the geometries.
+        """Return the difference of the geometries.
 
         Refer to `shapely.difference` for full documentation.
         """
         return shapely.difference(self, other, grid_size=grid_size)
 
     def intersection(self, other, grid_size=None):
-        """
-        Returns the intersection of the geometries.
+        """Return the intersection of the geometries.
 
         Refer to `shapely.intersection` for full documentation.
         """
         return shapely.intersection(self, other, grid_size=grid_size)
 
     def symmetric_difference(self, other, grid_size=None):
-        """
-        Returns the symmetric difference of the geometries.
+        """Return the symmetric difference of the geometries.
 
         Refer to `shapely.symmetric_difference` for full documentation.
         """
         return shapely.symmetric_difference(self, other, grid_size=grid_size)
 
     def union(self, other, grid_size=None):
-        """
-        Returns the union of the geometries.
+        """Return the union of the geometries.
 
         Refer to `shapely.union` for full documentation.
         """
@@ -624,84 +645,88 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def has_z(self):
-        """True if the geometry's coordinate sequence(s) have z values"""
+        """True if the geometry's coordinate sequence(s) have z values."""
         return bool(shapely.has_z(self))
 
     @property
     def has_m(self):
-        """True if the geometry's coordinate sequence(s) have m values"""
+        """True if the geometry's coordinate sequence(s) have m values."""
         return bool(shapely.has_m(self))
 
     @property
     def is_empty(self):
-        """True if the set of points in this geometry is empty, else False"""
+        """True if the set of points in this geometry is empty, else False."""
         return bool(shapely.is_empty(self))
 
     @property
     def is_ring(self):
-        """True if the geometry is a closed ring, else False"""
+        """True if the geometry is a closed ring, else False."""
         return bool(shapely.is_ring(self))
 
     @property
     def is_closed(self):
-        """True if the geometry is closed, else False
+        """True if the geometry is closed, else False.
 
-        Applicable only to 1-D geometries."""
+        Applicable only to 1-D geometries.
+        """
         if self.geom_type == "LinearRing":
             return True
         return bool(shapely.is_closed(self))
 
     @property
     def is_simple(self):
-        """True if the geometry is simple, meaning that any self-intersections
-        are only at boundary points, else False"""
+        """True if the geometry is simple.
+
+        Simple means that any self-intersections are only at boundary points.
+        """
         return bool(shapely.is_simple(self))
 
     @property
     def is_valid(self):
-        """True if the geometry is valid (definition depends on sub-class),
-        else False"""
+        """True if the geometry is valid.
+
+        The definition depends on sub-class.
+        """
         return bool(shapely.is_valid(self))
 
     # Binary predicates
     # -----------------
 
     def relate(self, other):
-        """Returns the DE-9IM intersection matrix for the two geometries
-        (string)"""
+        """Return the DE-9IM intersection matrix for the two geometries (string)."""
         return shapely.relate(self, other)
 
     def covers(self, other):
-        """Returns True if the geometry covers the other, else False"""
+        """Return True if the geometry covers the other, else False."""
         return _maybe_unpack(shapely.covers(self, other))
 
     def covered_by(self, other):
-        """Returns True if the geometry is covered by the other, else False"""
+        """Return True if the geometry is covered by the other, else False."""
         return _maybe_unpack(shapely.covered_by(self, other))
 
     def contains(self, other):
-        """Returns True if the geometry contains the other, else False"""
+        """Return True if the geometry contains the other, else False."""
         return _maybe_unpack(shapely.contains(self, other))
 
     def contains_properly(self, other):
-        """
-        Returns True if the geometry completely contains the other, with no
-        common boundary points, else False
+        """Return True if the geometry completely contains the other.
+
+        There should be no common boundary points.
 
         Refer to `shapely.contains_properly` for full documentation.
         """
         return _maybe_unpack(shapely.contains_properly(self, other))
 
     def crosses(self, other):
-        """Returns True if the geometries cross, else False"""
+        """Return True if the geometries cross, else False."""
         return _maybe_unpack(shapely.crosses(self, other))
 
     def disjoint(self, other):
-        """Returns True if geometries are disjoint, else False"""
+        """Return True if geometries are disjoint, else False."""
         return _maybe_unpack(shapely.disjoint(self, other))
 
     def equals(self, other):
-        """Returns True if geometries are equal, else False.
+        """Return True if geometries are equal, else False.
 
         This method considers point-set equality (or topological
         equality), and is equivalent to (self.within(other) &
@@ -724,32 +749,30 @@ class BaseGeometry(shapely.Geometry):
         return _maybe_unpack(shapely.equals(self, other))
 
     def intersects(self, other):
-        """Returns True if geometries intersect, else False"""
+        """Return True if geometries intersect, else False."""
         return _maybe_unpack(shapely.intersects(self, other))
 
     def overlaps(self, other):
-        """Returns True if geometries overlap, else False"""
+        """Return True if geometries overlap, else False."""
         return _maybe_unpack(shapely.overlaps(self, other))
 
     def touches(self, other):
-        """Returns True if geometries touch, else False"""
+        """Return True if geometries touch, else False."""
         return _maybe_unpack(shapely.touches(self, other))
 
     def within(self, other):
-        """Returns True if geometry is within the other, else False"""
+        """Return True if geometry is within the other, else False."""
         return _maybe_unpack(shapely.within(self, other))
 
     def dwithin(self, other, distance):
-        """
-        Returns True if geometry is within a given distance from the other, else False.
+        """Return True if geometry is within a given distance from the other.
 
         Refer to `shapely.dwithin` for full documentation.
         """
         return _maybe_unpack(shapely.dwithin(self, other, distance))
 
     def equals_exact(self, other, tolerance=0.0, normalize=False):
-        """Returns ``True`` if the geometries are structurally equivalent
-        within a given tolerance.
+        """Return True if the geometries are equivalent within the tolerance.
 
         Refer to :func:`~shapely.equals_exact` for full documentation.
 
@@ -783,8 +806,7 @@ class BaseGeometry(shapely.Geometry):
         return _maybe_unpack(shapely.equals_exact(self, other, tolerance, normalize))
 
     def almost_equals(self, other, decimal=6):
-        """True if geometries are equal at all coordinates to a
-        specified decimal place.
+        """Return True if all coordinates are equal to a specified decimal place.
 
         .. deprecated:: 1.8.0
             The 'almost_equals()' method is deprecated
@@ -823,16 +845,14 @@ class BaseGeometry(shapely.Geometry):
         return self.equals_exact(other, 0.5 * 10 ** (-decimal))
 
     def relate_pattern(self, other, pattern):
-        """Returns True if the DE-9IM string code for the relationship between
-        the geometries satisfies the pattern, else False"""
+        """Return True if the DE-9IM relationship code satisfies the pattern."""
         return _maybe_unpack(shapely.relate_pattern(self, other, pattern))
 
     # Linear referencing
     # ------------------
 
     def line_locate_point(self, other, normalized=False):
-        """Returns the distance along this geometry to a point nearest the
-        specified point
+        """Return the distance of this geometry to a point nearest the specified point.
 
         If the normalized arg is True, return the distance normalized to the
         length of the linear geometry.
@@ -844,8 +864,7 @@ class BaseGeometry(shapely.Geometry):
         )
 
     def project(self, other, normalized=False):
-        """Returns the distance along this geometry to a point nearest the
-        specified point
+        """Return the distance of geometry to a point nearest the specified point.
 
         If the normalized arg is True, return the distance normalized to the
         length of the linear geometry.
@@ -857,7 +876,7 @@ class BaseGeometry(shapely.Geometry):
         )
 
     def line_interpolate_point(self, distance, normalized=False):
-        """Return a point at the specified distance along a linear geometry
+        """Return a point at the specified distance along a linear geometry.
 
         Negative length values are taken as measured in the reverse
         direction from the end of the geometry. Out-of-range index
@@ -870,7 +889,7 @@ class BaseGeometry(shapely.Geometry):
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
     def interpolate(self, distance, normalized=False):
-        """Return a point at the specified distance along a linear geometry
+        """Return a point at the specified distance along a linear geometry.
 
         Negative length values are taken as measured in the reverse
         direction from the end of the geometry. Out-of-range index
@@ -883,7 +902,7 @@ class BaseGeometry(shapely.Geometry):
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
     def segmentize(self, max_segment_length):
-        """Adds vertices to line segments based on maximum segment length.
+        """Add vertices to line segments based on maximum segment length.
 
         Additional vertices will be added to every line segment in an input geometry
         so that segments are no longer than the provided maximum segment length. New
@@ -905,18 +924,19 @@ class BaseGeometry(shapely.Geometry):
         <LINESTRING (0 0, 0 5, 0 10)>
         >>> Polygon([(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]).segmentize(max_segment_length=5)
         <POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0))>
+
         """  # noqa: E501
         return shapely.segmentize(self, max_segment_length)
 
     def reverse(self):
-        """Returns a copy of this geometry with the order of coordinates reversed.
+        """Return a copy of this geometry with the order of coordinates reversed.
 
         If the geometry is a polygon with interior rings, the interior rings are also
         reversed.
 
         Points are unchanged.
 
-        See also
+        See Also
         --------
         is_ccw : Checks if a geometry is clockwise.
 
@@ -927,15 +947,23 @@ class BaseGeometry(shapely.Geometry):
         <LINESTRING (1 2, 0 0)>
         >>> Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]).reverse()
         <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
+
         """
         return shapely.reverse(self)
 
 
 class BaseMultipartGeometry(BaseGeometry):
+    """Base class for collections of multiple geometries."""
+
     __slots__ = []
 
     @property
     def coords(self):
+        """Not implemented.
+
+        Sub-geometries may have coordinate sequences, but multi-part geometries
+        do not.
+        """
         raise NotImplementedError(
             "Sub-geometries may have coordinate sequences, "
             "but multi-part geometries do not"
@@ -943,12 +971,15 @@ class BaseMultipartGeometry(BaseGeometry):
 
     @property
     def geoms(self):
+        """Access to the contained geometries."""
         return GeometrySequence(self)
 
     def __bool__(self):
+        """Return True if the geometry is not empty, else False."""
         return self.is_empty is False
 
     def __eq__(self, other):
+        """Return True if geometries are equal, else False."""
         if not isinstance(other, BaseGeometry):
             return NotImplemented
         return (
@@ -958,18 +989,20 @@ class BaseMultipartGeometry(BaseGeometry):
         )
 
     def __hash__(self):
+        """Return the hash value of the geometry."""
         return super().__hash__()
 
     def svg(self, scale_factor=1.0, color=None):
-        """Returns a group of SVG elements for the multipart geometry.
+        """Return a group of SVG elements for the multipart geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG stroke-width.  Default is 1.
         color : str, optional
             Hex string for stroke or fill color. Default is to use "#66cc99"
             if geometry is valid, and "#ff3333" if invalid.
+
         """
         if self.is_empty:
             return "<g />"
@@ -979,9 +1012,7 @@ class BaseMultipartGeometry(BaseGeometry):
 
 
 class GeometrySequence:
-    """
-    Iterative access to members of a homogeneous multipart geometry.
-    """
+    """Iterative access to members of a homogeneous multipart geometry."""
 
     # Attributes
     # ----------
@@ -990,19 +1021,23 @@ class GeometrySequence:
     _parent = None
 
     def __init__(self, parent):
+        """Initialize the sequence with a parent geometry."""
         self._parent = parent
 
     def _get_geom_item(self, i):
         return shapely.get_geometry(self._parent, i)
 
     def __iter__(self):
+        """Iterate over the geometries in the sequence."""
         for i in range(self.__len__()):
             yield self._get_geom_item(i)
 
     def __len__(self):
+        """Return the number of geometries in the sequence."""
         return shapely.get_num_geometries(self._parent)
 
     def __getitem__(self, key):
+        """Access a geometry in the sequence by index or slice."""
         m = self.__len__()
         if isinstance(key, (int, np.integer)):
             if key + m < 0 or key >= m:
@@ -1023,6 +1058,8 @@ class GeometrySequence:
 
 
 class EmptyGeometry(BaseGeometry):
+    """An empty geometry."""
+
     def __new__(self):
         """Create an empty geometry."""
         warn(

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -1,19 +1,17 @@
-"""Multi-part collections of geometries"""
+"""Multi-part collections of geometries."""
 
 import shapely
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
 
 
 class GeometryCollection(BaseMultipartGeometry):
-    """
-    A collection of one or more geometries that may contain more than one type
-    of geometry.
+    """Collection of one or more geometries that can be of different types.
 
     Parameters
     ----------
     geoms : list
-        A list of shapely geometry instances, which may be of varying
-        geometry types.
+        A list of shapely geometry instances, which may be of varying geometry
+        types.
 
     Attributes
     ----------
@@ -28,11 +26,13 @@ class GeometryCollection(BaseMultipartGeometry):
     >>> p = Point(51, -1)
     >>> l = LineString([(52, -1), (49, 2)])
     >>> gc = GeometryCollection([p, l])
+
     """
 
     __slots__ = []
 
     def __new__(self, geoms=None):
+        """Create a new GeometryCollection."""
         if not geoms:
             # TODO better empty constructor
             return shapely.from_wkt("GEOMETRYCOLLECTION EMPTY")
@@ -48,6 +48,7 @@ class GeometryCollection(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the geometry collection."""
         geometries = []
         for geom in self.geoms:
             geometries.append(geom.__geo_interface__)

--- a/shapely/geometry/conftest.py
+++ b/shapely/geometry/conftest.py
@@ -7,4 +7,5 @@ from shapely.geometry.linestring import LineString
 
 @pytest.fixture(autouse=True)
 def add_linestring(doctest_namespace):
+    """Add LineString to the doctest namespace."""
     doctest_namespace["LineString"] = LineString

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,6 +1,4 @@
-"""
-Geometry factories based on the geo interface
-"""
+"""Geometry factories based on the geo interface."""
 
 import numpy as np
 
@@ -15,8 +13,7 @@ from shapely.geometry.polygon import LinearRing, Polygon
 
 
 def _is_coordinates_empty(coordinates):
-    """Helper to identify if coordinates or subset of coordinates are empty"""
-
+    """Identify if coordinates or subset of coordinates are empty."""
     if coordinates is None:
         return True
 
@@ -29,7 +26,7 @@ def _is_coordinates_empty(coordinates):
 
 
 def _empty_shape_for_no_coordinates(geom_type):
-    """Return empty counterpart for geom_type"""
+    """Return empty counterpart for geom_type."""
     if geom_type == "point":
         return Point()
     elif geom_type == "multipoint":
@@ -47,7 +44,7 @@ def _empty_shape_for_no_coordinates(geom_type):
 
 
 def box(minx, miny, maxx, maxy, ccw=True):
-    """Returns a rectangular polygon with configurable normal vector"""
+    """Return a rectangular polygon with configurable normal vector."""
     coords = [(maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny)]
     if not ccw:
         coords = coords[::-1]
@@ -55,10 +52,10 @@ def box(minx, miny, maxx, maxy, ccw=True):
 
 
 def shape(context):
-    """
-    Returns a new, independent geometry with coordinates *copied* from the
-    context. Changes to the original context will not be reflected in the
-    geometry object.
+    """Return a new, independent geometry with coordinates copied from the context.
+
+    Changes to the original context will not be reflected in the geometry
+    object.
 
     Parameters
     ----------
@@ -84,6 +81,7 @@ def shape(context):
     >>> geom2 = shape(geom)
     >>> geom == geom2
     True
+
     """
     if hasattr(context, "__geo_interface__"):
         ob = context.__geo_interface__
@@ -120,13 +118,13 @@ def shape(context):
 
 
 def mapping(ob):
-    """
-    Returns a GeoJSON-like mapping from a Geometry or any
-    object which implements __geo_interface__
+    """Return a GeoJSON-like mapping.
+
+    Input should be a Geometry or an object which implements __geo_interface__.
 
     Parameters
     ----------
-    ob :
+    ob : geometry or object
         An object which implements __geo_interface__.
 
     Returns
@@ -138,5 +136,6 @@ def mapping(ob):
     >>> pt = Point(0, 0)
     >>> mapping(pt)
     {'type': 'Point', 'coordinates': (0.0, 0.0)}
+
     """
     return ob.__geo_interface__

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -1,4 +1,4 @@
-"""Line strings and related utilities"""
+"""Line strings and related utilities."""
 
 import numpy as np
 
@@ -10,8 +10,7 @@ __all__ = ["LineString"]
 
 
 class LineString(BaseGeometry):
-    """
-    A geometry type composed of one or more line segments.
+    """A geometry type composed of one or more line segments.
 
     A LineString is a one-dimensional feature and has a non-zero length but
     zero area. It may approximate a curve and need not be straight. Unlike a
@@ -31,11 +30,13 @@ class LineString(BaseGeometry):
     >>> a = LineString([[0, 0], [1, 0], [1, 1]])
     >>> a.length
     2.0
+
     """
 
     __slots__ = []
 
     def __new__(self, coordinates=None):
+        """Create a new LineString geometry."""
         if coordinates is None:
             # empty geometry
             # TODO better constructor
@@ -77,13 +78,14 @@ class LineString(BaseGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the LineString geometry."""
         return {"type": "LineString", "coordinates": tuple(self.coords)}
 
     def svg(self, scale_factor=1.0, stroke_color=None, opacity=None):
-        """Returns SVG polyline element for the LineString geometry.
+        """Return SVG polyline element for the LineString geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG stroke-width.  Default is 1.
         stroke_color : str, optional
@@ -91,6 +93,7 @@ class LineString(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.8
+
         """
         if self.is_empty:
             return "<g />"
@@ -107,15 +110,16 @@ class LineString(BaseGeometry):
 
     @property
     def xy(self):
-        """Separate arrays of X and Y coordinate values
+        """Separate arrays of X and Y coordinate values.
 
         Example:
-
+        -------
           >>> x, y = LineString([(0, 0), (1, 1)]).xy
           >>> list(x)
           [0.0, 1.0]
           >>> list(y)
           [0.0, 1.0]
+
         """
         return self.coords.xy
 
@@ -126,13 +130,12 @@ class LineString(BaseGeometry):
         join_style=JOIN_STYLE.round,
         mitre_limit=5.0,
     ):
-        """Returns a LineString or MultiLineString geometry at a distance from
-        the object on its right or its left side.
+        """Return a (Multi)LineString at a distance from the object.
 
-        The side is determined by the sign of the `distance` parameter
-        (negative for right side offset, positive for left side offset). The
-        resolution of the buffer around each vertex of the object increases
-        by increasing the `quad_segs` keyword parameter.
+        The side, left or right, is determined by the sign of the `distance`
+        parameter (negative for right side offset, positive for left side
+        offset). The resolution of the buffer around each vertex of the object
+        increases by increasing the `quad_segs` keyword parameter.
 
         The join style is for outside corners between line segments. Accepted
         values are JOIN_STYLE.round (1), JOIN_STYLE.mitre (2), and
@@ -167,8 +170,7 @@ class LineString(BaseGeometry):
         join_style=JOIN_STYLE.round,
         mitre_limit=5.0,
     ):
-        """
-        Alternative method to :meth:`offset_curve` method.
+        """Alternative method to :meth:`offset_curve` method.
 
         Older alternative method to the :meth:`offset_curve` method, but uses
         ``resolution`` instead of ``quad_segs`` and a ``side`` keyword

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -1,4 +1,4 @@
-"""Collections of linestrings and related utilities"""
+"""Collections of linestrings and related utilities."""
 
 import shapely
 from shapely.errors import EmptyPartError
@@ -9,8 +9,7 @@ __all__ = ["MultiLineString"]
 
 
 class MultiLineString(BaseMultipartGeometry):
-    """
-    A collection of one or more LineStrings.
+    """A collection of one or more LineStrings.
 
     A MultiLineString has non-zero length and zero area.
 
@@ -30,11 +29,13 @@ class MultiLineString(BaseMultipartGeometry):
     Construct a MultiLineString containing two LineStrings.
 
     >>> lines = MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]])
+
     """
 
     __slots__ = []
 
     def __new__(self, lines=None):
+        """Create a new MultiLineString geometry."""
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling
             # TODO better empty constructor
@@ -60,16 +61,17 @@ class MultiLineString(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping interface for this MultiLineString."""
         return {
             "type": "MultiLineString",
             "coordinates": tuple(tuple(c for c in g.coords) for g in self.geoms),
         }
 
     def svg(self, scale_factor=1.0, stroke_color=None, opacity=None):
-        """Returns a group of SVG polyline elements for the LineString geometry.
+        """Return a group of SVG polyline elements for the LineString geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG stroke-width.  Default is 1.
         stroke_color : str, optional
@@ -77,6 +79,7 @@ class MultiLineString(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.8
+
         """
         if self.is_empty:
             return "<g />"

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -1,4 +1,4 @@
-"""Collections of points and related utilities"""
+"""Collections of points and related utilities."""
 
 import shapely
 from shapely.errors import EmptyPartError
@@ -9,8 +9,7 @@ __all__ = ["MultiPoint"]
 
 
 class MultiPoint(BaseMultipartGeometry):
-    """
-    A collection of one or more Points.
+    """A collection of one or more Points.
 
     A MultiPoint has zero area and zero length.
 
@@ -35,11 +34,13 @@ class MultiPoint(BaseMultipartGeometry):
     2
     >>> type(ob.geoms[0]) == Point
     True
+
     """
 
     __slots__ = []
 
     def __new__(self, points=None):
+        """Create a new MultiPoint geometry."""
         if points is None:
             # allow creation of empty multipoints, to support unpickling
             # TODO better empty constructor
@@ -62,16 +63,17 @@ class MultiPoint(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping interface for this MultiPoint."""
         return {
             "type": "MultiPoint",
             "coordinates": tuple(g.coords[0] for g in self.geoms),
         }
 
     def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
-        """Returns a group of SVG circle elements for the MultiPoint geometry.
+        """Return a group of SVG circle elements for the MultiPoint geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG circle diameters.  Default is 1.
         fill_color : str, optional
@@ -79,6 +81,7 @@ class MultiPoint(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+
         """
         if self.is_empty:
             return "<g />"

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -1,4 +1,4 @@
-"""Collections of polygons and related utilities"""
+"""Collections of polygons and related utilities."""
 
 import shapely
 from shapely.geometry import polygon
@@ -8,8 +8,7 @@ __all__ = ["MultiPolygon"]
 
 
 class MultiPolygon(BaseMultipartGeometry):
-    """
-    A collection of one or more Polygons.
+    """A collection of one or more Polygons.
 
     If component polygons overlap the collection is invalid and some
     operations on it may fail.
@@ -41,11 +40,13 @@ class MultiPolygon(BaseMultipartGeometry):
     1
     >>> type(ob.geoms[0]) == Polygon
     True
+
     """
 
     __slots__ = []
 
     def __new__(self, polygons=None):
+        """Create a new MultiPolygon geometry."""
         if polygons is None:
             # allow creation of empty multipolygons, to support unpickling
             # TODO better empty constructor
@@ -86,6 +87,7 @@ class MultiPolygon(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the MultiPolygon geometry."""
         allcoords = []
         for geom in self.geoms:
             coords = []
@@ -96,10 +98,10 @@ class MultiPolygon(BaseMultipartGeometry):
         return {"type": "MultiPolygon", "coordinates": allcoords}
 
     def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
-        """Returns group of SVG path elements for the MultiPolygon geometry.
+        """Return group of SVG path elements for the MultiPolygon geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG stroke-width.  Default is 1.
         fill_color : str, optional
@@ -107,6 +109,7 @@ class MultiPolygon(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+
         """
         if self.is_empty:
             return "<g />"

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -1,4 +1,4 @@
-"""Points and related utilities"""
+"""Points and related utilities."""
 
 import numpy as np
 
@@ -10,9 +10,9 @@ __all__ = ["Point"]
 
 
 class Point(BaseGeometry):
-    """
-    A geometry type that represents a single coordinate with
-    x, y and possibly z and/or m values.
+    """A geometry type that represents a single coordinate.
+
+    Each coordinate has x, y and possibly z and/or m values.
 
     A point is a zero-dimensional feature and has zero length and zero area.
 
@@ -45,11 +45,13 @@ class Point(BaseGeometry):
     -1.0
     >>> p.x
     1.0
+
     """
 
     __slots__ = []
 
     def __new__(self, *args):
+        """Create a new Point geometry."""
         if len(args) == 0:
             # empty geometry
             # TODO better constructor
@@ -112,13 +114,14 @@ class Point(BaseGeometry):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the Point geometry."""
         return {"type": "Point", "coordinates": self.coords[0]}
 
     def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
-        """Returns SVG circle element for the Point geometry.
+        """Return SVG circle element for the Point geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG circle diameter.  Default is 1.
         fill_color : str, optional
@@ -126,6 +129,7 @@ class Point(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+
         """
         if self.is_empty:
             return "<g />"
@@ -141,14 +145,16 @@ class Point(BaseGeometry):
 
     @property
     def xy(self):
-        """Separate arrays of X and Y coordinate values
+        """Separate arrays of X and Y coordinate values.
 
         Example:
+        -------
           >>> x, y = Point(0, 0).xy
           >>> list(x)
           [0.0]
           >>> list(y)
           [0.0]
+
         """
         return self.coords.xy
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -1,4 +1,4 @@
-"""Polygons and their linear ring components"""
+"""Polygons and their linear ring components."""
 
 import numpy as np
 
@@ -22,9 +22,7 @@ def _unpickle_linearring(wkb):
 
 
 class LinearRing(LineString):
-    """
-    A geometry type composed of one or more line segments
-    that forms a closed loop.
+    """Geometry type composed of one or more line segments that forms a closed loop.
 
     A LinearRing is a closed, one-dimensional feature.
     A LinearRing that crosses itself or touches itself at a single point is
@@ -59,6 +57,7 @@ class LinearRing(LineString):
     __slots__ = []
 
     def __new__(self, coordinates=None):
+        """Create a new LinearRing geometry."""
         if coordinates is None:
             # empty geometry
             # TODO better way?
@@ -107,22 +106,28 @@ class LinearRing(LineString):
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the LinearRing geometry."""
         return {"type": "LinearRing", "coordinates": tuple(self.coords)}
 
     def __reduce__(self):
-        """WKB doesn't differentiate between LineString and LinearRing so we
-        need to move the coordinate sequence into the correct geometry type"""
+        """Pickle support.
+
+        WKB doesn't differentiate between LineString and LinearRing so we
+        need to move the coordinate sequence into the correct geometry type
+        """
         return (_unpickle_linearring, (shapely.to_wkb(self, include_srid=True),))
 
     @property
     def is_ccw(self):
-        """True is the ring is oriented counter clock-wise"""
+        """True is the ring is oriented counter clock-wise."""
         return bool(is_ccw_impl()(self))
 
     @property
     def is_simple(self):
-        """True if the geometry is simple, meaning that any self-intersections
-        are only at boundary points, else False"""
+        """True if the geometry is simple.
+
+        Simple means that any self-intersections are only at boundary points.
+        """
         return bool(shapely.is_simple(self))
 
 
@@ -179,8 +184,7 @@ class InteriorRingSequence:
 
 
 class Polygon(BaseGeometry):
-    """
-    A geometry type representing an area that is enclosed by a linear ring.
+    """A geometry type representing an area that is enclosed by a linear ring.
 
     A polygon is a two-dimensional feature and has a non-zero area. It may
     have one or more negative-space "holes" which are also bounded by linear
@@ -212,11 +216,13 @@ class Polygon(BaseGeometry):
     >>> polygon = Polygon(coords)
     >>> polygon.area
     1.0
+
     """
 
     __slots__ = []
 
     def __new__(self, shell=None, holes=None):
+        """Create a new Polygon geometry."""
         if shell is None:
             # empty geometry
             # TODO better way?
@@ -241,21 +247,25 @@ class Polygon(BaseGeometry):
 
     @property
     def exterior(self):
+        """Return the exterior ring of the polygon."""
         return shapely.get_exterior_ring(self)
 
     @property
     def interiors(self):
+        """Return the sequence of interior rings of the polygon."""
         if self.is_empty:
             return []
         return InteriorRingSequence(self)
 
     @property
     def coords(self):
+        """Not implemented for polygons."""
         raise NotImplementedError(
             "Component rings have coordinate sequences, but the polygon does not"
         )
 
     def __eq__(self, other):
+        """Test for equality with another geometry."""
         if not isinstance(other, BaseGeometry):
             return NotImplemented
         if not isinstance(other, Polygon):
@@ -282,10 +292,12 @@ class Polygon(BaseGeometry):
         )
 
     def __hash__(self):
+        """Hash the polygon."""
         return super().__hash__()
 
     @property
     def __geo_interface__(self):
+        """Return a GeoJSON-like mapping of the Polygon geometry."""
         if self.exterior == LinearRing():
             coords = []
         else:
@@ -295,10 +307,10 @@ class Polygon(BaseGeometry):
         return {"type": "Polygon", "coordinates": tuple(coords)}
 
     def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
-        """Returns SVG path element for the Polygon geometry.
+        """Return SVG path element for the Polygon geometry.
 
         Parameters
-        ==========
+        ----------
         scale_factor : float
             Multiplication factor for the SVG stroke-width.  Default is 1.
         fill_color : str, optional
@@ -306,6 +318,7 @@ class Polygon(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+
         """
         if self.is_empty:
             return "<g />"
@@ -338,6 +351,7 @@ shapely.lib.registry[3] = Polygon
 
 
 def orient(polygon, sign=1.0):
+    """Return an oriented polygon."""
     s = float(sign)
     rings = []
     ring = polygon.exterior

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -1,6 +1,4 @@
-"""
-Proxies for libgeos, GEOS-specific exceptions, and utilities
-"""
+"""Proxies for libgeos, GEOS-specific exceptions, and utilities."""
 
 import shapely
 

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -1,3 +1,5 @@
+"""Input/output functions for Shapely geometries."""
+
 import numpy as np
 
 from shapely import geos_version, lib
@@ -37,8 +39,7 @@ def to_wkt(
     old_3d=False,
     **kwargs,
 ):
-    """
-    Converts to the Well-Known Text (WKT) representation of a Geometry.
+    """Convert to the Well-Known Text (WKT) representation of a Geometry.
 
     The Well-known Text format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
@@ -53,6 +54,7 @@ def to_wkt(
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to convert to WKT.
     rounding_precision : int, default 6
         The rounding precision when writing the WKT string. Set to a value of
         -1 to indicate the full precision.
@@ -125,8 +127,7 @@ def to_wkb(
     flavor="extended",
     **kwargs,
 ):
-    r"""
-    Converts to the Well-Known Binary (WKB) representation of a Geometry.
+    r"""Convert to the Well-Known Binary (WKB) representation of a Geometry.
 
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
@@ -142,6 +143,7 @@ def to_wkb(
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to convert to WKB.
     hex : bool, default False
         If true, export the WKB as a hexadecimal string. The default is to
         return a binary bytes object.
@@ -176,6 +178,7 @@ def to_wkb(
     b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?'
     >>> to_wkb(point, hex=True, byte_order=1)
     '0101000000000000000000F03F000000000000F03F'
+
     """
     if not np.isscalar(hex):
         raise TypeError("hex only accepts scalar values")
@@ -210,7 +213,7 @@ def to_wkb(
 
 @requires_geos("3.10.0")
 def to_geojson(geometry, indent=None, **kwargs):
-    """Converts to the GeoJSON representation of a Geometry.
+    """Convert to the GeoJSON representation of a Geometry.
 
     The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
     NaN (not-a-number) coordinates will be written as 'null'.
@@ -223,6 +226,7 @@ def to_geojson(geometry, indent=None, **kwargs):
     Parameters
     ----------
     geometry : str, bytes or array_like
+        Geometry or geometries to convert to GeoJSON.
     indent : int, optional
         If indent is a non-negative integer, then GeoJSON will be formatted.
         An indent level of 0 will only insert newlines. None (the default)
@@ -244,6 +248,7 @@ def to_geojson(geometry, indent=None, **kwargs):
           1.0
       ]
     }
+
     """
     # GEOS Tickets:
     # - handle linearrings: https://trac.osgeo.org/geos/ticket/1140
@@ -259,8 +264,7 @@ def to_geojson(geometry, indent=None, **kwargs):
 
 
 def from_wkt(geometry, on_invalid="raise", **kwargs):
-    """
-    Creates geometries from the Well-Known Text (WKT) representation.
+    """Create geometries from the Well-Known Text (WKT) representation.
 
     The Well-known Text format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
@@ -281,6 +285,7 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
     --------
     >>> from_wkt('POINT (0 0)')
     <POINT (0 0)>
+
     """
     if not np.isscalar(on_invalid):
         raise TypeError("on_invalid only accepts scalar values")
@@ -291,12 +296,10 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
 
 
 def from_wkb(geometry, on_invalid="raise", **kwargs):
-    r"""
-    Creates geometries from the Well-Known Binary (WKB) representation.
+    r"""Create geometries from the Well-Known Binary (WKB) representation.
 
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
-
 
     Parameters
     ----------
@@ -314,8 +317,8 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     --------
     >>> from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
     <POINT (1 1)>
-    """  # noqa: E501
 
+    """  # noqa: E501
     if not np.isscalar(on_invalid):
         raise TypeError("on_invalid only accepts scalar values")
 
@@ -330,7 +333,7 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
 
 @requires_geos("3.10.1")
 def from_geojson(geometry, on_invalid="raise", **kwargs):
-    """Creates geometries from GeoJSON representations (strings).
+    """Create geometries from GeoJSON representations (strings).
 
     If a GeoJSON is a FeatureCollection, it is read as a single geometry
     (with type GEOMETRYCOLLECTION). This may be unpacked using
@@ -356,7 +359,7 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_parts
 
@@ -364,6 +367,7 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
     --------
     >>> from_geojson('{"type": "Point","coordinates": [1, 2]}')
     <POINT (1 2)>
+
     """
     # GEOS Tickets:
     # - support 3D: https://trac.osgeo.org/geos/ticket/1141

--- a/shapely/linear.py
+++ b/shapely/linear.py
@@ -1,3 +1,5 @@
+"""Linear geometry functions."""
+
 from shapely import lib
 from shapely.decorators import multithreading_enabled
 from shapely.errors import UnsupportedGEOSVersionError
@@ -13,7 +15,7 @@ __all__ = [
 
 @multithreading_enabled
 def line_interpolate_point(line, distance, normalized=False, **kwargs):
-    """Returns a point interpolated at given distance on a line.
+    """Return a point interpolated at given distance on a line.
 
     Parameters
     ----------
@@ -44,6 +46,7 @@ def line_interpolate_point(line, distance, normalized=False, **kwargs):
     [<POINT (0 4)>, <POINT (0 8)>]
     >>> line_interpolate_point(LineString(), 1)
     <POINT EMPTY>
+
     """
     if normalized:
         return lib.line_interpolate_point_normalized(line, distance)
@@ -53,7 +56,7 @@ def line_interpolate_point(line, distance, normalized=False, **kwargs):
 
 @multithreading_enabled
 def line_locate_point(line, other, normalized=False, **kwargs):
-    """Returns the distance to the line origin of given point.
+    """Return the distance to the line origin of given point.
 
     If given point does not intersect with the line, the point will first be
     projected onto the line after which the distance is taken.
@@ -61,10 +64,12 @@ def line_locate_point(line, other, normalized=False, **kwargs):
     Parameters
     ----------
     line : Geometry or array_like
-    point : Geometry or array_like
+        Line or lines to calculate the distance to.
+    other : Geometry or array_like
+        Point or points to calculate the distance from.
     normalized : bool, default False
-        If True, the distance is a fraction of the total
-        line length instead of the absolute distance.
+        If True, the distance is a fraction of the total line length instead of
+        the absolute distance.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -81,6 +86,7 @@ def line_locate_point(line, other, normalized=False, **kwargs):
     8.0
     >>> line_locate_point(LineString(), point)
     nan
+
     """
     if normalized:
         return lib.line_locate_point_normalized(line, other)
@@ -90,8 +96,7 @@ def line_locate_point(line, other, normalized=False, **kwargs):
 
 @multithreading_enabled
 def line_merge(line, directed=False, **kwargs):
-    """Returns (Multi)LineStrings formed by combining the lines in a
-    MultiLineString.
+    """Return (Multi)LineStrings formed by combining the lines in a MultiLineString.
 
     Lines are joined together at their endpoints in case two lines are
     intersecting. Lines are not joined when 3 or more lines are intersecting at
@@ -107,6 +112,7 @@ def line_merge(line, directed=False, **kwargs):
     Parameters
     ----------
     line : Geometry or array_like
+        MultiLineString(s) to merge.
     directed : bool, default False
         Only combine lines if possible without changing point order.
         Requires GEOS >= 3.11.0
@@ -126,6 +132,7 @@ def line_merge(line, directed=False, **kwargs):
     <LINESTRING (1 0, 0 0, 3 0)>
     >>> line_merge(MultiLineString([[(0, 0), (1, 0)], [(0, 0), (3, 0)]]), directed=True)
     <MULTILINESTRING ((0 0, 1 0), (0 0, 3 0))>
+
     """
     if directed:
         if lib.geos_version < (3, 11, 0):
@@ -140,7 +147,7 @@ def line_merge(line, directed=False, **kwargs):
 
 @multithreading_enabled
 def shared_paths(a, b, **kwargs):
-    """Returns the shared paths between geom1 and geom2.
+    """Return the shared paths between a and b.
 
     Both geometries should be linestrings or arrays of linestrings.
     A geometrycollection or array of geometrycollections is returned
@@ -152,7 +159,9 @@ def shared_paths(a, b, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Linestring or linestrings to compare.
     b : Geometry or array_like
+        Linestring or linestrings to compare.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -166,14 +175,14 @@ def shared_paths(a, b, **kwargs):
     >>> line3 = LineString([(1, 1), (0, 1)])
     >>> shared_paths(line1, line3).wkt
     'GEOMETRYCOLLECTION (MULTILINESTRING ((1 1, 0 1)), MULTILINESTRING EMPTY)'
+
     """
     return lib.shared_paths(a, b, **kwargs)
 
 
 @multithreading_enabled
 def shortest_line(a, b, **kwargs):
-    """
-    Returns the shortest line between two geometries.
+    """Return the shortest line between two geometries.
 
     The resulting line consists of two points, representing the nearest
     points between the geometry pair. The line always starts in the first
@@ -184,11 +193,13 @@ def shortest_line(a, b, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to compare.
     b : Geometry or array_like
+        Geometry or geometries to compare
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     prepare : improve performance by preparing ``a`` (the first argument)
               (for GEOS>=3.9)
@@ -200,5 +211,6 @@ def shortest_line(a, b, **kwargs):
     >>> line2 = LineString([(0, 3), (3, 0), (5, 3)])
     >>> shortest_line(line1, line2)
     <LINESTRING (1 1, 1.5 1.5)>
+
     """
     return lib.shortest_line(a, b, **kwargs)

--- a/shapely/measurement.py
+++ b/shapely/measurement.py
@@ -1,3 +1,5 @@
+"""Methods for measuring (between) geometries."""
+
 import warnings
 
 import numpy as np
@@ -20,11 +22,12 @@ __all__ = [
 
 @multithreading_enabled
 def area(geometry, **kwargs):
-    """Computes the area of a (multi)polygon.
+    """Compute the area of a (multi)polygon.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the area.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -40,17 +43,21 @@ def area(geometry, **kwargs):
     0.0
     >>> area(None)
     nan
+
     """  # noqa: E501
     return lib.area(geometry, **kwargs)
 
 
 @multithreading_enabled
 def distance(a, b, **kwargs):
-    """Computes the Cartesian distance between two geometries.
+    """Compute the Cartesian distance between two geometries.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to compute the distance between.
+    b : Geometry or array_like
+        Geometry or geometries to compute the distance between.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -68,19 +75,21 @@ def distance(a, b, **kwargs):
     nan
     >>> distance(None, point)
     nan
+
     """
     return lib.distance(a, b, **kwargs)
 
 
 @multithreading_enabled
 def bounds(geometry, **kwargs):
-    """Computes the bounds (extent) of a geometry.
+    """Compute the bounds (extent) of a geometry.
 
     For each geometry these 4 numbers are returned: min x, min y, max x, max y.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the bounds.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -95,16 +104,18 @@ def bounds(geometry, **kwargs):
     [nan, nan, nan, nan]
     >>> bounds(None).tolist()
     [nan, nan, nan, nan]
+
     """
     return lib.bounds(geometry, **kwargs)
 
 
 def total_bounds(geometry, **kwargs):
-    """Computes the total bounds (extent) of the geometry.
+    """Compute the total bounds (extent) of the geometry.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the total bounds.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -130,6 +141,7 @@ def total_bounds(geometry, **kwargs):
     [2.0, 3.0, 2.0, 3.0]
     >>> total_bounds(None).tolist()
     [nan, nan, nan, nan]
+
     """
     b = bounds(geometry, **kwargs)
     if b.ndim == 1:
@@ -150,11 +162,12 @@ def total_bounds(geometry, **kwargs):
 
 @multithreading_enabled
 def length(geometry, **kwargs):
-    """Computes the length of a (multi)linestring or polygon perimeter.
+    """Compute the length of a (multi)linestring or polygon perimeter.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the length.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -174,6 +187,7 @@ def length(geometry, **kwargs):
     0.0
     >>> length(None)
     nan
+
     """
     return lib.length(geometry, **kwargs)
 
@@ -190,7 +204,10 @@ def hausdorff_distance(a, b, densify=None, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to compute the distance between.
+    b : Geometry or array_like
+        Geometry or geometries to compute the distance between.
     densify : float or array_like, optional
         The value of densify is required to be between 0 and 1.
     **kwargs
@@ -209,6 +226,7 @@ def hausdorff_distance(a, b, densify=None, **kwargs):
     nan
     >>> hausdorff_distance(line1, None)
     nan
+
     """
     if densify is None:
         return lib.hausdorff_distance(a, b, **kwargs)
@@ -232,7 +250,10 @@ def frechet_distance(a, b, densify=None, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to compute the distance between.
+    b : Geometry or array_like
+        Geometry or geometries to compute the distance between.
     densify : float or array_like, optional
         The value of densify is required to be between 0 and 1.
     **kwargs
@@ -251,6 +272,7 @@ def frechet_distance(a, b, densify=None, **kwargs):
     nan
     >>> frechet_distance(line1, None)
     nan
+
     """
     if densify is None:
         return lib.frechet_distance(a, b, **kwargs)
@@ -259,7 +281,7 @@ def frechet_distance(a, b, densify=None, **kwargs):
 
 @multithreading_enabled
 def minimum_clearance(geometry, **kwargs):
-    """Computes the Minimum Clearance distance.
+    """Compute the Minimum Clearance distance.
 
     A geometry's "minimum clearance" is the smallest distance by which
     a vertex of the geometry could be moved to produce an invalid geometry.
@@ -270,6 +292,7 @@ def minimum_clearance(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the minimum clearance.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -283,18 +306,19 @@ def minimum_clearance(geometry, **kwargs):
     inf
     >>> minimum_clearance(None)
     nan
+
     """
     return lib.minimum_clearance(geometry, **kwargs)
 
 
 @multithreading_enabled
 def minimum_bounding_radius(geometry, **kwargs):
-    """Computes the radius of the minimum bounding circle that encloses an input
-    geometry.
+    """Compute the radius of the minimum bounding circle of an input geometry.
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries for which to compute the minimum bounding radius.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -313,8 +337,9 @@ def minimum_bounding_radius(geometry, **kwargs):
     >>> minimum_bounding_radius(GeometryCollection())
     0.0
 
-    See also
+    See Also
     --------
     minimum_bounding_circle
+
     """
     return lib.minimum_bounding_radius(geometry, **kwargs)

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -1,4 +1,4 @@
-"""Support for various GEOS geometry operations"""
+"""Support for various GEOS geometry operations."""
 
 from warnings import warn
 
@@ -50,7 +50,7 @@ class CollectionOperator:
                 return LineString(ob)
 
     def polygonize(self, lines):
-        """Creates polygons from a source of lines
+        """Create polygons from a source of lines.
 
         The source may be a MultiLineString, a sequence of LineString objects,
         or a sequence of objects than can be adapted to LineStrings.
@@ -66,8 +66,9 @@ class CollectionOperator:
         return collection.geoms
 
     def polygonize_full(self, lines):
-        """Creates polygons from a source of lines, returning the polygons
-        and leftover geometries.
+        """Create polygons from a source of lines.
+
+        The polygons and leftover geometries are returned as well.
 
         The source may be a MultiLineString, a sequence of LineString objects,
         or a sequence of objects than can be adapted to LineStrings.
@@ -90,7 +91,7 @@ class CollectionOperator:
         return shapely.polygonize_full(obs)
 
     def linemerge(self, lines, directed=False):
-        """Merges all connected lines from a source
+        """Merge all connected lines from a source.
 
         The source may be a MultiLineString, a sequence of LineString objects,
         or a sequence of objects than can be adapted to LineStrings.  Returns a
@@ -112,7 +113,7 @@ class CollectionOperator:
         return shapely.line_merge(source, directed=directed)
 
     def cascaded_union(self, geoms):
-        """Returns the union of a sequence of geometries
+        """Return the union of a sequence of geometries.
 
         .. deprecated:: 1.8
             This function was superseded by :meth:`unary_union`.
@@ -126,7 +127,7 @@ class CollectionOperator:
         return shapely.union_all(geoms, axis=None)
 
     def unary_union(self, geoms):
-        """Returns the union of a sequence of geometries
+        """Return the union of a sequence of geometries.
 
         Usually used to convert a collection into the smallest set of polygons
         that cover the same area.
@@ -143,7 +144,7 @@ unary_union = operator.unary_union
 
 
 def triangulate(geom, tolerance=0.0, edges=False):
-    """Creates the Delaunay triangulation and returns a list of geometries
+    """Create the Delaunay triangulation and return a list of geometries.
 
     The source may be any geometry type. All vertices of the geometry will be
     used as the points of the triangulation.
@@ -162,8 +163,8 @@ def triangulate(geom, tolerance=0.0, edges=False):
 
 
 def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
-    """
-    Constructs a Voronoi Diagram [1] from the given geometry.
+    """Construct a Voronoi Diagram [1] from the given geometry.
+
     Returns a list of geometries.
 
     Parameters
@@ -202,6 +203,7 @@ def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
     ----------
     [1] https://en.wikipedia.org/wiki/Voronoi_diagram
     [2] https://geos.osgeo.org/doxygen/geos__c_8h_source.html  (line 730)
+
     """
     try:
         result = shapely.voronoi_polygons(
@@ -220,12 +222,14 @@ def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
 
 
 def validate(geom):
+    """Return True if the geometry is valid."""
     return shapely.is_valid_reason(geom)
 
 
 def transform(func, geom):
-    """Applies `func` to all coordinates of `geom` and returns a new
-    geometry of the same type from the transformed coordinates.
+    """Apply `func` to all coordinates of `geom`.
+
+    Returns a new geometry of the same type from the transformed coordinates.
 
     `func` maps x, y, and optionally z to output xp, yp, zp. The input
     parameters may iterable types like lists or arrays or single values.
@@ -298,7 +302,7 @@ def transform(func, geom):
 
 
 def nearest_points(g1, g2):
-    """Returns the calculated nearest points in the input geometries
+    """Return the calculated nearest points in the input geometries.
 
     The points are returned in the same order as the input geometries.
     """
@@ -315,8 +319,7 @@ def nearest_points(g1, g2):
 
 
 def snap(g1, g2, tolerance):
-    """
-    Snaps an input geometry (g1) to reference (g2) geometry's vertices.
+    """Snaps an input geometry (g1) to reference (g2) geometry's vertices.
 
     Parameters
     ----------
@@ -328,13 +331,13 @@ def snap(g1, g2, tolerance):
         The snapping tolerance
 
     Refer to :func:`shapely.snap` for full documentation.
-    """
 
+    """
     return shapely.snap(g1, g2, tolerance)
 
 
 def shared_paths(g1, g2):
-    """Find paths shared between the two given lineal geometries
+    """Find paths shared between the two given lineal geometries.
 
     Returns a GeometryCollection with two elements:
      - First element is a MultiLineString containing shared paths with the
@@ -348,6 +351,7 @@ def shared_paths(g1, g2):
         The first geometry
     g2 : geometry
         The second geometry
+
     """
     if not isinstance(g1, LineString):
         raise GeometryTypeError("First geometry must be a LineString")
@@ -359,7 +363,7 @@ def shared_paths(g1, g2):
 class SplitOp:
     @staticmethod
     def _split_polygon_with_line(poly, splitter):
-        """Split a Polygon with a LineString"""
+        """Split a Polygon with a LineString."""
         if not isinstance(poly, Polygon):
             raise GeometryTypeError("First argument must be a Polygon")
         if not isinstance(splitter, LineString):
@@ -381,8 +385,7 @@ class SplitOp:
 
     @staticmethod
     def _split_line_with_line(line, splitter):
-        """Split a LineString with another (Multi)LineString or (Multi)Polygon"""
-
+        """Split a LineString with another (Multi)LineString or (Multi)Polygon."""
         # if splitter is a polygon, pick it's boundary
         if splitter.geom_type in ("Polygon", "MultiPolygon"):
             splitter = splitter.boundary
@@ -416,7 +419,7 @@ class SplitOp:
 
     @staticmethod
     def _split_line_with_point(line, splitter):
-        """Split a LineString with a Point"""
+        """Split a LineString with a Point."""
         if not isinstance(line, LineString):
             raise GeometryTypeError("First argument must be a LineString")
         if not isinstance(splitter, Point):
@@ -458,8 +461,7 @@ class SplitOp:
 
     @staticmethod
     def _split_line_with_multipoint(line, splitter):
-        """Split a LineString with a MultiPoint"""
-
+        """Split a LineString with a MultiPoint."""
         if not isinstance(line, LineString):
             raise GeometryTypeError("First argument must be a LineString")
         if not isinstance(splitter, MultiPoint):
@@ -477,9 +479,7 @@ class SplitOp:
 
     @staticmethod
     def split(geom, splitter):
-        """
-        Splits a geometry by another geometry and returns a collection of
-        geometries.
+        """Split a geometry by another geometry and return a collection of geometries.
 
         This function is the theoretical opposite of the union of
         the split geometry parts. If the splitter does not split the geometry, a
@@ -512,8 +512,8 @@ class SplitOp:
         >>> result = split(line, pt)
         >>> result.wkt
         'GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), LINESTRING (1 1, 2 2))'
-        """
 
+        """
         if geom.geom_type in ("MultiLineString", "MultiPolygon"):
             return GeometryCollection(
                 [i for part in geom.geoms for i in SplitOp.split(part, splitter).geoms]
@@ -557,7 +557,7 @@ split = SplitOp.split
 
 
 def substring(geom, start_dist, end_dist, normalized=False):
-    """Return a line segment between specified distances along a LineString
+    """Return a line segment between specified distances along a LineString.
 
     Negative distance values are taken as measured in the reverse
     direction from the end of the geometry. Out-of-range index
@@ -613,8 +613,8 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
     >>> substring(ls, 2.5, -2.5).wkt
     'POINT (2.5 0)'
-    """
 
+    """
     if not isinstance(geom, LineString):
         raise GeometryTypeError(
             "Can only calculate a substring of LineString geometries. "
@@ -684,7 +684,7 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
 
 def clip_by_rect(geom, xmin, ymin, xmax, ymax):
-    """Returns the portion of a geometry within a rectangle
+    """Return the portion of a geometry within a rectangle.
 
     The geometry is clipped in a fast but possibly dirty way. The output is
     not guaranteed to be valid. No exceptions will be raised for topological
@@ -706,6 +706,7 @@ def clip_by_rect(geom, xmin, ymin, xmax, ymax):
     Notes
     -----
     New in 1.7.
+
     """
     if geom.is_empty:
         return geom
@@ -713,7 +714,7 @@ def clip_by_rect(geom, xmin, ymin, xmax, ymax):
 
 
 def orient(geom, sign=1.0):
-    """A properly oriented copy of the given geometry.
+    """Return a properly oriented copy of the given geometry.
 
     The signed area of the result will have the given sign. A sign of
     1.0 means that the coordinates of the product's exterior rings will

--- a/shapely/plotting.py
+++ b/shapely/plotting.py
@@ -1,5 +1,4 @@
-"""
-Plot single geometries using Matplotlib.
+"""Plot single geometries using Matplotlib.
 
 Note: this module is experimental, and mainly targeting (interactive)
 exploration, debugging and illustration purposes.
@@ -35,8 +34,7 @@ def _path_from_polygon(polygon):
 
 
 def patch_from_polygon(polygon, **kwargs):
-    """
-    Gets a Matplotlib patch from a (Multi)Polygon.
+    """Get a Matplotlib patch from a (Multi)Polygon.
 
     Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
@@ -44,12 +42,14 @@ def patch_from_polygon(polygon, **kwargs):
     Parameters
     ----------
     polygon : shapely.Polygon or shapely.MultiPolygon
+        The polygon to convert to a Matplotlib Patch.
     **kwargs
         Additional keyword arguments passed to the matplotlib Patch.
 
     Returns
     -------
     Matplotlib artist (PathPatch)
+
     """
     from matplotlib.patches import PathPatch
 
@@ -66,8 +66,7 @@ def plot_polygon(
     linewidth=None,
     **kwargs,
 ):
-    """
-    Plot a (Multi)Polygon.
+    """Plot a (Multi)Polygon.
 
     Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
@@ -75,6 +74,7 @@ def plot_polygon(
     Parameters
     ----------
     polygon : shapely.Polygon or shapely.MultiPolygon
+        The polygon to plot.
     ax : matplotlib Axes, default None
         The axes on which to draw the plot. If not specified, will get the
         current active axes or create a new figure.
@@ -97,6 +97,7 @@ def plot_polygon(
     -------
     Matplotlib artist (PathPatch), if `add_points` is false.
     A tuple of Matplotlib artists (PathPatch, Line2D), if `add_points` is true.
+
     """
     from matplotlib import colors
 
@@ -129,8 +130,7 @@ def plot_polygon(
 
 
 def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs):
-    """
-    Plot a (Multi)LineString/LinearRing.
+    """Plot a (Multi)LineString/LinearRing.
 
     Note: this function is experimental, and mainly targeting (interactive)
     exploration, debugging and illustration purposes.
@@ -138,6 +138,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     Parameters
     ----------
     line : shapely.LineString or shapely.LinearRing
+        The line to plot.
     ax : matplotlib Axes, default None
         The axes on which to draw the plot. If not specified, will get the
         current active axes or create a new figure.
@@ -153,6 +154,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
     Returns
     -------
     Matplotlib artist (PathPatch)
+
     """
     from matplotlib.patches import PathPatch
     from matplotlib.path import Path
@@ -184,8 +186,7 @@ def plot_line(line, ax=None, add_points=True, color=None, linewidth=2, **kwargs)
 
 
 def plot_points(geom, ax=None, color=None, marker="o", **kwargs):
-    """
-    Plot a Point/MultiPoint or the vertices of any other geometry type.
+    """Plot a Point/MultiPoint or the vertices of any other geometry type.
 
     Parameters
     ----------
@@ -206,6 +207,7 @@ def plot_points(geom, ax=None, color=None, marker="o", **kwargs):
     Returns
     -------
     Matplotlib artist (Line2D)
+
     """
     if ax is None:
         ax = _default_ax()

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -1,3 +1,5 @@
+"""Predicates for spatial analysis."""
+
 import warnings
 
 import numpy as np
@@ -41,7 +43,7 @@ __all__ = [
 
 @multithreading_enabled
 def has_z(geometry, **kwargs):
-    """Returns True if a geometry has Z coordinates.
+    """Return True if a geometry has Z coordinates.
 
     Note that for GEOS < 3.12 this function returns False if the (first) Z coordinate
     equals NaN.
@@ -49,10 +51,11 @@ def has_z(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to check for Z coordinates.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_coordinate_dimension, has_m
 
@@ -65,6 +68,7 @@ def has_z(geometry, **kwargs):
     True
     >>> has_z(Point())
     False
+
     """
     return lib.has_z(geometry, **kwargs)
 
@@ -72,17 +76,18 @@ def has_z(geometry, **kwargs):
 @multithreading_enabled
 @requires_geos("3.12.0")
 def has_m(geometry, **kwargs):
-    """Returns True if a geometry has M coordinates.
+    """Return True if a geometry has M coordinates.
 
     .. versionadded:: 2.1.0
 
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to check for M coordinates.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     get_coordinate_dimension, has_z
 
@@ -97,13 +102,14 @@ def has_m(geometry, **kwargs):
     True
     >>> has_m(from_wkt("POINT ZM (0 0 0 0)"))
     True
+
     """
     return lib.has_m(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_ccw(geometry, **kwargs):
-    """Returns True if a linestring or linearring is counterclockwise.
+    """Return True if a linestring or linearring is counterclockwise.
 
     Note that there are no checks on whether lines are actually closed and
     not self-intersecting, while this is a requirement for is_ccw. The recommended
@@ -118,7 +124,7 @@ def is_ccw(geometry, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_simple : Checks if a linestring is closed and simple.
     is_valid : Checks additionally if the geometry is simple.
@@ -134,13 +140,14 @@ def is_ccw(geometry, **kwargs):
     False
     >>> is_ccw(Point(0, 0))
     False
+
     """
     return lib.is_ccw(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_closed(geometry, **kwargs):
-    """Returns True if a linestring's first and last points are equal.
+    """Return True if a linestring's first and last points are equal.
 
     Parameters
     ----------
@@ -149,7 +156,7 @@ def is_closed(geometry, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_ring : Checks additionally if the geometry is simple.
 
@@ -162,13 +169,14 @@ def is_closed(geometry, **kwargs):
     True
     >>> is_closed(Point(0, 0))
     False
+
     """
     return lib.is_closed(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_empty(geometry, **kwargs):
-    """Returns True if a geometry is an empty point, polygon, etc.
+    """Return True if a geometry is an empty point, polygon, etc.
 
     Parameters
     ----------
@@ -177,7 +185,7 @@ def is_empty(geometry, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_missing : checks if the object is a geometry
 
@@ -190,21 +198,23 @@ def is_empty(geometry, **kwargs):
     False
     >>> is_empty(None)
     False
+
     """
     return lib.is_empty(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_geometry(geometry, **kwargs):
-    """Returns True if the object is a geometry
+    """Return True if the object is a geometry.
 
     Parameters
     ----------
     geometry : any object or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_missing : check if an object is missing (None)
     is_valid_input : check if an object is a geometry or None
@@ -220,21 +230,23 @@ def is_geometry(geometry, **kwargs):
     False
     >>> is_geometry("text")
     False
+
     """
     return lib.is_geometry(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_missing(geometry, **kwargs):
-    """Returns True if the object is not a geometry (None)
+    """Return True if the object is not a geometry (None).
 
     Parameters
     ----------
     geometry : any object or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_geometry : check if an object is a geometry
     is_valid_input : check if an object is a geometry or None
@@ -251,13 +263,14 @@ def is_missing(geometry, **kwargs):
     True
     >>> is_missing("text")
     False
+
     """
     return lib.is_missing(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_prepared(geometry, **kwargs):
-    """Returns True if a Geometry is prepared.
+    """Return True if a Geometry is prepared.
 
     Note that it is not necessary to check if a geometry is already prepared
     before preparing it. It is more efficient to call ``prepare`` directly
@@ -268,10 +281,11 @@ def is_prepared(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_valid_input : check if an object is a geometry or None
     prepare : prepare a geometry
@@ -287,21 +301,23 @@ def is_prepared(geometry, **kwargs):
     True
     >>> is_prepared(None)
     False
+
     """
     return lib.is_prepared(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_valid_input(geometry, **kwargs):
-    """Returns True if the object is a geometry or None
+    """Return True if the object is a geometry or None.
 
     Parameters
     ----------
     geometry : any object or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_geometry : checks if an object is a geometry
     is_missing : checks if an object is None
@@ -319,22 +335,25 @@ def is_valid_input(geometry, **kwargs):
     False
     >>> is_valid_input("text")
     False
+
     """
     return lib.is_valid_input(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_ring(geometry, **kwargs):
-    """Returns True if a linestring is closed and simple.
+    """Return True if a linestring is closed and simple.
+
+    This function will return False for non-linestrings.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        This function will return False for non-linestrings.
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_closed : Checks only if the geometry is closed.
     is_simple : Checks only if the geometry is simple.
@@ -353,26 +372,31 @@ def is_ring(geometry, **kwargs):
     >>> geom = LineString([(0, 0), (1, 1), (0, 1), (1, 0), (0, 0)])
     >>> is_closed(geom), is_simple(geom), is_ring(geom)
     (True, False, False)
+
     """
     return lib.is_ring(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_simple(geometry, **kwargs):
-    """Returns True if a Geometry has no anomalous geometric points, such as
+    """Return True if the geometry is simple.
+
+    A simple geometry has no anomalous geometric points, such as
     self-intersections or self tangency.
 
     Note that polygons and linearrings are assumed to be simple. Use is_valid
     to check these kind of geometries for self-intersections.
 
+    This function will return False for geometrycollections.
+
     Parameters
     ----------
     geometry : Geometry or array_like
-        This function will return False for geometrycollections.
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_ring : Checks additionally if the geometry is closed.
     is_valid : Checks whether a geometry is well formed.
@@ -386,22 +410,25 @@ def is_simple(geometry, **kwargs):
     False
     >>> is_simple(None)
     False
+
     """
     return lib.is_simple(geometry, **kwargs)
 
 
 @multithreading_enabled
 def is_valid(geometry, **kwargs):
-    """Returns True if a geometry is well formed.
+    """Return True if a geometry is well formed.
+
+    Returns False for missing values.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        Any geometry type is accepted. Returns False for missing values.
+        Geometry or geometries to check. Any geometry type is accepted.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_valid_reason : Returns the reason in case of invalid.
 
@@ -416,6 +443,7 @@ def is_valid(geometry, **kwargs):
     True
     >>> is_valid(None)
     False
+
     """
     # GEOS is valid will emit warnings for invalid geometries. Suppress them.
     with warnings.catch_warnings():
@@ -425,16 +453,18 @@ def is_valid(geometry, **kwargs):
 
 
 def is_valid_reason(geometry, **kwargs):
-    """Returns a string stating if a geometry is valid and if not, why.
+    """Return a string stating if a geometry is valid and if not, why.
+
+    Returns None for missing values.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-        Any geometry type is accepted. Returns None for missing values.
+        Geometry or geometries to check. Any geometry type is accepted.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     is_valid : returns True or False
 
@@ -447,13 +477,14 @@ def is_valid_reason(geometry, **kwargs):
     'Self-intersection[1 2]'
     >>> is_valid_reason(None) is None
     True
+
     """
     return lib.is_valid_reason(geometry, **kwargs)
 
 
 @multithreading_enabled
 def crosses(a, b, **kwargs):
-    """Returns True if A and B spatially cross.
+    """Return True if A and B spatially cross.
 
     A crosses B if they have some but not all interior points in common,
     the intersection is one dimension less than the maximum dimension of A or B,
@@ -461,11 +492,14 @@ def crosses(a, b, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     prepare : improve performance by preparing ``a`` (the first argument)
 
@@ -497,13 +531,14 @@ def crosses(a, b, **kwargs):
     >>> # A contains some but not all points of B; they intersect at a point:
     >>> crosses(area, MultiPoint([(2, 2), (0.5, 0.5)]))
     True
+
     """
     return lib.crosses(a, b, **kwargs)
 
 
 @multithreading_enabled
 def contains(a, b, **kwargs):
-    """Returns True if geometry B is completely inside geometry A.
+    """Return True if geometry B is completely inside geometry A.
 
     A contains B if no points of B lie in the exterior of A and at least one
     point of the interior of B lies in the interior of A.
@@ -514,11 +549,14 @@ def contains(a, b, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     within : ``contains(A, B) == within(B, A)``
     contains_properly : contains with no common boundary points
@@ -554,14 +592,16 @@ def contains(a, b, **kwargs):
     True
     >>> contains(area, None)
     False
+
     """
     return lib.contains(a, b, **kwargs)
 
 
 @multithreading_enabled
 def contains_properly(a, b, **kwargs):
-    """Returns True if geometry B is completely inside geometry A, with no
-    common boundary points.
+    """Return True if geometry B is completely inside geometry A.
+
+    They should have no common boundary points.
 
     A contains B properly if B intersects the interior of A but not the
     boundary (or exterior). This means that a geometry A does not
@@ -574,11 +614,14 @@ def contains_properly(a, b, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     contains : contains which allows common boundary points
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -603,21 +646,25 @@ def contains_properly(a, b, **kwargs):
     True
     >>> contains_properly(area1, area3)
     True
+
     """
     return lib.contains_properly(a, b, **kwargs)
 
 
 @multithreading_enabled
 def covered_by(a, b, **kwargs):
-    """Returns True if no point in geometry A is outside geometry B.
+    """Return True if no point in geometry A is outside geometry B.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     covers : ``covered_by(A, B) == covers(B, A)``
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -651,21 +698,25 @@ def covered_by(a, b, **kwargs):
     True
     >>> covered_by(None, area)
     False
+
     """
     return lib.covered_by(a, b, **kwargs)
 
 
 @multithreading_enabled
 def covers(a, b, **kwargs):
-    """Returns True if no point in geometry B is outside geometry A.
+    """Return True if no point in geometry B is outside geometry A.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     covered_by : ``covers(A, B) == covered_by(B, A)``
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -699,24 +750,28 @@ def covers(a, b, **kwargs):
     True
     >>> covers(area, None)
     False
+
     """
     return lib.covers(a, b, **kwargs)
 
 
 @multithreading_enabled
 def disjoint(a, b, **kwargs):
-    """Returns True if A and B do not share any point in space.
+    """Return True if A and B do not share any point in space.
 
     Disjoint implies that overlaps, touches, within, and intersects are False.
     Note missing (None) values are never disjoint.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     intersects : ``disjoint(A, B) == ~intersects(A, B)``
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -740,20 +795,24 @@ def disjoint(a, b, **kwargs):
     False
     >>> disjoint(None, None)
     False
+
     """
     return lib.disjoint(a, b, **kwargs)
 
 
 @multithreading_enabled
 def equals(a, b, **kwargs):
-    """Returns True if A and B are spatially equal.
+    """Return True if A and B are spatially equal.
 
     If A is within B and B is within A, A and B are considered equal. The
     ordering of points can be different.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -772,23 +831,27 @@ def equals(a, b, **kwargs):
     True
     >>> equals(None, None)
     False
+
     """
     return lib.equals(a, b, **kwargs)
 
 
 @multithreading_enabled
 def intersects(a, b, **kwargs):
-    """Returns True if A and B share any portion of space.
+    """Return True if A and B share any portion of space.
 
     Intersects implies that overlaps, touches, covers, or within are True.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     disjoint : ``intersects(A, B) == ~disjoint(A, B)``
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -806,13 +869,14 @@ def intersects(a, b, **kwargs):
     True
     >>> intersects(None, None)
     False
+
     """
     return lib.intersects(a, b, **kwargs)
 
 
 @multithreading_enabled
 def overlaps(a, b, **kwargs):
-    """Returns True if A and B spatially overlap.
+    """Return True if A and B spatially overlap.
 
     A and B overlap if they have some but not all points in common, have the
     same dimension, and the intersection of the interiors of the two geometries
@@ -823,11 +887,14 @@ def overlaps(a, b, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     prepare : improve performance by preparing ``a`` (the first argument)
 
@@ -860,22 +927,25 @@ def overlaps(a, b, **kwargs):
     False
     >>> overlaps(None, None)
     False
+
     """
     return lib.overlaps(a, b, **kwargs)
 
 
 @multithreading_enabled
 def touches(a, b, **kwargs):
-    """Returns True if the only points shared between A and B are on the
-    boundary of A and B.
+    """Return True if the only points shared between A and B are on their boundaries.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     prepare : improve performance by preparing ``a`` (the first argument)
 
@@ -900,24 +970,28 @@ def touches(a, b, **kwargs):
     True
     >>> touches(area, Polygon([(0, 1), (1, 1), (1, 2), (0, 2), (0, 1)]))
     True
+
     """
     return lib.touches(a, b, **kwargs)
 
 
 @multithreading_enabled
 def within(a, b, **kwargs):
-    """Returns True if geometry A is completely inside geometry B.
+    """Return True if geometry A is completely inside geometry B.
 
     A is within B if no points of A lie in the exterior of B and at least one
     point of the interior of A lies in the interior of B.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     contains : ``within(A, B) == contains(B, A)``
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -951,14 +1025,14 @@ def within(a, b, **kwargs):
     True
     >>> within(None, area)
     False
+
     """
     return lib.within(a, b, **kwargs)
 
 
 @multithreading_enabled
 def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
-    """Returns True if the geometries are structurally equivalent within a
-    given tolerance.
+    """Return True if the geometries are equivalent within a given tolerance.
 
     This method uses exact coordinate equality, which requires coordinates
     to be equal (within specified tolerance) and in the same order for
@@ -977,8 +1051,12 @@ def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     tolerance : float or array_like (default: 0.)
+        The tolerance to use in the comparison.
     normalize : bool, optional (default: False)
         If True, normalize the two geometries so that the coordinates are
         in the same order.
@@ -1011,6 +1089,7 @@ def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
     False
     >>> equals(polygon1, polygon2)
     True
+
     """
     if normalize:
         a = lib.normalize(a)
@@ -1020,12 +1099,14 @@ def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
 
 
 def relate(a, b, **kwargs):
-    """
-    Returns a string representation of the DE-9IM intersection matrix.
+    """Return a string representation of the DE-9IM intersection matrix.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -1036,15 +1117,14 @@ def relate(a, b, **kwargs):
     >>> line = LineString([(0, 0), (1, 1)])
     >>> relate(point, line)
     'F0FFFF102'
+
     """
     return lib.relate(a, b, **kwargs)
 
 
 @multithreading_enabled
 def relate_pattern(a, b, pattern, **kwargs):
-    """
-    Returns True if the DE-9IM string code for the relationship between
-    the geometries satisfies the pattern, else False.
+    """Return True if the DE-9IM relationship code satisfies the pattern.
 
     This function compares the DE-9IM code string for two geometries
     against a specified pattern. If the string matches the pattern then
@@ -1055,8 +1135,12 @@ def relate_pattern(a, b, pattern, **kwargs):
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     pattern : string
+        The pattern to match the DE-9IM relationship code against.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -1069,6 +1153,7 @@ def relate_pattern(a, b, pattern, **kwargs):
     '0FFFFF212'
     >>> relate_pattern(point, square, "T*F**F***")
     True
+
     """
     return lib.relate_pattern(a, b, pattern, **kwargs)
 
@@ -1076,21 +1161,23 @@ def relate_pattern(a, b, pattern, **kwargs):
 @multithreading_enabled
 @requires_geos("3.10.0")
 def dwithin(a, b, distance, **kwargs):
-    """
-    Returns True if the geometries are within a given distance.
+    """Return True if the geometries are within a given distance.
 
     Using this function is more efficient than computing the distance and
     comparing the result.
 
     Parameters
     ----------
-    a, b : Geometry or array_like
+    a : Geometry or array_like
+        Geometry or geometries to check.
+    b : Geometry or array_like
+        Geometry or geometries to check.
     distance : float
         Negative distances always return False.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     distance : compute the actual distance between A and B
     prepare : improve performance by preparing ``a`` (the first argument)
@@ -1107,14 +1194,14 @@ def dwithin(a, b, distance, **kwargs):
     True
     >>> dwithin(point, None, 100)
     False
+
     """
     return lib.dwithin(a, b, distance, **kwargs)
 
 
 @multithreading_enabled
 def contains_xy(geom, x, y=None, **kwargs):
-    """
-    Returns True if the Point (x, y) is completely inside geom.
+    """Return True if the Point (x, y) is completely inside geom.
 
     This is a special-case (and faster) variant of the `contains` function
     which avoids having to create a Point object if you start from x/y
@@ -1128,13 +1215,14 @@ def contains_xy(geom, x, y=None, **kwargs):
     Parameters
     ----------
     geom : Geometry or array_like
+        Geometry or geometries to check if they contain the point.
     x, y : float or array_like
         Coordinates as separate x and y arrays, or a single array of
         coordinate x, y tuples.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     contains : variant taking two geometries as input
 
@@ -1152,6 +1240,7 @@ def contains_xy(geom, x, y=None, **kwargs):
     True
     >>> contains_xy(area, 0.5, 0.5)
     True
+
     """
     if y is None:
         coords = np.asarray(x)
@@ -1161,8 +1250,7 @@ def contains_xy(geom, x, y=None, **kwargs):
 
 @multithreading_enabled
 def intersects_xy(geom, x, y=None, **kwargs):
-    """
-    Returns True if geom and the Point (x, y) share any portion of space.
+    """Return True if geom and the Point (x, y) share any portion of space.
 
     This is a special-case (and faster) variant of the `intersects` function
     which avoids having to create a Point object if you start from x/y
@@ -1173,13 +1261,14 @@ def intersects_xy(geom, x, y=None, **kwargs):
     Parameters
     ----------
     geom : Geometry or array_like
+        Geometry or geometries to check if they intersect with the point.
     x, y : float or array_like
         Coordinates as separate x and y arrays, or a single array of
         coordinate x, y tuples.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     intersects : variant taking two geometries as input
 
@@ -1200,6 +1289,7 @@ def intersects_xy(geom, x, y=None, **kwargs):
     True
     >>> intersects_xy(line, 0, 0)
     True
+
     """
     if y is None:
         coords = np.asarray(x)

--- a/shapely/prepared.py
+++ b/shapely/prepared.py
@@ -1,6 +1,4 @@
-"""
-Support for GEOS prepared geometry operations.
-"""
+"""Support for GEOS prepared geometry operations."""
 
 from pickle import PicklingError
 
@@ -8,19 +6,20 @@ import shapely
 
 
 class PreparedGeometry:
-    """
-    A geometry prepared for efficient comparison to a set of other geometries.
+    """A geometry prepared for efficient comparison to a set of other geometries.
 
     Example:
-
+    -------
       >>> from shapely.geometry import Point, Polygon
       >>> triangle = Polygon([(0.0, 0.0), (1.0, 1.0), (1.0, -1.0)])
       >>> p = prep(triangle)
       >>> p.intersects(Point(0.5, 0.5))
       True
+
     """
 
     def __init__(self, context):
+        """Prepare a geometry for efficient comparison to other geometries."""
         if isinstance(context, PreparedGeometry):
             self.context = context.context
         else:
@@ -29,45 +28,46 @@ class PreparedGeometry:
         self.prepared = True
 
     def contains(self, other):
-        """Returns True if the geometry contains the other, else False"""
+        """Return True if the geometry contains the other, else False."""
         return self.context.contains(other)
 
     def contains_properly(self, other):
-        """Returns True if the geometry properly contains the other, else False"""
+        """Return True if the geometry properly contains the other, else False."""
         return self.context.contains_properly(other)
 
     def covers(self, other):
-        """Returns True if the geometry covers the other, else False"""
+        """Return True if the geometry covers the other, else False."""
         return self.context.covers(other)
 
     def crosses(self, other):
-        """Returns True if the geometries cross, else False"""
+        """Return True if the geometries cross, else False."""
         return self.context.crosses(other)
 
     def disjoint(self, other):
-        """Returns True if geometries are disjoint, else False"""
+        """Return True if geometries are disjoint, else False."""
         return self.context.disjoint(other)
 
     def intersects(self, other):
-        """Returns True if geometries intersect, else False"""
+        """Return True if geometries intersect, else False."""
         return self.context.intersects(other)
 
     def overlaps(self, other):
-        """Returns True if geometries overlap, else False"""
+        """Return True if geometries overlap, else False."""
         return self.context.overlaps(other)
 
     def touches(self, other):
-        """Returns True if geometries touch, else False"""
+        """Return True if geometries touch, else False."""
         return self.context.touches(other)
 
     def within(self, other):
-        """Returns True if geometry is within the other, else False"""
+        """Return True if geometry is within the other, else False."""
         return self.context.within(other)
 
     def __reduce__(self):
+        """Pickling is not supported."""
         raise PicklingError("Prepared geometries cannot be pickled.")
 
 
 def prep(ob):
-    """Creates and returns a prepared geometric object."""
+    """Create and return a prepared geometric object."""
     return PreparedGeometry(ob)

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -1,3 +1,5 @@
+"""Set-theoretic operations on geometry objects."""
+
 import numpy as np
 
 from shapely import GeometryType, lib
@@ -20,7 +22,7 @@ __all__ = [
 
 @multithreading_enabled
 def difference(a, b, grid_size=None, **kwargs):
-    """Returns the part of geometry A that does not intersect with geometry B.
+    """Return the part of geometry A that does not intersect with geometry B.
 
     If grid_size is nonzero, input coordinates will be snapped to a precision
     grid of that size and resulting coordinates will be snapped to that same
@@ -32,14 +34,16 @@ def difference(a, b, grid_size=None, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to subtract b from.
     b : Geometry or array_like
+        Geometry or geometries to subtract from a.
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     set_precision
 
@@ -60,8 +64,8 @@ def difference(a, b, grid_size=None, **kwargs):
     >>> box1 = box(0.1, 0.2, 2.1, 2.1)
     >>> difference(box1, box2, grid_size=1)
     <POLYGON ((2 0, 0 0, 0 2, 1 2, 1 1, 2 1, 2 0))>
-    """
 
+    """
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
             raise UnsupportedGEOSVersionError(
@@ -78,7 +82,7 @@ def difference(a, b, grid_size=None, **kwargs):
 
 @multithreading_enabled
 def intersection(a, b, grid_size=None, **kwargs):
-    """Returns the geometry that is shared between input geometries.
+    """Return the geometry that is shared between input geometries.
 
     If grid_size is nonzero, input coordinates will be snapped to a precision
     grid of that size and resulting coordinates will be snapped to that same
@@ -90,14 +94,16 @@ def intersection(a, b, grid_size=None, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to intersect with b.
     b : Geometry or array_like
+        Geometry or geometries to intersect with a.
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     intersection_all
     set_precision
@@ -115,8 +121,8 @@ def intersection(a, b, grid_size=None, **kwargs):
     >>> box1 = box(0.1, 0.2, 2.1, 2.1)
     >>> intersection(box1, box2, grid_size=1)
     <POLYGON ((2 2, 2 1, 1 1, 1 2, 2 2))>
-    """
 
+    """
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
             raise UnsupportedGEOSVersionError(
@@ -133,7 +139,7 @@ def intersection(a, b, grid_size=None, **kwargs):
 
 @multithreading_enabled
 def intersection_all(geometries, axis=None, **kwargs):
-    """Returns the intersection of multiple geometries.
+    """Return the intersection of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
     If all elements of the given axis are None, an empty GeometryCollection is
@@ -142,6 +148,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
+        Geometries to calculate the intersection of.
     axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
@@ -150,7 +157,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     intersection
 
@@ -165,6 +172,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     [<LINESTRING (1 1, 2 2)>]
     >>> intersection_all([line1, None])
     <LINESTRING (0 0, 2 2)>
+
     """
     geometries = np.asarray(geometries)
     if axis is None:
@@ -177,8 +185,7 @@ def intersection_all(geometries, axis=None, **kwargs):
 
 @multithreading_enabled
 def symmetric_difference(a, b, grid_size=None, **kwargs):
-    """Returns the geometry that represents the portions of input geometries
-    that do not intersect.
+    """Return the geometry with the portions of input geometries that do not intersect.
 
     If grid_size is nonzero, input coordinates will be snapped to a precision
     grid of that size and resulting coordinates will be snapped to that same
@@ -190,14 +197,16 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to "symmetric_difference" with b.
     b : Geometry or array_like
+        Geometry or geometries to "symmetric_difference" with a.
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     symmetric_difference_all
     set_precision
@@ -215,8 +224,8 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     >>> box1 = box(0.1, 0.2, 2.1, 2.1)
     >>> symmetric_difference(box1, box2, grid_size=1)
     <MULTIPOLYGON (((2 0, 0 0, 0 2, 1 2, 1 1, 2 1, 2 0)), ((2 2, 1 2, 1 3, 3 3, ...>
-    """
 
+    """
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
             raise UnsupportedGEOSVersionError(
@@ -233,7 +242,7 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
 
 @multithreading_enabled
 def symmetric_difference_all(geometries, axis=None, **kwargs):
-    """Returns the symmetric difference of multiple geometries.
+    """Return the symmetric difference of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
     If all elements of the given axis are None an empty GeometryCollection is
@@ -242,6 +251,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
+        Geometries to calculate the combined symmetric difference of.
     axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
@@ -250,7 +260,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     symmetric_difference
 
@@ -267,6 +277,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     <LINESTRING (0 0, 2 2)>
     >>> symmetric_difference_all([None, None])
     <GEOMETRYCOLLECTION EMPTY>
+
     """
     geometries = np.asarray(geometries)
     if axis is None:
@@ -279,7 +290,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
 
 @multithreading_enabled
 def union(a, b, grid_size=None, **kwargs):
-    """Merges geometries into one.
+    """Merge geometries into one.
 
     If grid_size is nonzero, input coordinates will be snapped to a precision
     grid of that size and resulting coordinates will be snapped to that same
@@ -291,14 +302,16 @@ def union(a, b, grid_size=None, **kwargs):
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to merge with b.
     b : Geometry or array_like
+        Geometry or geometries to merge with a.
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     union_all
     set_precision
@@ -318,8 +331,8 @@ def union(a, b, grid_size=None, **kwargs):
     >>> box1 = box(0.1, 0.2, 2.1, 2.1)
     >>> union(box1, box2, grid_size=1)
     <POLYGON ((2 0, 0 0, 0 2, 1 2, 1 3, 3 3, 3 1, 2 1, 2 0))>
-    """
 
+    """
     if grid_size is not None:
         if lib.geos_version < (3, 9, 0):
             raise UnsupportedGEOSVersionError(
@@ -336,7 +349,7 @@ def union(a, b, grid_size=None, **kwargs):
 
 @multithreading_enabled
 def union_all(geometries, grid_size=None, axis=None, **kwargs):
-    """Returns the union of multiple geometries.
+    """Return the union of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
     If all elements of the given axis are None an empty GeometryCollection is
@@ -354,6 +367,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
+        Geometries to merge/union.
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
@@ -365,7 +379,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     union
     set_precision
@@ -392,6 +406,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     <GEOMETRYCOLLECTION EMPTY>
     >>> union_all([])
     <GEOMETRYCOLLECTION EMPTY>
+
     """
     # for union_all, GEOS provides an efficient route through first creating
     # GeometryCollections
@@ -426,17 +441,21 @@ unary_union = union_all
 
 @multithreading_enabled
 def coverage_union(a, b, **kwargs):
-    """Merges multiple polygons into one. This is an optimized version of
-    union which assumes the polygons to be non-overlapping.
+    """Merge multiple polygons into one.
+
+    This is an optimized version of union which assumes the polygons to be
+    non-overlapping.
 
     Parameters
     ----------
     a : Geometry or array_like
+        Geometry or geometries to be merged with b.
     b : Geometry or array_like
+        Geometry or geometries to be merged with a.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     coverage_union_all
 
@@ -450,13 +469,15 @@ def coverage_union(a, b, **kwargs):
     Union with None returns same polygon
     >>> normalize(coverage_union(polygon, None))
     <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
+
     """  # noqa: E501
     return coverage_union_all([a, b], **kwargs)
 
 
 @multithreading_enabled
 def coverage_union_all(geometries, axis=None, **kwargs):
-    """Returns the union of multiple polygons of a geometry collection.
+    """Return the union of multiple polygons of a geometry collection.
+
     This is an optimized version of union which assumes the polygons
     to be non-overlapping.
 
@@ -467,6 +488,7 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
+        Geometries to merge/union.
     axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
@@ -475,7 +497,7 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
-    See also
+    See Also
     --------
     coverage_union
 
@@ -490,6 +512,7 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
     >>> normalize(coverage_union_all([None, None]))
     <GEOMETRYCOLLECTION EMPTY>
+
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/shapely/speedups.py
+++ b/shapely/speedups.py
@@ -1,3 +1,5 @@
+"""Speedups for Shapely geometry operations."""
+
 import warnings
 
 __all__ = ["available", "enable", "disable", "enabled"]
@@ -15,9 +17,7 @@ _MSG = (
 
 
 def enable():
-    """
-    This function has no longer any effect, and will be removed in a future
-    release.
+    """Will be removed in a future release and has no longer any effect.
 
     Previously, this function enabled cython-based speedups. Starting with
     Shapely 2.0, equivalent speedups are available in every installation.
@@ -26,9 +26,7 @@ def enable():
 
 
 def disable():
-    """
-    This function has no longer any effect, and will be removed in a future
-    release.
+    """Will be removed in a future release and has no longer any effect.
 
     Previously, this function enabled cython-based speedups. Starting with
     Shapely 2.0, equivalent speedups are available in every installation.

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -1,3 +1,5 @@
+"""STRtree spatial index for efficient spatial queries."""
+
 from typing import Any, Iterable, Union
 
 import numpy as np
@@ -12,7 +14,7 @@ __all__ = ["STRtree"]
 
 
 class BinaryPredicate(ParamEnum):
-    """The enumeration of GEOS binary predicates types"""
+    """The enumeration of GEOS binary predicates types."""
 
     intersects = 1
     within = 2
@@ -26,9 +28,9 @@ class BinaryPredicate(ParamEnum):
 
 
 class STRtree:
-    """
-    A query-only R-tree spatial index created using the
-    Sort-Tile-Recursive (STR) [1]_ algorithm.
+    """A query-only R-tree spatial index.
+
+    It is created using the Sort-Tile-Recursive (STR) [1]_ algorithm.
 
     The tree indexes the bounding boxes of each geometry.  The tree is
     constructed directly at initialization and nodes cannot be added or
@@ -67,13 +69,11 @@ class STRtree:
        (February 1997). "STR: A Simple and Efficient Algorithm for
        R-Tree Packing".
        https://ia600900.us.archive.org/27/items/nasa_techdoc_19970016975/19970016975.pdf
+
     """
 
-    def __init__(
-        self,
-        geoms: Iterable[BaseGeometry],
-        node_capacity: int = 10,
-    ):
+    def __init__(self, geoms: Iterable[BaseGeometry], node_capacity: int = 10):
+        """Create a new STRtree spatial index."""
         # Keep references to geoms in a copied array so that this array is not
         # modified while the tree depends on it remaining the same
         self._geometries = np.array(geoms, dtype=np.object_, copy=True)
@@ -82,15 +82,16 @@ class STRtree:
         self._tree = lib.STRtree(self.geometries, node_capacity)
 
     def __len__(self):
+        """Return the number of geometries in the tree."""
         return self._tree.count
 
     def __reduce__(self):
+        """Pickle support."""
         return (STRtree, (self.geometries,))
 
     @property
     def geometries(self):
-        """
-        Geometries stored in the tree in the order used to construct the tree.
+        """Geometries stored in the tree in the order used to construct the tree.
 
         The order of this array corresponds to the tree indices returned by
         other STRtree methods.
@@ -100,12 +101,14 @@ class STRtree:
         Returns
         -------
         ndarray of Geometry objects
+
         """
         return self._geometries
 
     def query(self, geometry, predicate=None, distance=None):
-        """
-        Return the integer indices of all combinations of each input geometry
+        """Get the index combinations of all possibly intersecting geometries.
+
+        Returns the integer indices of all combinations of each input geometry
         and tree geometries where the bounding box of each input geometry
         intersects the bounding box of a tree geometry.
 
@@ -231,8 +234,8 @@ tree.geometries.take(arr_indices[1])]).T.tolist()
         effectively performs an inner join, where only those combinations of
         geometries that can be joined based on overlapping bounding boxes or
         optional predicate are returned.
-        """
 
+        """
         geometry = np.asarray(geometry)
         is_scalar = False
         if geometry.ndim == 0:
@@ -270,9 +273,10 @@ tree.geometries.take(arr_indices[1])]).T.tolist()
         return indices[1] if is_scalar else indices
 
     def nearest(self, geometry) -> Union[Any, None]:
-        """
-        Return the index of the nearest geometry in the tree for each input
-        geometry based on distance within two-dimensional Cartesian space.
+        """Return the index of the nearest geometry in the tree.
+
+        This is determined for each input geometry based on distance within
+        two-dimensional Cartesian space.
 
         This distance will be 0 when input geometries intersect tree geometries.
 
@@ -299,7 +303,7 @@ tree.geometries.take(arr_indices[1])]).T.tolist()
             None is returned if this index is empty. This may change in
             version 2.0.
 
-        See also
+        See Also
         --------
         query_nearest: returns all equidistant geometries, exclusive geometries, \
 and optional distances
@@ -330,6 +334,7 @@ and optional distances
         >>> tree = STRtree ([Point(0, 0), Point(0, 0)])
         >>> tree.nearest(Point(0, 0))
         0
+
         """
         if self._tree.count == 0:
             return None
@@ -357,8 +362,10 @@ and optional distances
         exclusive=False,
         all_matches=True,
     ):
-        """Return the index of the nearest geometries in the tree for each input
-        geometry based on distance within two-dimensional Cartesian space.
+        """Return the index of the nearest geometries in the tree.
+
+        This is determined for each input geometry based on distance within
+        two-dimensional Cartesian space.
 
         This distance will be 0 when input geometries intersect tree geometries.
 
@@ -415,7 +422,7 @@ and optional distances
             The first subarray of indices contains input geometry indices.
             The second subarray of indices contains tree geometry indices.
 
-        See also
+        See Also
         --------
         nearest: returns singular nearest geometry for each input
 
@@ -493,8 +500,8 @@ and optional distances
         >>> items = np.array([record["value"] for record in records])
         >>> items.take(tree.query_nearest(Point(0.5, 0.5))).tolist()
         ['A']
-        """  # noqa: E501
 
+        """  # noqa: E501
         geometry = np.asarray(geometry, dtype=object)
         is_scalar = False
         if geometry.ndim == 0:

--- a/shapely/testing.py
+++ b/shapely/testing.py
@@ -1,3 +1,5 @@
+"""Utilities for testing with shapely geometries."""
+
 from functools import partial
 
 import numpy as np
@@ -80,17 +82,21 @@ def assert_geometries_equal(
     err_msg="",
     verbose=True,
 ):
-    """Raises an AssertionError if two geometry array_like objects are not equal.
+    """Raise an AssertionError if two geometry array_like objects are not equal.
 
-    Given two array_like objects, check that the shape is equal and all elements of
-    these objects are equal. An exception is raised at shape mismatch or conflicting
-    values. In contrast to the standard usage in shapely, no assertion is raised if
-    both objects have NaNs/Nones in the same positions.
+    Given two array_like objects, check that the shape is equal and all elements
+    of these objects are equal. An exception is raised at shape mismatch or
+    conflicting values. In contrast to the standard usage in shapely, no
+    assertion is raised if both objects have NaNs/Nones in the same positions.
 
     Parameters
     ----------
     x : Geometry or array_like
+        Geometry or geometries to compare.
     y : Geometry or array_like
+        Geometry or geometries to compare.
+    tolerance: float, default 1e-7
+        The tolerance to use when comparing geometries.
     equal_none : bool, default True
         Whether to consider None elements equal to other None elements.
     equal_nan : bool, default True
@@ -101,6 +107,7 @@ def assert_geometries_equal(
         The error message to be printed in case of failure.
     verbose : bool, optional
         If True, the conflicting values are appended to the error message.
+
     """
     __tracebackhide__ = True  # Hide traceback for py.test
     if normalize:

--- a/shapely/validation.py
+++ b/shapely/validation.py
@@ -1,3 +1,4 @@
+"""Validate geometries and make them valid."""
 # TODO: allow for implementations using other than GEOS
 
 import shapely
@@ -6,8 +7,8 @@ __all__ = ["explain_validity", "make_valid"]
 
 
 def explain_validity(ob):
-    """
-    Explain the validity of the input geometry, if it is invalid.
+    """Explain the validity of the input geometry, if it is invalid.
+
     This will describe why the geometry is invalid, and might
     include a location if there is a self-intersection or a
     ring self-intersection.
@@ -27,8 +28,7 @@ def explain_validity(ob):
 
 
 def make_valid(ob):
-    """
-    Make the input geometry valid according to the GEOS MakeValid algorithm.
+    """Make the input geometry valid according to the GEOS MakeValid algorithm.
 
     If the input geometry is already valid, then it will be returned.
 

--- a/shapely/vectorized/__init__.py
+++ b/shapely/vectorized/__init__.py
@@ -20,9 +20,9 @@ def _construct_points(x, y):
 
 
 def contains(geometry, x, y):
-    """
-    Vectorized (element-wise) version of `contains` which checks whether
-    multiple points are contained by a single geometry.
+    """Check whether multiple points are contained by a single geometry.
+
+    Vectorized (element-wise) version of `contains`.
 
     Parameters
     ----------
@@ -47,9 +47,9 @@ def contains(geometry, x, y):
 
 
 def touches(geometry, x, y):
-    """
-    Vectorized (element-wise) version of `touches` which checks whether
-    multiple points touch the exterior of a single geometry.
+    """Check whether multiple points touch the exterior of a single geometry.
+
+    Vectorized (element-wise) version of `touches`.
 
     Parameters
     ----------

--- a/shapely/wkb.py
+++ b/shapely/wkb.py
@@ -7,13 +7,15 @@ import shapely
 
 
 def loads(data, hex=False):
-    """Load a geometry from a WKB byte string, or hex-encoded string if
-    ``hex=True``.
+    """Load a geometry from a WKB byte string.
+
+    If ``hex=True``, the string will be hex-encoded.
 
     Raises
     ------
     GEOSException, UnicodeDecodeError
         If ``data`` contains an invalid geometry.
+
     """
     return shapely.from_wkb(data)
 
@@ -25,19 +27,21 @@ def load(fp, hex=False):
     ------
     GEOSException, UnicodeDecodeError
         If the given file contains an invalid geometry.
+
     """
     data = fp.read()
     return loads(data, hex=hex)
 
 
 def dumps(ob, hex=False, srid=None, **kw):
-    """Dump a WKB representation of a geometry to a byte string, or a
-    hex-encoded string if ``hex=True``.
+    """Dump a WKB representation of a geometry to a byte string.
+
+    If ``hex=True``, the string will be hex-encoded.
 
     Parameters
     ----------
     ob : geometry
-        The geometry to export to well-known binary (WKB) representation
+        The geometry to export to well-known binary (WKB) representation.
     hex : bool
         If true, export the WKB as a hexadecimal string. The default is to
         return a binary string/bytes object.
@@ -46,6 +50,7 @@ def dumps(ob, hex=False, srid=None, **kw):
         means no SRID is included.
     **kw : kwargs, optional
         Keyword output options passed to :func:`~shapely.to_wkb`.
+
     """
     if srid is not None:
         # clone the object and set the SRID before dumping

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -1,4 +1,4 @@
-"""Load/dump geometries using the well-known text (WKT) format
+"""Load/dump geometries using the well-known text (WKT) format.
 
 Also provides pickle-like convenience functions.
 """
@@ -7,8 +7,7 @@ import shapely
 
 
 def loads(data):
-    """
-    Load a geometry from a WKT string.
+    """Load a geometry from a WKT string.
 
     Parameters
     ----------
@@ -18,13 +17,13 @@ def loads(data):
     Returns
     -------
     Shapely geometry object
+
     """
     return shapely.from_wkt(data)
 
 
 def load(fp):
-    """
-    Load a geometry from an open file.
+    """Load a geometry from an open file.
 
     Parameters
     ----------
@@ -34,14 +33,14 @@ def load(fp):
     Returns
     -------
     Shapely geometry object
+
     """
     data = fp.read()
     return loads(data)
 
 
 def dumps(ob, trim=False, rounding_precision=-1, **kw):
-    """
-    Dump a WKT representation of a geometry to a string.
+    """Dump a WKT representation of a geometry to a string.
 
     Parameters
     ----------
@@ -58,13 +57,13 @@ def dumps(ob, trim=False, rounding_precision=-1, **kw):
     Returns
     -------
     input geometry as WKT string
+
     """
     return shapely.to_wkt(ob, trim=trim, rounding_precision=rounding_precision, **kw)
 
 
 def dump(ob, fp, **settings):
-    """
-    Dump a geometry to an open file.
+    """Dump a geometry to an open file.
 
     Parameters
     ----------
@@ -78,5 +77,6 @@ def dump(ob, fp, **settings):
     Returns
     -------
     None
+
     """
     fp.write(dumps(ob, **settings))


### PR DESCRIPTION
Apply pydocstyle and fix all linting errors because of this.

Changes to the documentation are "minimal": only changes needed to conform to the pydocstyle checks.