### PR TITLE
BLD: suppress 'incompatible-function-pointer-types' error for clang>=16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
             GEOS_CONFIG=${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}/bin/geos-config
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
+            CFLAGS='-Wno-error=incompatible-function-pointer-types'
           CIBW_ENVIRONMENT_WINDOWS:
             GEOS_INSTALL='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}'
             GEOS_LIBRARY_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\lib'


### PR DESCRIPTION
Starting with clang 16 ([announcement](https://discourse.llvm.org/t/clang-16-notice-of-potentially-breaking-changes/65562)), it started to default `-Wincompatible-function-pointer-types` to be on. This causes a bunch of hard errors in the wheel build for MacOS arm64 on the macos-14 image, like:

```
         src/ufuncs.c:213:47: error: incompatible function pointer types initializing 'PyUFuncGenericFunction' (aka 'void (*)(char **, long *, long *, void *)') with an expression of type 'void (*)(char **, const npy_intp *, const npy_intp *, void *)' (aka 'void (*)(char **, const long *, const long *, void *)') [-Wincompatible-function-pointer-types]
        static PyUFuncGenericFunction Y_b_funcs[1] = {&Y_b_func};
                                                      ^~~~~~~~~
```

In this case it seems to be the issue of `const long *` vs `long *`.

This could probably be fixed "properly", but for the time being (given this has been done like this for a long time and didn't give any problems, and to get CI green right now), this PR is suppressing those errors by passing `-Wno-error=incompatible-function-pointer-types`.

