### PR TITLE
MAINT: Drop GEOS 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.9.0, 3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
+        geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
         include:
           # 2019
           - python: 3.8
-            geos: 3.9.0  # this older version is here temporarily to allow matrix to work
+            geos: 3.9.5  # this is here temporarily to allow matrix to work
             numpy: 1.17.3
           # 2020
           - python: 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           # 2019
           - python: 3.8
-            geos: 3.9.0
+            geos: 3.9.0  # this older version is here temporarily to allow matrix to work
             numpy: 1.17.3
           # 2020
           - python: 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.8.4, 3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
+        geos: [3.9.0, 3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
         include:
           # 2019
           - python: 3.8
-            geos: 3.8.4
+            geos: 3.9.0
             numpy: 1.17.3
           # 2020
           - python: 3.9
@@ -56,7 +56,7 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: 3.8
-            geos: 3.8.4
+            geos: 3.9.5
             numpy: 1.16.2
           - os: windows-2019
             architecture: x86

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Requirements
 Shapely 2.1 requires
 
 * Python >=3.8
-* GEOS >=3.7
+* GEOS >=3.9
 * NumPy >=1.16
 
 Installing Shapely

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2614,7 +2614,6 @@ be parsed out.
 .. plot:: code/make_valid_geometrycollection.py
 
   `New in version 1.8`
-  `Requires GEOS > 3.8`
 
 The Shapely version, GEOS library version, and GEOS C API version are
 accessible via ``shapely.__version__``, ``shapely.geos_version_string``, and

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 ch = logging.StreamHandler()
 log.addHandler(ch)
 
-MIN_GEOS_VERSION = "3.8"
+MIN_GEOS_VERSION = "3.9"
 
 if "all" in sys.warnoptions:
     # show GEOS messages in console with: python -W all

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -45,10 +45,7 @@ def to_wkt(
 
     The following limitations apply to WKT serialization:
 
-    - for GEOS <= 3.8 a multipoint with an empty sub-geometry will raise an exception
-    - for GEOS <= 3.8 empty geometries are always serialized to 2D
-    - for GEOS >= 3.9 only simple empty geometries can be 3D, collections are still
-      always 2D
+    - only simple empty geometries can be 3D, collections are always 2D
 
     Parameters
     ----------
@@ -135,9 +132,6 @@ def to_wkb(
 
     - linearrings will be converted to linestrings
     - a point with only NaN coordinates is converted to an empty point
-    - for GEOS <= 3.7, empty points are always serialized to 3D if
-      output_dimension=3, and to 2D if output_dimension=2
-    - for GEOS == 3.8, empty points are always serialized to 2D
 
     Parameters
     ----------

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -45,7 +45,7 @@ def to_wkt(
 
     The following limitations apply to WKT serialization:
 
-    - only simple empty geometries can be 3D, collections are always 2D
+    - only simple empty geometries can be 3D, empty collections are always 2D
 
     Parameters
     ----------

--- a/shapely/linear.py
+++ b/shapely/linear.py
@@ -191,7 +191,6 @@ def shortest_line(a, b, **kwargs):
     See also
     --------
     prepare : improve performance by preparing ``a`` (the first argument)
-              (for GEOS>=3.9)
 
     Examples
     --------

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from shapely import GeometryType, lib
 from shapely.decorators import multithreading_enabled
-from shapely.errors import UnsupportedGEOSVersionError
 
 __all__ = [
     "difference",
@@ -34,8 +33,7 @@ def difference(a, b, grid_size=None, **kwargs):
     a : Geometry or array_like
     b : Geometry or array_like
     grid_size : float, optional
-        Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
-        precision of the inputs by default.
+        Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -63,11 +61,6 @@ def difference(a, b, grid_size=None, **kwargs):
     """
 
     if grid_size is not None:
-        if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSVersionError(
-                "grid_size parameter requires GEOS >= 3.9.0"
-            )
-
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 
@@ -92,8 +85,7 @@ def intersection(a, b, grid_size=None, **kwargs):
     a : Geometry or array_like
     b : Geometry or array_like
     grid_size : float, optional
-        Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
-        precision of the inputs by default.
+        Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -118,11 +110,6 @@ def intersection(a, b, grid_size=None, **kwargs):
     """
 
     if grid_size is not None:
-        if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSVersionError(
-                "grid_size parameter requires GEOS >= 3.9.0"
-            )
-
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 
@@ -192,8 +179,7 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     a : Geometry or array_like
     b : Geometry or array_like
     grid_size : float, optional
-        Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
-        precision of the inputs by default.
+        Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -218,11 +204,6 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     """
 
     if grid_size is not None:
-        if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSVersionError(
-                "grid_size parameter requires GEOS >= 3.9.0"
-            )
-
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 
@@ -293,8 +274,7 @@ def union(a, b, grid_size=None, **kwargs):
     a : Geometry or array_like
     b : Geometry or array_like
     grid_size : float, optional
-        Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
-        precision of the inputs by default.
+        Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -321,11 +301,6 @@ def union(a, b, grid_size=None, **kwargs):
     """
 
     if grid_size is not None:
-        if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSVersionError(
-                "grid_size parameter requires GEOS >= 3.9.0"
-            )
-
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 
@@ -355,8 +330,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     ----------
     geometries : array_like
     grid_size : float, optional
-        Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
-        precision of the inputs by default.
+        Precision grid size; will use the highest precision of the inputs by default.
     axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
@@ -408,11 +382,6 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     )
 
     if grid_size is not None:
-        if lib.geos_version < (3, 9, 0):
-            raise UnsupportedGEOSVersionError(
-                "grid_size parameter requires GEOS >= 3.9.0"
-            )
-
         if not np.isscalar(grid_size):
             raise ValueError("grid_size parameter only accepts scalar values")
 

--- a/shapely/tests/geometry/test_equality.py
+++ b/shapely/tests/geometry/test_equality.py
@@ -146,12 +146,7 @@ def test_equality_z():
 
     # different dimensionality with NaN z
     geom2 = Point(0, 1, np.nan)
-    if shapely.geos_version < (3, 10, 0):
-        # GEOS < 3.8 fill the NaN with 0, so the z dimension is different
-        # assert geom1 != geom2
-        # however, has_z still returns False, so z dimension is ignored in .coords
-        assert geom1 == geom2
-    elif shapely.geos_version < (3, 12, 0):
+    if shapely.geos_version < (3, 12, 0):
         # GEOS 3.10-3.11 ignore NaN for Z also when explicitly created with 3D
         # and so the geometries are considered as 2D (and thus z dimension is ignored)
         assert geom1 == geom2
@@ -253,17 +248,7 @@ def test_comparison_not_supported():
 def test_hash_same_equal(geom):
     hash1 = hash(geom)
     hash2 = hash(shapely.transform(geom, lambda x: x))
-    if (
-        geom.is_empty
-        and shapely.get_num_geometries(geom) > 0
-        and geom.geom_type not in {"MultiPoint", "Point"}
-        and shapely.geos_version < (3, 9, 0)
-    ):
-        # abnormal test for older GEOS version
-        assert hash1 != hash2, geom
-    else:
-        # normal test
-        assert hash1 == hash2, geom
+    assert hash1 == hash2, geom
 
 
 @pytest.mark.parametrize("geom", all_non_empty_types)

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -99,7 +99,6 @@ def test_reverse():
     assert result.coords[:] == coords[::-1]
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize(
     "op", ["union", "intersection", "difference", "symmetric_difference"]
 )

--- a/shapely/tests/legacy/test_pickle.py
+++ b/shapely/tests/legacy/test_pickle.py
@@ -77,8 +77,5 @@ if __name__ == "__main__":
     print(shapely.geos.geos_version)
 
     for name, geom in TEST_DATA.items():
-        if name == "emptypoint" and shapely.geos.geos_version < (3, 9, 0):
-            # Empty Points cannot be represented in WKB
-            continue
         with open(datadir / f"{name}_{shapely_version}.pickle", "wb") as f:
             pickle.dump(geom, f)

--- a/shapely/tests/legacy/test_wkb.py
+++ b/shapely/tests/legacy/test_wkb.py
@@ -7,7 +7,6 @@ import pytest
 
 from shapely import wkt
 from shapely.geometry import Point
-from shapely.geos import geos_version
 from shapely.tests.legacy.conftest import shapely20_todo
 from shapely.wkb import dump, dumps, load, loads
 
@@ -170,16 +169,6 @@ def test_point_empty():
     assert all(math.isnan(val) for val in coords)
 
 
-# Generally GEOS only serializes this correctly starting with GEOS 3.9
-# For some reason MacOS has different behaviour (it's actually correct for
-# older GEOS versions, but not for GEOS 3.8)
-@pytest.mark.xfail(
-    (
-        geos_version < (3, 9, 0)
-        and not (geos_version < (3, 8, 0) and sys.platform == "darwin")
-    ),
-    reason="GEOS >= 3.9.0 is required",
-)
 def test_point_z_empty():
     g = wkt.loads("POINT Z EMPTY")
     assert g.wkb_hex == hostorder(

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -63,9 +63,9 @@ def test_no_args_array(geometry, func):
         geometry.is_empty
         and shapely.get_num_geometries(geometry) > 0
         and func is shapely.node
-        and shapely.geos_version < (3, 8, 3)
+        and shapely.geos_version < (3, 9, 3)
     ):
-        pytest.xfail("GEOS < 3.8.3 crashes with empty geometries")  # GEOS GH-601
+        pytest.xfail("GEOS < 3.9.3 crashes with empty geometries")  # GEOS GH-601
     actual = func([geometry, geometry])
     assert actual.shape == (2,)
     assert actual[0] is None or isinstance(actual[0], Geometry)
@@ -74,13 +74,6 @@ def test_no_args_array(geometry, func):
 @pytest.mark.parametrize("geometry", all_types)
 @pytest.mark.parametrize("func", CONSTRUCTIVE_FLOAT_ARG)
 def test_float_arg_array(geometry, func):
-    if (
-        geometry.is_empty
-        and shapely.get_num_geometries(geometry) > 0
-        and (func is shapely.delaunay_triangles or func is shapely.voronoi_polygons)
-        and shapely.geos_version < (3, 8, 1)
-    ):
-        pytest.xfail("GEOS < 3.8.1 crashes with empty geometries")
     if (
         func is shapely.offset_curve
         and shapely.get_type_id(geometry) not in [1, 2]
@@ -509,12 +502,9 @@ def test_remove_repeated_points_invalid_type(geom, tolerance):
                 holes=[[(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]],
             ),
         ),
-        pytest.param(
+        (
             MultiLineString([[(0, 0), (1, 2)], [(3, 3), (4, 4)]]),
             MultiLineString([[(1, 2), (0, 0)], [(4, 4), (3, 3)]]),
-            marks=pytest.mark.skipif(
-                shapely.geos_version < (3, 8, 1), reason="GEOS < 3.8.1"
-            ),
         ),
         (
             MultiPolygon(
@@ -637,6 +627,15 @@ def test_clip_by_rect_polygon(geom, rect, expected):
 
 @pytest.mark.parametrize("geometry", all_types)
 def test_clip_by_rect_array(geometry):
+    if (
+        geometry.is_empty
+        and shapely.get_type_id(geometry) == 0
+        and shapely.geos_version < (3, 9, 5)
+    ):
+        # GEOS GH-913
+        with pytest.raises(GEOSException):
+            shapely.clip_by_rect([geometry, geometry], 0.0, 0.0, 1.0, 1.0)
+        return
     actual = shapely.clip_by_rect([geometry, geometry], 0.0, 0.0, 1.0, 1.0)
     assert actual.shape == (2,)
     assert actual[0] is None or isinstance(actual[0], Geometry)

--- a/shapely/tests/test_coordinates.py
+++ b/shapely/tests/test_coordinates.py
@@ -274,13 +274,7 @@ def test_transform_correct_coordinate_dimension():
 
 
 @pytest.mark.parametrize("geom", [
-    pytest.param(
-        empty_point_z,
-        marks=pytest.mark.skipif(
-            shapely.geos_version < (3, 9, 0),
-            reason="Empty points don't have a dimensionality before GEOS 3.9",
-        ),
-    ),
+    empty_point_z,
     empty_line_string_z,
 ])
 def test_transform_empty_preserve_z(geom):
@@ -290,13 +284,7 @@ def test_transform_empty_preserve_z(geom):
 
 
 @pytest.mark.parametrize("geom", [
-    pytest.param(
-        empty_point_z,
-        marks=pytest.mark.skipif(
-            shapely.geos_version < (3, 9, 0),
-            reason="Empty points don't have a dimensionality before GEOS 3.9",
-        ),
-    ),
+    empty_point_z,
     empty_line_string_z,
 ])
 def test_transform_remove_z(geom):

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -124,12 +124,7 @@ def test_points_handle_nan_allow(coords, expected_wkt):
 )
 def test_points_handle_nan(coords, handle_nan, expected_wkt):
     actual = shapely.points(coords, handle_nan=handle_nan)
-    # empty points have no dimensionality for GEOS < 3.9
-    if expected_wkt == "POINT Z EMPTY" and shapely.geos_version < (3, 9, 0):
-        allowed = {"POINT EMPTY", "POINT Z EMPTY"}
-    else:
-        allowed = {expected_wkt}
-    assert actual.wkt in allowed
+    assert actual.wkt in expected_wkt
 
 
 @pytest.mark.parametrize(

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -223,15 +223,6 @@ def test_get_m():
 
 @pytest.mark.parametrize("geom", all_types)
 def test_new_from_wkt(geom):
-    if geom.is_empty and shapely.get_num_geometries(geom) > 0:
-        # Older GEOS versions have various issues
-        if shapely.geos_version < (3, 9, 0) and geom.geom_type == "MultiPoint":
-            with pytest.raises(ValueError):
-                str(geom)
-            pytest.skip(
-                "GEOS < 3.9.0 does not support WKT of multipoint with empty points"
-            )
-
     actual = shapely.from_wkt(str(geom))
     if equal_geometries_abnormally_yield_unequal(geom):
         # abnormal test
@@ -251,17 +242,7 @@ def test_adapt_ptr_raises():
 @pytest.mark.parametrize("geom", all_types)
 def test_set_unique(geom):
     a = {geom, shapely.transform(geom, lambda x: x)}
-    if (
-        geom.is_empty
-        and shapely.get_num_geometries(geom) > 0
-        and geom.geom_type not in {"Point", "MultiPoint"}
-        and shapely.geos_version < (3, 9, 0)
-    ):
-        # unknown issue with older versions of GEOS
-        assert len(a) == 2
-    else:
-        # normal
-        assert len(a) == 1
+    assert len(a) == 1
 
 
 def test_set_nan():
@@ -506,7 +487,7 @@ def test_set_precision_z(mode):
 @pytest.mark.parametrize("mode", ("valid_output", "pointwise", "keep_collapsed"))
 def test_set_precision_nan(mode):
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")  # GEOS <= 3.9 emits warning for 'pointwise'
+        warnings.simplefilter("ignore")  # GEOS emits warnings
         actual = shapely.set_precision(line_string_nan, 1, mode=mode)
         assert_geometries_equal(actual, line_string_nan)
 
@@ -617,19 +598,16 @@ def test_set_precision_grid_size_nan():
 def test_set_precision_collapse(geometry, mode, expected):
     """Lines and polygons collapse to empty geometries if vertices are too close"""
     actual = shapely.set_precision(geometry, 1, mode=mode)
-    if shapely.geos_version < (3, 9, 0):
-        # pre GEOS 3.9 has difficulty comparing empty geometries exactly
-        # normalize and compare by WKT instead
-        assert shapely.to_wkt(shapely.normalize(actual)) == shapely.to_wkt(
-            shapely.normalize(expected)
-        )
-    else:
-        # force to 2D because GEOS 3.10 yields 3D geometries when they are empty.
-        assert_geometries_equal(shapely.force_2d(actual), expected)
+    assert_geometries_equal(
+        # force to 2D because of various dimension issues; GEOS GH-1152
+        shapely.force_2d(actual),
+        expected,
+        normalize=shapely.geos_version == (3, 9, 0),
+    )
 
 
 def test_set_precision_intersection():
-    """Operations should use the most precise presision grid size of the inputs"""
+    """Operations should use the most precise precision grid size of the inputs"""
 
     box1 = shapely.normalize(shapely.box(0, 0, 0.9, 0.9))
     box2 = shapely.normalize(shapely.box(0.75, 0, 1.75, 0.75))
@@ -683,10 +661,6 @@ def test_empty():
 
 # corresponding to geometry_collection_z:
 geometry_collection_2 = shapely.geometrycollections([point, line_string])
-empty_geom_mark = pytest.mark.skipif(
-    shapely.geos_version < (3, 9, 0),
-    reason="Empty points don't have a dimensionality before GEOS 3.9",
-)
 
 
 @pytest.mark.parametrize(
@@ -694,12 +668,12 @@ empty_geom_mark = pytest.mark.skipif(
     [
         (point, point),
         (point_z, point),
-        pytest.param(empty_point, empty_point, marks=empty_geom_mark),
-        pytest.param(empty_point_z, empty_point, marks=empty_geom_mark),
+        (empty_point, empty_point),
+        (empty_point_z, empty_point),
         (line_string, line_string),
         (line_string_z, line_string),
-        pytest.param(empty_line_string, empty_line_string, marks=empty_geom_mark),
-        pytest.param(empty_line_string_z, empty_line_string, marks=empty_geom_mark),
+        (empty_line_string, empty_line_string),
+        (empty_line_string_z, empty_line_string),
         (polygon, polygon),
         (polygon_z, polygon),
         (polygon_with_hole, polygon_with_hole),
@@ -725,12 +699,12 @@ def test_force_2d(geom, expected):
     [
         (point, point_z),
         (point_z, point_z),
-        pytest.param(empty_point, empty_point_z, marks=empty_geom_mark),
-        pytest.param(empty_point_z, empty_point_z, marks=empty_geom_mark),
+        (empty_point, empty_point_z),
+        (empty_point_z, empty_point_z),
         (line_string, line_string_z),
         (line_string_z, line_string_z),
-        pytest.param(empty_line_string, empty_line_string_z, marks=empty_geom_mark),
-        pytest.param(empty_line_string_z, empty_line_string_z, marks=empty_geom_mark),
+        (empty_line_string, empty_line_string_z),
+        (empty_line_string_z, empty_line_string_z),
         (polygon, polygon_z),
         (polygon_z, polygon_z),
         (polygon_with_hole, polygon_with_hole_z),

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -182,15 +182,6 @@ def test_from_wkt_on_invalid_unsupported_option():
 
 @pytest.mark.parametrize("geom", all_types)
 def test_from_wkt_all_types(geom):
-    if geom.is_empty and shapely.get_num_geometries(geom) > 0:
-        # Older GEOS versions have various issues
-        if shapely.geos_version < (3, 9, 0) and geom.geom_type == "MultiPoint":
-            with pytest.raises(ValueError):
-                shapely.to_wkt(geom)
-            pytest.skip(
-                "GEOS < 3.9.0 does not support WKT of multipoint with empty points"
-            )
-
     wkt = shapely.to_wkt(geom)
     actual = shapely.from_wkt(wkt)
 
@@ -419,8 +410,6 @@ def test_to_wkt_array_with_empty_z():
     # See GH-2004
     empty_wkt = ["POINT Z EMPTY", None, "POLYGON Z EMPTY"]
     empty_geoms = shapely.from_wkt(empty_wkt)
-    if shapely.geos_version < (3, 9, 0):
-        empty_wkt = ["POINT EMPTY", None, "POLYGON EMPTY"]
     assert list(shapely.to_wkt(empty_geoms)) == empty_wkt
 
 
@@ -436,10 +425,6 @@ def test_to_wkt_point_empty():
     assert shapely.to_wkt(empty_point) == "POINT EMPTY"
 
 
-@pytest.mark.skipif(
-    shapely.geos_version < (3, 9, 0),
-    reason="Empty geometries have no dimensionality on GEOS < 3.9",
-)
 @pytest.mark.parametrize(
     "wkt",
     [
@@ -460,10 +445,6 @@ def test_to_wkt_geometrycollection_with_point_empty():
     assert shapely.to_wkt(collection).endswith("(POINT EMPTY, POINT (2 3))")
 
 
-@pytest.mark.skipif(
-    shapely.geos_version < (3, 9, 0),
-    reason="MULTIPOINT (EMPTY, (2 3)) only works for GEOS >= 3.9",
-)
 def test_to_wkt_multipoint_with_point_empty():
     geom = shapely.multipoints([empty_point, point])
     if shapely.geos_version >= (3, 12, 0):
@@ -472,17 +453,6 @@ def test_to_wkt_multipoint_with_point_empty():
         # invalid WKT form
         expected = "MULTIPOINT (EMPTY, 2 3)"
     assert shapely.to_wkt(geom) == expected
-
-
-@pytest.mark.skipif(
-    shapely.geos_version >= (3, 9, 0),
-    reason="MULTIPOINT (EMPTY, 2 3) gives ValueError on GEOS < 3.9",
-)
-def test_to_wkt_multipoint_with_point_empty_errors():
-    # test if segfault is prevented
-    geom = shapely.multipoints([empty_point, point])
-    with pytest.raises(ValueError):
-        shapely.to_wkt(geom)
 
 
 @pytest.mark.parametrize("geom", [Point(1e100, 0), Point(0, 1e100)])
@@ -576,20 +546,6 @@ def test_repr_max_length():
     assert representation.endswith("...>")
 
 
-@pytest.mark.skipif(
-    shapely.geos_version >= (3, 9, 0),
-    reason="MULTIPOINT (EMPTY, 2 3) gives Exception on GEOS < 3.9",
-)
-def test_repr_multipoint_with_point_empty():
-    # Test if segfault is prevented
-    geom = shapely.multipoints([point, empty_point])
-    assert repr(geom) == "<shapely.MultiPoint Exception in WKT writer>"
-
-
-@pytest.mark.skipif(
-    shapely.geos_version < (3, 9, 0),
-    reason="Empty geometries have no dimensionality on GEOS < 3.9",
-)
 def test_repr_point_z_empty():
     assert repr(empty_point_z) == "<POINT Z EMPTY>"
 
@@ -838,9 +794,6 @@ def test_to_wkb_point_empty_2d(geom, expected):
     assert np.isnan(struct.unpack("<2d", actual[header_length:])).all()
 
 
-@pytest.mark.xfail(
-    shapely.geos_version[:2] == (3, 8), reason="GEOS==3.8 never outputs 3D empty points"
-)
 @pytest.mark.parametrize(
     "geom,expected",
     [
@@ -1013,9 +966,7 @@ def test_from_wkb_point_empty(wkb, expected_type, expected_dim):
     # POINT (nan nan) transforms to an empty point
     assert shapely.is_empty(geom)
     assert shapely.get_type_id(geom) == expected_type
-    # The dimensionality (2D/3D) is only read correctly for GEOS >= 3.9.0
-    if shapely.geos_version >= (3, 9, 0):
-        assert shapely.get_coordinate_dimension(geom) == expected_dim
+    assert shapely.get_coordinate_dimension(geom) == expected_dim
 
 
 @pytest.mark.skipif(

--- a/shapely/tests/test_linear.py
+++ b/shapely/tests/test_linear.py
@@ -56,9 +56,6 @@ def test_line_interpolate_point_float_array():
     ],
 )
 def test_line_interpolate_point_empty(geom, normalized):
-    # These geometries segfault in some versions of GEOS (in 3.8.0, still
-    # some of them segfault). Instead, we patched this to return POINT EMPTY.
-    # This matches GEOS 3.8.0 behavior on simple empty geometries.
     assert_geometries_equal(
         shapely.line_interpolate_point(geom, 0.2, normalized=normalized), empty_point
     )

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -42,10 +42,6 @@ def test_geos_version():
     assert actual == expected
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win") and shapely.geos_version[:2] == (3, 7),
-    reason="GEOS_C_API_VERSION broken for GEOS 3.7.x on Windows",
-)
 def test_geos_capi_version():
     expected = "{}.{}.{}-CAPI-{}.{}.{}".format(
         *(shapely.geos_version + shapely.geos_capi_version)

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -3,7 +3,6 @@ import pytest
 
 import shapely
 from shapely import Geometry, GeometryCollection, Polygon
-from shapely.errors import UnsupportedGEOSVersionError
 from shapely.testing import assert_geometries_equal
 from shapely.tests.common import all_types, empty, ignore_invalid, point, polygon
 
@@ -63,17 +62,6 @@ def test_set_operation_array(a, func):
     assert isinstance(actual[0], Geometry)
 
 
-@pytest.mark.skipif(shapely.geos_version >= (3, 9, 0), reason="GEOS >= 3.9")
-@pytest.mark.parametrize("func", SET_OPERATIONS)
-@pytest.mark.parametrize("grid_size", [0, 1])
-def test_set_operations_prec_not_supported(func, grid_size):
-    with pytest.raises(
-        UnsupportedGEOSVersionError, match="grid_size parameter requires GEOS >= 3.9.0"
-    ):
-        func(point, point, grid_size)
-
-
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("func", SET_OPERATIONS)
 def test_set_operation_prec_nonscalar_grid_size(func):
     with pytest.raises(
@@ -82,7 +70,6 @@ def test_set_operation_prec_nonscalar_grid_size(func):
         func(point, point, grid_size=[1])
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("a", all_single_types)
 @pytest.mark.parametrize("func", SET_OPERATIONS)
 @pytest.mark.parametrize("grid_size", [0, 1, 2])
@@ -184,17 +171,6 @@ def test_set_operation_reduce_all_none_arr(n, func, related_func):
     assert func([[None] * 2] * n, axis=0).tolist() == [empty, empty]
 
 
-@pytest.mark.skipif(shapely.geos_version >= (3, 9, 0), reason="GEOS >= 3.9")
-@pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
-@pytest.mark.parametrize("grid_size", [0, 1])
-def test_set_operation_prec_reduce_not_supported(func, related_func, grid_size):
-    with pytest.raises(
-        UnsupportedGEOSVersionError, match="grid_size parameter requires GEOS >= 3.9.0"
-    ):
-        func([point, point], grid_size)
-
-
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_nonscalar_grid_size(func, related_func):
     with pytest.raises(
@@ -203,14 +179,12 @@ def test_set_operation_prec_reduce_nonscalar_grid_size(func, related_func):
         func([point, point], grid_size=[1])
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_grid_size_nan(func, related_func):
     actual = func([point, point], grid_size=np.nan)
     assert actual is None
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("n", range(1, 5))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 @pytest.mark.parametrize("grid_size", [0, 1])
@@ -224,7 +198,6 @@ def test_set_operation_prec_reduce_1dim(n, func, related_func, grid_size):
     assert shapely.equals(actual, expected)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_axis(func, related_func):
     data = [[point] * 2] * 3  # shape = (3, 2)
@@ -238,7 +211,6 @@ def test_set_operation_prec_reduce_axis(func, related_func):
     assert actual.shape == (3,)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("none_position", range(3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_one_none(func, related_func, none_position):
@@ -249,7 +221,6 @@ def test_set_operation_prec_reduce_one_none(func, related_func, none_position):
     assert_geometries_equal(actual, expected)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("none_position", range(3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_two_none(func, related_func, none_position):
@@ -261,7 +232,6 @@ def test_set_operation_prec_reduce_two_none(func, related_func, none_position):
     assert_geometries_equal(actual, expected)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("n", range(1, 3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
 def test_set_operation_prec_reduce_all_none(n, func, related_func):
@@ -360,7 +330,6 @@ def test_coverage_union_non_polygon_inputs(geom_1, geom_2):
             shapely.coverage_union(geom_1, geom_2)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize(
     "geom,grid_size,expected",
     [
@@ -426,7 +395,6 @@ def test_union_all_prec(geom, grid_size, expected):
     assert shapely.equals(actual, expected)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 def test_uary_union_alias():
     geoms = [shapely.box(0.1, 0.1, 5, 5), shapely.box(0, 0.2, 5.1, 10)]
     actual = shapely.unary_union(geoms, grid_size=1)

--- a/shapely/tests/test_testing.py
+++ b/shapely/tests/test_testing.py
@@ -29,12 +29,6 @@ EMPTY_GEOMS = (
 line_string_reversed = shapely.linestrings([(0, 0), (1, 0), (1, 1)][::-1])
 
 
-PRE_GEOS_390 = pytest.mark.skipif(
-    shapely.geos_version < (3, 9, 0),
-    reason="2D and 3D empty geometries did not have dimensionality before GEOS 3.9",
-)
-
-
 def make_array(left, right, use_array):
     if use_array in ("left", "both"):
         left = np.array([left] * 3, dtype=object)
@@ -56,8 +50,8 @@ def test_assert_geometries_equal(geom, use_array):
         (point, line_string),
         (line_string, line_string_z),
         (empty_point, empty_polygon),
-        pytest.param(empty_point, empty_point_z, marks=PRE_GEOS_390),
-        pytest.param(empty_line_string, empty_line_string_z, marks=PRE_GEOS_390),
+        (empty_point, empty_point_z),
+        (empty_line_string, empty_line_string_z),
     ],
 )
 def test_assert_geometries_not_equal(geom1, geom2, use_array):

--- a/src/geos.c
+++ b/src/geos.c
@@ -40,8 +40,7 @@ void destroy_geom_arr(void* context, GEOSGeometry** array, int length) {
   }
 }
 
-/* These functions are used to workaround two GEOS issues (in WKB writer for
- * GEOS < 3.9, in WKT writer for GEOS < 3.9 and in GeoJSON writer for GEOS 3.10.0):
+/* These functions are used to workaround issues in GeoJSON writer for GEOS 3.10.0:
  * - POINT EMPTY was not handled correctly (we do it ourselves)
  * - MULTIPOINT (EMPTY) resulted in segfault (we check for it and raise)
  */
@@ -272,38 +271,6 @@ GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx, GEOSGeometry
   return result;
 }
 
-/* Checks whether the geometry is a multipoint with an empty point in it
- *
- * According to https://github.com/libgeos/geos/issues/305, this check is not
- * necessary for GEOS 3.7.3, 3.8.2, or 3.9. When these versions are out, we
- * should add version conditionals and test.
- *
- * The return value is one of:
- * - PGERR_SUCCESS
- * - PGERR_MULTIPOINT_WITH_POINT_EMPTY
- * - PGERR_GEOS_EXCEPTION
- */
-char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
-  char geom_type, is_empty;
-
-  geom_type = GEOSGeomTypeId_r(ctx, geom);
-  if (geom_type == -1) {
-    return PGERR_GEOS_EXCEPTION;
-  }
-  if (geom_type != GEOS_MULTIPOINT) {
-    return PGERR_SUCCESS;
-  }
-
-  is_empty = multipoint_has_point_empty(ctx, geom);
-  if (is_empty == 0) {
-    return PGERR_SUCCESS;
-  } else if (is_empty == 1) {
-    return PGERR_MULTIPOINT_WITH_POINT_EMPTY;
-  } else {
-    return PGERR_GEOS_EXCEPTION;
-  }
-}
-
 /* Checks whether the geometry contains a coordinate greater than 1E+100
  *
  * See also:
@@ -405,7 +372,6 @@ char get_zmax_collection(GEOSContextHandle_t ctx, const GEOSGeometry* geom,
 #if !GEOS_SINCE_3_13_0
 char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* geom,
                                   int dimension) {
-  char is_empty;
   double xmax = 0.0;
   double ymax = 0.0;
   double zmax = 0.0;
@@ -434,7 +400,7 @@ char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* g
 }
 #endif  // !GEOS_SINCE_3_13_0
 
-#if GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
+#if !GEOS_SINCE_3_12_0
 
 /* Checks whether the geometry is a 3D empty geometry and, if so, create the WKT string
  *
@@ -500,7 +466,7 @@ char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom, char** w
   return PGERR_SUCCESS;
 }
 
-#endif  // GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
+#endif  // !GEOS_SINCE_3_12_0
 
 /* GEOSInterpolate_r and GEOSInterpolateNormalized_r segfault on empty
  * geometries and also on collections with the first geometry empty.
@@ -510,9 +476,6 @@ char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom, char** w
  * - PGERR_EMPTY_GEOMETRY on empty linear geometries
  * - PGERR_EXCEPTIONS on GEOS exceptions
  * - PGERR_SUCCESS on a non-empty and linear geometry
- *
- * Note that GEOS 3.8 fixed this situation for empty LINESTRING/LINEARRING,
- * but it still segfaults on other empty geometries.
  */
 char geos_interpolate_checker(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
   char type;
@@ -706,25 +669,11 @@ GEOSGeometry* create_box(GEOSContextHandle_t ctx, double xmin, double ymin, doub
  */
 GEOSGeometry* PyGEOS_create3DEmptyPoint(GEOSContextHandle_t ctx) {
   GEOSGeometry* geom;
-#if GEOS_SINCE_3_8_0
-  coord_seq = GEOSCoordSeq_create_r(ctx, 0, 3);
+  GEOSCoordSequence* coord_seq = GEOSCoordSeq_create_r(ctx, 0, 3);
   if (coord_seq == NULL) {
     return NULL;
   }
   geom = GEOSGeom_createPoint_r(ctx, coord_seq);
-#else  // GEOS_SINCE_3_8_0
-  const char* wkt = "POINT Z EMPTY";
-
-  GEOSWKTReader* reader;
-
-  reader = GEOSWKTReader_create_r(ctx);
-  if (reader == NULL) {
-    return NULL;
-  }
-  geom = GEOSWKTReader_read_r(ctx, reader, wkt);
-  GEOSWKTReader_destroy_r(ctx, reader);
-
-#endif  // GEOS_SINCE_3_8_0
   return geom;
 }
 
@@ -742,15 +691,13 @@ GEOSGeometry* PyGEOS_create3DEmptyPoint(GEOSContextHandle_t ctx) {
  * GEOSGeometry* on success (owned by caller) or NULL on failure
  */
 GEOSGeometry* PyGEOS_createPoint(GEOSContextHandle_t ctx, double x, double y, double* z) {
-#if GEOS_SINCE_3_8_0
   if (z == NULL) {
     // There is no 3D equivalent for GEOSGeom_createPointFromXY_r
     // instead, it is constructed from a coord seq.
     return GEOSGeom_createPointFromXY_r(ctx, x, y);
   }
-#endif
 
-  // Fallback point construction (3D or GEOS < 3.8.0)
+  // Fallback point construction (3D)
   GEOSCoordSequence* coord_seq = NULL;
 
   coord_seq = GEOSCoordSeq_create_r(ctx, 1, z == NULL ? 2 : 3);
@@ -835,20 +782,6 @@ GEOSGeometry* force_dims_simple(GEOSContextHandle_t ctx, GEOSGeometry* geom, int
   unsigned int actual_dims, n, i, j;
   double coord;
   const GEOSCoordSequence* seq = GEOSGeom_getCoordSeq_r(ctx, geom);
-
-/* Special case for POINT EMPTY (on GEOS < 3.8, point coordinate list cannot be 0-length)
- */
-#if !GEOS_SINCE_3_8_0
-  if ((type == 0) && (GEOSisEmpty_r(ctx, geom) == 1)) {
-    if (dims == 2) {
-      return GEOSGeom_createEmptyPoint_r(ctx);
-    } else if (dims == 3) {
-      return PyGEOS_create3DEmptyPoint(ctx);
-    } else {
-      return NULL;
-    }
-  }
-#endif  // !GEOS_SINCE_3_8_0
 
   /* Investigate the coordinate sequence, return when already of correct dimensionality */
   if (GEOSCoordSeq_getDimensions_r(ctx, seq, &actual_dims) == 0) {

--- a/src/geos.h
+++ b/src/geos.h
@@ -159,7 +159,6 @@ enum ShapelyErrorCode {
   GEOS_finish_r(ctx);       \
   Py_END_ALLOW_THREADS GEOS_HANDLE_ERR
 
-#define GEOS_SINCE_3_9_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 9))
 #define GEOS_SINCE_3_10_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 10))
 #define GEOS_SINCE_3_11_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 11))
 #define GEOS_SINCE_3_12_0 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 12))
@@ -173,14 +172,13 @@ extern void destroy_geom_arr(void* context, GEOSGeometry** array, int length);
 extern char has_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 extern GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx,
                                                   GEOSGeometry* geom);
-extern char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 #if !GEOS_SINCE_3_13_0
 extern char check_to_wkt_trim_compatible(GEOSContextHandle_t ctx, const GEOSGeometry* geom, int dimension);
 #endif  // !GEOS_SINCE_3_13_0
-#if GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
+#if !GEOS_SINCE_3_12_0
 extern char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom,
                                   char** wkt);
-#endif  // GEOS_SINCE_3_9_0 && !GEOS_SINCE_3_12_0
+#endif  // !GEOS_SINCE_3_12_0
 extern char geos_interpolate_checker(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 
 extern int init_geos(PyObject* m);

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -94,13 +94,7 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
   }
 #endif  // !GEOS_SINCE_3_13_0
 
-#if !GEOS_SINCE_3_9_0
-  // Before GEOS 3.9.0, there was as segfault on e.g. MULTIPOINT (1 1, EMPTY)
-  errstate = check_to_wkt_compatible(ctx, geom);
-  if (errstate != PGERR_SUCCESS) {
-    goto finish;
-  }
-#elif !GEOS_SINCE_3_12_0
+#if !GEOS_SINCE_3_12_0
   // Since GEOS 3.9.0 and before 3.12.0 further handling required
   errstate = wkt_empty_3d_geometry(ctx, geom, &wkt);
   if (errstate != PGERR_SUCCESS) {
@@ -110,7 +104,7 @@ static PyObject* GeometryObject_ToWKT(GeometryObject* obj) {
     result = PyUnicode_FromString(wkt);
     goto finish;
   }
-#endif
+#endif // !GEOS_SINCE_3_12_0
 
   GEOSWKTWriter* writer = GEOSWKTWriter_create_r(ctx);
   if (writer == NULL) {
@@ -160,23 +154,7 @@ static PyObject* GeometryObject_ToWKB(GeometryObject* obj) {
   }
 
   GEOS_INIT;
-
-#if !GEOS_SINCE_3_9_0
-  // WKB Does not allow empty points in GEOS < 3.9.
-  // We check for that and patch the POINT EMPTY if necessary
-  has_empty = has_point_empty(ctx, obj->ptr);
-  if (has_empty == 2) {
-    errstate = PGERR_GEOS_EXCEPTION;
-    goto finish;
-  }
-  if (has_empty == 1) {
-    geom = point_empty_to_nan_all_geoms(ctx, obj->ptr);
-  } else {
-    geom = obj->ptr;
-  }
-#else
   geom = obj->ptr;
-#endif  // !GEOS_SINCE_3_9_0
 
   /* Create the WKB writer */
   writer = GEOSWKBWriter_create_r(ctx);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -693,9 +693,7 @@ static void* simplify_data[1] = {GEOSSimplify_r};
 static void* simplify_preserve_topology_data[1] = {GEOSTopologyPreserveSimplify_r};
 static void* force_3d_data[1] = {PyGEOSForce3D};
 
-#if GEOS_SINCE_3_9_0
 static void* unary_union_prec_data[1] = {GEOSUnaryUnionPrec_r};
-#endif
 
 #if GEOS_SINCE_3_10_0
 static void* segmentize_data[1] = {GEOSDensify_r};
@@ -1366,8 +1364,6 @@ finish:
 }
 static PyUFuncGenericFunction YYd_d_funcs[1] = {&YYd_d_func};
 
-#if GEOS_SINCE_3_9_0
-
 /* Define the geom, geom, double -> geom functions (YYd_Y) */
 static void* intersection_prec_data[1] = {GEOSIntersectionPrec_r};
 static void* difference_prec_data[1] = {GEOSDifferencePrec_r};
@@ -1423,7 +1419,6 @@ static void YYd_Y_func(char** args, const npy_intp* dimensions, const npy_intp* 
   free(geom_arr);
 }
 static PyUFuncGenericFunction YYd_Y_funcs[1] = {&YYd_Y_func};
-#endif
 
 /* Define functions with unique call signatures */
 static char box_dtypes[6] = {NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
@@ -2436,15 +2431,11 @@ static void shortest_line_func(char** args, const npy_intp* dimensions, const np
       geom_arr[i] = NULL;
       continue;
     }
-#if GEOS_SINCE_3_9_0
     if (in1_prepared != NULL) {
       coord_seq = GEOSPreparedNearestPoints_r(ctx, in1_prepared, in2);
     } else {
       coord_seq = GEOSNearestPoints_r(ctx, in1, in2);
     }
-#else
-    coord_seq = GEOSNearestPoints_r(ctx, in1, in2);
-#endif
     if (coord_seq == NULL) {
       errstate = PGERR_GEOS_EXCEPTION;
       destroy_geom_arr(ctx, geom_arr, i - 1);
@@ -3228,9 +3219,6 @@ static void to_wkb_func(char** args, const npy_intp* dimensions, const npy_intp*
   GEOSWKBWriter* writer;
   unsigned char* wkb;
   size_t size;
-#if !GEOS_SINCE_3_9_0
-  char has_empty;
-#endif  // !GEOS_SINCE_3_9_0
 
   if ((is2 != 0) || (is3 != 0) || (is4 != 0) || (is5 != 0) || (is6 != 0)) {
     PyErr_Format(PyExc_ValueError, "to_wkb function called with non-scalar parameters");
@@ -3280,33 +3268,12 @@ static void to_wkb_func(char** args, const npy_intp* dimensions, const npy_intp*
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
-#if !GEOS_SINCE_3_9_0
-      // WKB Does not allow empty points in GEOS<3.9.
-      // We check for that and patch the POINT EMPTY if necessary
-      has_empty = has_point_empty(ctx, in1);
-      if (has_empty == 2) {
-        errstate = PGERR_GEOS_EXCEPTION;
-        goto finish;
-      }
-      if (has_empty) {
-        temp_geom = point_empty_to_nan_all_geoms(ctx, in1);
-      } else {
-        temp_geom = in1;
-      }
-#else
       temp_geom = in1;
-#endif  // !GEOS_SINCE_3_9_0
       if (hex) {
         wkb = GEOSWKBWriter_writeHEX_r(ctx, writer, temp_geom, &size);
       } else {
         wkb = GEOSWKBWriter_write_r(ctx, writer, temp_geom, &size);
       }
-#if !GEOS_SINCE_3_9_0
-      // Destroy the temp_geom if it was patched (POINT EMPTY patch)
-      if (has_empty) {
-        GEOSGeom_destroy_r(ctx, temp_geom);
-      }
-#endif  // !GEOS_SINCE_3_9_0
       if (wkb == NULL) {
         errstate = PGERR_GEOS_EXCEPTION;
         goto finish;
@@ -3395,13 +3362,7 @@ static void to_wkt_func(char** args, const npy_intp* dimensions, const npy_intp*
         }
       }
 #endif  // !GEOS_SINCE_3_13_0
-#if !GEOS_SINCE_3_9_0
-      // Before GEOS 3.9.0, there was as segfault on e.g. MULTIPOINT (1 1, EMPTY)
-      errstate = check_to_wkt_compatible(ctx, in1);
-      if (errstate != PGERR_SUCCESS) {
-        goto finish;
-      }
-#elif !GEOS_SINCE_3_12_0
+#if !GEOS_SINCE_3_12_0
       // Since GEOS 3.9.0 and before 3.12.0 further handling required
       errstate = wkt_empty_3d_geometry(ctx, in1, &wkt);
       if (errstate != PGERR_SUCCESS) {
@@ -3412,7 +3373,7 @@ static void to_wkt_func(char** args, const npy_intp* dimensions, const npy_intp*
         *out = PyUnicode_FromString(wkt);
         continue;
       }
-#endif
+#endif  // !GEOS_SINCE_3_12_0
       wkt = GEOSWKTWriter_write_r(ctx, writer, in1);
       if (wkt == NULL) {
         errstate = PGERR_GEOS_EXCEPTION;
@@ -3759,6 +3720,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_Yd_Y(simplify);
   DEFINE_Yd_Y(simplify_preserve_topology);
   DEFINE_Yd_Y(force_3d);
+  DEFINE_Yd_Y(unary_union_prec);
 
   DEFINE_YY_Y(intersection);
   DEFINE_YY_Y(difference);
@@ -3825,13 +3787,10 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_CUSTOM(to_wkt, 5);
   DEFINE_CUSTOM(set_precision, 3);
 
-#if GEOS_SINCE_3_9_0
   DEFINE_YYd_Y(difference_prec);
   DEFINE_YYd_Y(intersection_prec);
   DEFINE_YYd_Y(symmetric_difference_prec);
   DEFINE_YYd_Y(union_prec);
-  DEFINE_Yd_Y(unary_union_prec);
-#endif
 
 #if GEOS_SINCE_3_10_0
   DEFINE_CUSTOM(make_valid_with_params, 3);


### PR DESCRIPTION
GEOS 3.8.4 reached it's EOL on 2023/11/12, thus it should be dropped for shapely's main branch.

The CI test matrix is substituted with GEOS 3.9.0 for now, as the number of combinations need to also include Python versions too (see #2119).

Many of the tests are simplified to remove conditionals.

<s>The C lib also contains some important corrections, which I may bring as a backport for maint-2.0.</s> (Update: the corrections only apply to main, thus should not be backported). There were some partially removed GEOS 3.7 features from #1885 that need refining, e.g. the def for `GEOS_SINCE_3_8_0` was removed, but there were still active blocks that used that def, now handled in this PR.