### PR TITLE
MAINT: clean-up numpy build dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,8 @@ requires = [
     "Cython",
     # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
     # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
-    # define).  For older Python versions (where NumPy 1.25 is not yet available)
-    # continue using oldest-support-numpy.
-    "oldest-supported-numpy; python_version<'3.9'",
-    "numpy>=1.25; python_version>='3.9'",
+    # define).
+    "numpy>=1.25,<3",
     "setuptools>=61.0.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Now that we only support Python >= 3.9, we can remove the oldest-supported-numpy entirely. 

And also added a rough upper pin on numpy<3, because a numpy 3 would probably again mean ABI breaking changes that would require a re-build of packages.