### PR TITLE
MAINT: drop Python 3.8 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Run ruff
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: cp36-* pp* *musllinux* *-manylinux_i686
+          CIBW_SKIP: pp* *musllinux* *-manylinux_i686
           CIBW_TEST_SKIP: "cp38-macosx_arm64"
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,6 @@ jobs:
         architecture: [x64]
         geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
         include:
-          # 2019
-          - python: 3.8
-            geos: 3.9.5  # this is here temporarily to allow matrix to work
-            numpy: 1.17.3
           # 2020
           - python: 3.9
             geos: 3.9.5
@@ -55,7 +51,7 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: 3.8
+            python: 3.9
             geos: 3.9.5
             numpy: 1.16.2
           - os: windows-2019
@@ -65,7 +61,7 @@ jobs:
             numpy: 1.24.4
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-22.04
-            python: "pypy3.8"
+            python: "pypy3.10"
             geos: 3.12.2
             numpy: 1.24.4
 
@@ -157,7 +153,7 @@ jobs:
 
       # Windows requires special treatment:
       # - geos-config does not exist, so we specify include and library paths
-      # - Python >=3.8 ignores the PATH for finding DLLs, so we copy them into the package
+      # - Python ignores the PATH for finding DLLs, so we copy them into the package
       - name: Set environment variables + copy DLLs (Windows)
         run: |
           cp geosinstall/geos-${{ matrix.geos }}/bin/*.dll shapely

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           # 2020
           - python: 3.9
             geos: 3.9.5
-            numpy: 1.19.5
+            numpy: 1.20.3
           # 2021
           - python: "3.10"
             geos: 3.10.6
@@ -53,7 +53,7 @@ jobs:
             architecture: x86
             python: 3.9
             geos: 3.9.5
-            numpy: 1.16.2
+            numpy: 1.20.3
           - os: windows-2019
             architecture: x86
             python: "3.11"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,7 @@ Bug fixes:
 
 Improvements:
 
-- Require GEOS >= 3.8, NumPy >= 1.16, and Python >= 3.8 (#1802, #1885)
+- Require GEOS >= 3.9, NumPy >= 1.19, and Python >= 3.9 (#1802, #1885, #2124)
 - Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,7 @@ Bug fixes:
 
 Improvements:
 
-- Require GEOS >= 3.9, NumPy >= 1.19, and Python >= 3.9 (#1802, #1885, #2124)
+- Require GEOS >= 3.9, NumPy >= 1.20, and Python >= 3.9 (#1802, #1885, #2124)
 - Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Shapely 2.1 requires
 
 * Python >=3.9
 * GEOS >=3.9
-* NumPy >=1.19
+* NumPy >=1.20
 
 Installing Shapely
 ==================

--- a/README.rst
+++ b/README.rst
@@ -111,9 +111,9 @@ Requirements
 
 Shapely 2.1 requires
 
-* Python >=3.8
+* Python >=3.9
 * GEOS >=3.9
-* NumPy >=1.16
+* NumPy >=1.19
 
 Installing Shapely
 ==================

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -55,7 +55,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    "pythons": ["3.12"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -8,7 +8,7 @@ Version 2.1.0 (unreleased)
 
 Improvements:
 
-- Require GEOS >= 3.7, NumPy >= 1.16, and Python >= 3.8 (#1802)
+- Require GEOS >= 3.9, NumPy >= 1.19, and Python >= 3.9 (#1802, #1885, #2124)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
   behaviour (allow) is backwards compatible (#1594).

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -8,7 +8,7 @@ Version 2.1.0 (unreleased)
 
 Improvements:
 
-- Require GEOS >= 3.9, NumPy >= 1.19, and Python >= 3.9 (#1802, #1885, #2124)
+- Require GEOS >= 3.9, NumPy >= 1.20, and Python >= 3.9 (#1802, #1885, #2124)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
   behaviour (allow) is backwards compatible (#1594).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.19",
+    "numpy>=1.20",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.16",
+    "numpy>=1.19",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.9"

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -214,11 +214,8 @@ class BaseGeometry(shapely.Geometry):
         """Return True if geometries are equal, else False."""
         if not isinstance(other, BaseGeometry):
             return NotImplemented
-        # equal_nan=False is the default, but not yet available for older numpy
-        # TODO updated once we require numpy >= 1.19
         return type(other) is type(self) and np.array_equal(
-            self.coords,
-            other.coords,  # , equal_nan=False
+            self.coords, other.coords, equal_nan=False
         )
 
     def __ne__(self, other):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -283,10 +283,9 @@ class Polygon(BaseGeometry):
         ]
         if not len(my_coords) == len(other_coords):
             return False
-        # equal_nan=False is the default, but not yet available for older numpy
         return np.all(
             [
-                np.array_equal(left, right)  # , equal_nan=False)
+                np.array_equal(left, right, equal_nan=False)
                 for left, right in zip(my_coords, other_coords)
             ]
         )

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -1,6 +1,7 @@
 """STRtree spatial index for efficient spatial queries."""
 
-from typing import Any, Iterable, Union
+from collections.abc import Iterable
+from typing import Any, Union
 
 import numpy as np
 


### PR DESCRIPTION
A first step following https://github.com/shapely/shapely/issues/2119 (after also dropping GEOS 3.8 in https://github.com/shapely/shapely/pull/2124), dropping at least Python 3.8.