### PR TITLE
TST/CI: enable testing Python 3.13, NumPy 2.1, GEOS 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
             matplotlib: true
             doctest: true
             extra_pytest_args: "-W error"  # error on warnings
-          # 2024 -- wait until Python 3.13 with binary wheels for numpy are available
-          # - python: "3.13"
-          #   geos: 3.13.0
-          #   numpy: 2.0.0
+          # 2024
+          - python: "3.13"
+            geos: 3.12.2  # update to 3.13.0 when released
+            numpy: 2.1.0
           # apple silicon
           - os: macos-14
             python: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.4, 3.12.2, main]
+        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
         include:
           # 2019
           - python: 3.8
@@ -41,8 +41,8 @@ jobs:
             extra_pytest_args: "-W error"  # error on warnings
           # 2024
           - python: "3.13"
-            geos: 3.12.2  # update to 3.13.0 when released
-            numpy: 2.1.0rc1
+            geos: 3.13.0beta1
+            numpy: 2.1.0
           # apple silicon
           - os: macos-14
             python: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           # 2024
           - python: "3.13"
             geos: 3.12.2  # update to 3.13.0 when released
-            numpy: 2.1.0
+            numpy: 2.1.0rc1
           # apple silicon
           - os: macos-14
             python: "3.12"

--- a/shapely/tests/legacy/test_operations.py
+++ b/shapely/tests/legacy/test_operations.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 import shapely
+from shapely import geos_version
 from shapely.errors import TopologicalError
 from shapely.geometry import GeometryCollection, LineString, MultiPoint, Point, Polygon
 from shapely.wkt import loads
@@ -81,8 +82,11 @@ class OperationsTestCase(unittest.TestCase):
             "(60 60, 80 60, 80 40, 60 40, 60 60))"
         )
         assert not invalid_polygon.is_valid
-        with pytest.raises((TopologicalError, shapely.GEOSException)):
-            invalid_polygon.relate(invalid_polygon)
+        if geos_version < (3, 13, 0):
+            with pytest.raises((TopologicalError, shapely.GEOSException)):
+                invalid_polygon.relate(invalid_polygon)
+        else:  # resolved with RelateNG
+            assert invalid_polygon.relate(invalid_polygon) == "2FFF1FFF2"
 
     def test_hausdorff_distance(self):
         point = Point(1, 1)

--- a/shapely/tests/legacy/test_predicates.py
+++ b/shapely/tests/legacy/test_predicates.py
@@ -5,6 +5,7 @@ import unittest
 import pytest
 
 import shapely
+from shapely import geos_version
 from shapely.geometry import Point, Polygon
 
 
@@ -64,8 +65,15 @@ class PredicatesTestCase(unittest.TestCase):
             (339, 207),
         ]
 
-        with pytest.raises(shapely.GEOSException):
-            Polygon(p1).within(Polygon(p2))
+        g1 = Polygon(p1)
+        g2 = Polygon(p2)
+        assert not g1.is_valid
+        assert not g2.is_valid
+        if geos_version < (3, 13, 0):
+            with pytest.raises(shapely.GEOSException):
+                g1.within(g2)
+        else:  # resolved with RelateNG
+            assert not g1.within(g2)
 
     def test_relate_pattern(self):
         # a pair of partially overlapping polygons, and a nearby point


### PR DESCRIPTION
Follows #2086 to finally enable testing of Python 3.13 with NumPy 2.1. Currently, both these are available as release candidates. Also note that NumPy 2.0.x does not have any binary wheels out for Python 3.13.

I'm not sure when GEOS 3.13 is ready, but this would ideally be put under the "2024" item too when it's out.