### PR TITLE
BUG: fix to_geojson with empty point

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Changes
 Bug fixes:
 
 - Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13. (#1907)
+- Fixes GeoJSON serialization of empty points (#2118)
 
 Improvements:
 

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1254,9 +1254,7 @@ def test_to_geojson_exceptions():
         shapely.to_geojson(1)
 
 
-@pytest.mark.skipif(
-    (3, 10, 2) <= shapely.geos_version < (3, 10, 0), reason="3.10.2 <= GEOS < 3.10"
-)
+@pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 @pytest.mark.parametrize(
     "geom",
     [
@@ -1269,16 +1267,13 @@ def test_to_geojson_exceptions():
     ],
 )
 def test_to_geojson_point_empty(geom):
-    # Pending GEOS ticket: https://trac.osgeo.org/geos/ticket/1139
-    with pytest.raises(ValueError):
-        assert shapely.to_geojson(geom)
-
-
-@pytest.mark.skipif(shapely.geos_version < (3, 10, 2), reason="GEOS < 3.10.2")
-@pytest.mark.parametrize("geom", [empty_point])
-def test_to_geojson_single_point_empty(geom):
-    geojson = shapely.to_geojson(geom)
-    assert geojson == '{"type":"Point","coordinates":[]}'
+    if shapely.geos_version < (3, 10, 2):
+        # Pending GEOS ticket: https://trac.osgeo.org/geos/ticket/1139
+        with pytest.raises(ValueError):
+            assert shapely.to_geojson(geom)
+        return
+    # Else, just confirm that the operation succeed
+    shapely.to_geojson(geom)
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 1), reason="GEOS < 3.10.1")

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1254,7 +1254,9 @@ def test_to_geojson_exceptions():
         shapely.to_geojson(1)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")
+@pytest.mark.skipif(
+    (3, 10, 2) <= shapely.geos_version < (3, 10, 0), reason="3.10.2 <= GEOS < 3.10"
+)
 @pytest.mark.parametrize(
     "geom",
     [
@@ -1272,17 +1274,28 @@ def test_to_geojson_point_empty(geom):
         assert shapely.to_geojson(geom)
 
 
+@pytest.mark.skipif(shapely.geos_version < (3, 10, 2), reason="GEOS < 3.10.2")
+@pytest.mark.parametrize("geom", [empty_point])
+def test_to_geojson_point_empty(geom):
+    geojson = shapely.to_geojson(geom)
+    assert geojson == '{"type":"Point","coordinates":[]}'
+
+
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 1), reason="GEOS < 3.10.1")
 @pytest.mark.parametrize("geom", all_types)
 def test_geojson_all_types(geom):
     type_id = shapely.get_type_id(geom)
     if type_id == shapely.GeometryType.LINEARRING:
         pytest.skip("Linearrings are not preserved in GeoJSON")
-    elif geom.is_empty and (
-        type_id == shapely.GeometryType.POINT
-        or (
-            type_id == shapely.GeometryType.MULTIPOINT
-            and shapely.get_num_geometries(geom) > 0
+    elif (
+        shapely.geos_version < (3, 10, 2)
+        and geom.is_empty
+        and (
+            type_id == shapely.GeometryType.POINT
+            or (
+                type_id == shapely.GeometryType.MULTIPOINT
+                and shapely.get_num_geometries(geom) > 0
+            )
         )
     ):
         with pytest.raises(ValueError):  # same as test_to_geojson_point_empty

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1276,7 +1276,7 @@ def test_to_geojson_point_empty(geom):
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 2), reason="GEOS < 3.10.2")
 @pytest.mark.parametrize("geom", [empty_point])
-def test_to_geojson_point_empty(geom):
+def test_to_geojson_single_point_empty(geom):
     geojson = shapely.to_geojson(geom)
     assert geojson == '{"type":"Point","coordinates":[]}'
 

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1267,13 +1267,7 @@ def test_to_geojson_exceptions():
     ],
 )
 def test_to_geojson_point_empty(geom):
