### PR TITLE
TST: adjust for GEOS 3.13.0beta1

### DIFF
--- a/shapely/tests/legacy/test_operations.py
+++ b/shapely/tests/legacy/test_operations.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 import shapely
+from shapely import geos_version
 from shapely.errors import TopologicalError
 from shapely.geometry import GeometryCollection, LineString, MultiPoint, Point, Polygon
 from shapely.wkt import loads
@@ -81,8 +82,11 @@ class OperationsTestCase(unittest.TestCase):
             "(60 60, 80 60, 80 40, 60 40, 60 60))"
         )
         assert not invalid_polygon.is_valid
-        with pytest.raises((TopologicalError, shapely.GEOSException)):
-            invalid_polygon.relate(invalid_polygon)
+        if geos_version < (3, 13, 0):
+            with pytest.raises((TopologicalError, shapely.GEOSException)):
+                invalid_polygon.relate(invalid_polygon)
+        else:  # resolved with RelateNG
+            assert invalid_polygon.relate(invalid_polygon) == "2FFF1FFF2"
 
     def test_hausdorff_distance(self):
         point = Point(1, 1)

--- a/shapely/tests/legacy/test_predicates.py
+++ b/shapely/tests/legacy/test_predicates.py
@@ -5,6 +5,7 @@ import unittest
 import pytest
 
 import shapely
+from shapely import geos_version
 from shapely.geometry import Point, Polygon
 
 
@@ -64,8 +65,15 @@ class PredicatesTestCase(unittest.TestCase):
             (339, 207),
         ]
 
-        with pytest.raises(shapely.GEOSException):
-            Polygon(p1).within(Polygon(p2))
+        g1 = Polygon(p1)
+        g2 = Polygon(p2)
+        assert not g1.is_valid
+        assert not g2.is_valid
+        if geos_version < (3, 13, 0):
+            with pytest.raises(shapely.GEOSException):
+                g1.within(g2)
+        else:  # resolved with RelateNG
+            assert not g1.within(g2)
 
     def test_relate_pattern(self):
         # a pair of partially overlapping polygons, and a nearby point


### PR DESCRIPTION
See [changes](https://github.com/libgeos/geos/blob/3.13.0beta1/NEWS.md) for GEOS 3.13.0beta1.

The more significant change is with RelateNG, which is more tolerant with invalid geometries.

Changes to STRTree are also more tolerant with invalid geometries.