### PR TITLE
DOC/RLS: starts changelog for 2.0.6

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,14 @@ Breaking changes in GEOS 3.12:
   to "MULTIPOINT ((0 0), (1 1))". (#1885)
 
 
+2.0.6 (2024-08-19)
+------------------
+
+Bug fixes:
+
+- Fix compatibility with NumPy 2.1.0 (#2099).
+
+
 2.0.5 (2024-07-13)
 ------------------
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "Please cite this software using these metadata."
 type: software
 title: Shapely
-version: "2.0.5"
-date-released: "2024-07-13"
+version: "2.0.6"
+date-released: "2024-08-19"
 doi: 10.5281/zenodo.5597138
 abstract: "Manipulation and analysis of geometric objects in the Cartesian plane."
 repository-artifact: https://pypi.org/project/Shapely

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -13,6 +13,15 @@ Improvements:
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
   behaviour (allow) is backwards compatible (#1594).
 
+.. _version-2-0-6:
+
+Version 2.0.6 (2024-08-19)
+--------------------------
+
+Bug fixes:
+
+- Fix compatibility with NumPy 2.1.0 (#2099).
+
 .. _version-2-0-5:
 
 Version 2.0.5 (2024-07-13)


### PR DESCRIPTION
The next minor version of the 2.0.x series is anticipated sometime today, to fix compatibility with the just released numpy 2.1.0 (https://github.com/shapely/shapely/pull/2099)