-    if shapely.geos_version < (3, 10, 2):
-        # Pending GEOS ticket: https://trac.osgeo.org/geos/ticket/1139
-        with pytest.raises(ValueError):
-            assert shapely.to_geojson(geom)
-        return
-    # Else, just confirm that the operation succeed
-    shapely.to_geojson(geom)
+    assert geom.equals(shapely.from_geojson(shapely.to_geojson(geom)))
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 1), reason="GEOS < 3.10.1")
@@ -1282,20 +1276,6 @@ def test_geojson_all_types(geom):
     type_id = shapely.get_type_id(geom)
     if type_id == shapely.GeometryType.LINEARRING:
         pytest.skip("Linearrings are not preserved in GeoJSON")
-    elif (
-        shapely.geos_version < (3, 10, 2)
-        and geom.is_empty
-        and (
-            type_id == shapely.GeometryType.POINT
-            or (
-                type_id == shapely.GeometryType.MULTIPOINT
-                and shapely.get_num_geometries(geom) > 0
-            )
-        )
-    ):
-        with pytest.raises(ValueError):  # same as test_to_geojson_point_empty
-            assert shapely.to_geojson(geom)
-        return
     geojson = shapely.to_geojson(geom)
     actual = shapely.from_geojson(geojson)
     assert not actual.has_z

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3543,18 +3543,6 @@ static void to_geojson_func(char** args, const npy_intp* dimensions, const npy_i
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
-      #define FIRST_CHAR(c, ...) c
-      #if FIRST_CHAR(GEOS_VERSION_PATCH) < 2
-      // Check for empty points (https://trac.osgeo.org/geos/ticket/1139)
-      point_empty_error = has_point_empty(ctx, in1);
-      if (point_empty_error == 2) {
-        errstate = PGERR_GEOS_EXCEPTION;
-        goto finish;
-      } else if (point_empty_error == 1) {
-        errstate = PGERR_GEOJSON_EMPTY_POINT;
-        goto finish;
-      }
-      #endif  // GEOS_VERSION_PATCH < 2
       geojson = GEOSGeoJSONWriter_writeGeometry_r(ctx, writer, in1, indent);
       if (geojson == NULL) {
         errstate = PGERR_GEOS_EXCEPTION;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3543,7 +3543,8 @@ static void to_geojson_func(char** args, const npy_intp* dimensions, const npy_i
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
-      #if (GEOS_VERSION_PATCH < 2) 
+      #define FIRST_CHAR(c, ...) c
+      #if FIRST_CHAR(GEOS_VERSION_PATCH) < 2
       // Check for empty points (https://trac.osgeo.org/geos/ticket/1139)
       point_empty_error = has_point_empty(ctx, in1);
       if (point_empty_error == 2) {
@@ -3553,7 +3554,7 @@ static void to_geojson_func(char** args, const npy_intp* dimensions, const npy_i
         errstate = PGERR_GEOJSON_EMPTY_POINT;
         goto finish;
       }
-      #endif  // GEOS_SINCE_3_10_0
+      #endif  // GEOS_VERSION_PATCH < 2
       geojson = GEOSGeoJSONWriter_writeGeometry_r(ctx, writer, in1, indent);
       if (geojson == NULL) {
         errstate = PGERR_GEOS_EXCEPTION;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3543,6 +3543,7 @@ static void to_geojson_func(char** args, const npy_intp* dimensions, const npy_i
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
+      #if (GEOS_VERSION_PATCH < 2) 
       // Check for empty points (https://trac.osgeo.org/geos/ticket/1139)
       point_empty_error = has_point_empty(ctx, in1);
       if (point_empty_error == 2) {
@@ -3552,6 +3553,7 @@ static void to_geojson_func(char** args, const npy_intp* dimensions, const npy_i
         errstate = PGERR_GEOJSON_EMPTY_POINT;
         goto finish;
       }
+      #endif  // GEOS_SINCE_3_10_0
       geojson = GEOSGeoJSONWriter_writeGeometry_r(ctx, writer, in1, indent);
       if (geojson == NULL) {
         errstate = PGERR_GEOS_EXCEPTION;


### PR DESCRIPTION
Fixes https://github.com/shapely/shapely/issues/2111

Serialization of empty points in GEOS has been fixed in [3.10.2](https://github.com/libgeos/geos/blob/7cb33c988bb0115f4fe107785570ae5786ed2401/NEWS#L73), so I updated the C code and tests to handle that.