### PR TITLE
DOC: Add blank line at docstring to fix the error of API documentation

### DIFF
--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -448,6 +448,7 @@ def coverage_union(a, b, **kwargs):
     <POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))>
 
     Union with None returns same polygon
+
     >>> normalize(coverage_union(polygon, None))
     <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
     """  # noqa: E501


### PR DESCRIPTION
This is a minor fix of docstring to fix the error of API documentation.
- https://shapely.readthedocs.io/en/latest/reference/shapely.coverage_union.html#shapely.coverage_union