### PR TITLE
BLD: refactor setup.py, consolidate define_macros, cleanup warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,9 +167,9 @@ jobs:
         # ensure we build against numpy nightly (numpy 2.0 compat)
         run: |
           if [ -z "${{ matrix.numpy }}" ]; then
-            pip install -e . --no-build-isolation
+            pip install -v -e . --no-build-isolation
           else
-            pip install -e .
+            pip install -v -e .
           fi
 
       - name: Overview of the Python environment (pip list)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-import builtins
+"""Setuptools build."""
+
 import logging
 import os
 import subprocess
@@ -6,7 +7,6 @@ import sys
 from pathlib import Path
 
 from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext as _build_ext
 
 # ensure the current directory is on sys.path so versioneer can be imported
 # when pip uses PEP 517/518 build rules.
@@ -33,7 +33,7 @@ if "all" in sys.warnoptions:
 
 
 def get_geos_config(option):
-    """Get configuration option from the `geos-config` development utility
+    """Get configuration option from the `geos-config` development utility.
 
     The PATH environment variable should include the path where geos-config is
     located, or the GEOS_CONFIG environment variable should point to the
@@ -41,7 +41,7 @@ def get_geos_config(option):
     """
     cmd = os.environ.get("GEOS_CONFIG", "geos-config")
     try:
-        proc = subprocess.run([cmd, option], capture_output=True, text=True)
+        proc = subprocess.run([cmd, option], capture_output=True, text=True, check=True)
     except OSError:
         return
     if proc.stderr and not proc.stdout:
@@ -52,8 +52,8 @@ def get_geos_config(option):
     return result
 
 
-def get_geos_paths():
-    """Obtain the paths for compiling and linking with the GEOS C-API
+def get_ext_options():
+    """Get Extension options to build using GEOS and NumPy C API.
 
     First the presence of the GEOS_INCLUDE_PATH and GEOS_INCLUDE_PATH environment
     variables is checked. If they are both present, these are taken.
@@ -61,24 +61,44 @@ def get_geos_paths():
     If one of the two paths was not present, geos-config is called (it should be on the
     PATH variable). geos-config provides all the paths.
 
-    If geos-config was not found, no additional paths are provided to the extension. It is
-    still possible to compile in this case using custom arguments to setup.py.
+    If geos-config was not found, no additional paths are provided to the extension.
+    It is still possible to compile in this case using custom arguments to setup.py.
     """
+    import numpy
+
+    opts = {
+        "define_macros": [
+            # avoid accidental use of non-reentrant functions
+            ("GEOS_USE_ONLY_R_API", None),
+            # silence warnings
+            ("NPY_NO_DEPRECATED_API", "0"),
+            # minimum numpy version
+            ("NPY_TARGET_VERSION", "NPY_1_20_API_VERSION"),
+        ],
+        "include_dirs": ["./src"],
+        "library_dirs": [],
+        "extra_link_args": [],
+        "libraries": [],
+    }
+
+    if include_dir := numpy.get_include():
+        opts["include_dirs"].append(include_dir)
+
+    # Without geos-config (e.g. MSVC), specify these two vars
     include_dir = os.environ.get("GEOS_INCLUDE_PATH")
     library_dir = os.environ.get("GEOS_LIBRARY_PATH")
     if include_dir and library_dir:
-        return {
-            "include_dirs": ["./src", include_dir],
-            "library_dirs": [library_dir],
-            "libraries": ["geos_c"],
-        }
+        opts["include_dirs"].append(include_dir)
+        opts["library_dirs"].append(library_dir)
+        opts["libraries"].append("geos_c")
+        return opts
 
     geos_version = get_geos_config("--version")
     if not geos_version:
         log.warning(
-            "Could not find geos-config executable. Either append the path to geos-config"
-            " to PATH or manually provide the include_dirs, library_dirs, libraries and "
-            "other link args for compiling against a GEOS version >=%s.",
+            "Could not find geos-config executable. Either append the path to "
+            "geos-config to PATH or manually provide the include_dirs, library_dirs, "
+            "libraries and other link args for compiling against a GEOS version >=%s.",
             MIN_GEOS_VERSION,
         )
         return {}
@@ -91,47 +111,19 @@ def get_geos_paths():
             f"GEOS version should be >={MIN_GEOS_VERSION}, found {geos_version}"
         )
 
-    libraries = []
-    library_dirs = []
-    include_dirs = ["./src"]
-    extra_link_args = []
     for item in get_geos_config("--cflags").split():
         if item.startswith("-I"):
-            include_dirs.extend(item[2:].split(":"))
+            opts["include_dirs"].extend(item[2:].split(":"))
 
     for item in get_geos_config("--clibs").split():
         if item.startswith("-L"):
-            library_dirs.extend(item[2:].split(":"))
+            opts["library_dirs"].extend(item[2:].split(":"))
         elif item.startswith("-l"):
-            libraries.append(item[2:])
+            opts["libraries"].append(item[2:])
         else:
-            extra_link_args.append(item)
+            opts["extra_link_args"].append(item)
 
-    return {
-        "include_dirs": include_dirs,
-        "library_dirs": library_dirs,
-        "libraries": libraries,
-        "extra_link_args": extra_link_args,
-    }
-
-
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-
-        # Add numpy include dirs without importing numpy on module level.
-        # derived from scikit-hep:
-        # https://github.com/scikit-hep/root_numpy/pull/292
-
-        # Prevent numpy from thinking it is still in its setup process:
-        try:
-            del builtins.__NUMPY_SETUP__
-        except AttributeError:
-            pass
-
-        import numpy
-
-        self.include_dirs.insert(0, numpy.get_include())
+    return opts
 
 
 ext_modules = []
@@ -151,10 +143,11 @@ if "clean" in sys.argv:
 elif "sdist" in sys.argv:
     if Path("LICENSE_GEOS").exists() or Path("LICENSE_win32").exists():
         raise FileExistsError(
-            "Source distributions should not pack LICENSE_GEOS or LICENSE_win32. Please remove the files."
+            "Source distributions should not pack LICENSE_GEOS or LICENSE_win32. "
+            "Please remove the files."
         )
 else:
-    ext_options = get_geos_paths()
+    ext_options = get_ext_options()
 
     ext_modules = [
         Extension(
@@ -181,16 +174,12 @@ else:
     cython_modules = [
         Extension(
             "shapely._geometry_helpers",
-            [
-                "shapely/_geometry_helpers.pyx",
-            ],
+            ["shapely/_geometry_helpers.pyx"],
             **ext_options,
         ),
         Extension(
             "shapely._geos",
-            [
-                "shapely/_geos.pyx",
-            ],
+            ["shapely/_geos.pyx"],
             **ext_options,
         ),
     ]
@@ -198,13 +187,10 @@ else:
     ext_modules += cythonize(
         cython_modules,
         compiler_directives={"language_level": "3"},
-        # enable once Cython >= 0.3 is released
-        # define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     )
 
 
 cmdclass = versioneer.get_cmdclass()
-cmdclass["build_ext"] = build_ext
 
 
 # see pyproject.toml for static project metadata

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -1,5 +1,3 @@
-# distutils: define_macros=GEOS_USE_ONLY_R_API
-
 cimport cython
 from cpython cimport PyObject
 from cython cimport view

--- a/shapely/_geos.pyx
+++ b/shapely/_geos.pyx
@@ -1,4 +1,3 @@
-# distutils: define_macros=GEOS_USE_ONLY_R_API
 #from shapely import GEOSException
 from libc.stdio cimport snprintf
 from libc.stdlib cimport free, malloc

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -7,7 +7,6 @@
  *
  ***********************************************************************/
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #define PyGEOS_API_Module

--- a/src/coords.c
+++ b/src/coords.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #include <math.h>

--- a/src/geos.c
+++ b/src/geos.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include "geos.h"
 
@@ -1059,8 +1058,7 @@ enum ShapelyErrorCode coordseq_from_buffer(GEOSContextHandle_t ctx, const double
                                            unsigned int size, unsigned int dims,
                                            char is_ring, int handle_nan, npy_intp cs1,
                                            npy_intp cs2, GEOSCoordSequence** coord_seq) {
-  char* cp1;
-  unsigned int i, j, first_i, last_i, actual_size;
+  unsigned int first_i, last_i, actual_size;
   double coord;
   char errstate;
   char ring_closure = 0;
@@ -1102,7 +1100,7 @@ enum ShapelyErrorCode coordseq_from_buffer(GEOSContextHandle_t ctx, const double
 #if GEOS_SINCE_3_10_0
   if ((!ring_closure) && ((last_i - first_i + 1) == actual_size)) {
     /* Initialize cp1 so that it points to the first coordinate (possibly skipping NaN)*/
-    cp1 = (char*)buf + cs1 * first_i;
+    char* cp1 = (char*)buf + cs1 * first_i;
     if ((cs1 == dims * 8) && (cs2 == 8)) {
       /* C-contiguous memory */
       int hasZ = dims == 3;
@@ -1137,7 +1135,7 @@ enum ShapelyErrorCode coordseq_from_buffer(GEOSContextHandle_t ctx, const double
   }
   /* add the closing coordinate if necessary */
   if (ring_closure) {
-    for (j = 0; j < dims; j++) {
+    for (unsigned int j = 0; j < dims; j++) {
       coord = *(double*)((char*)buf + first_i * cs1 + j * cs2);
       if (!GEOSCoordSeq_setOrdinate_r(ctx, *coord_seq, actual_size, j, coord)) {
         GEOSCoordSeq_destroy_r(ctx, *coord_seq);

--- a/src/geos.h
+++ b/src/geos.h
@@ -10,10 +10,16 @@
 #endif
 
 // wrap geos.h import to silence geos gcc warnings
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+
 #include <geos_c.h>
+
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 /* Macros to setup GEOS Context and error handlers
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include "pygeom.h"
 

--- a/src/pygeos.c
+++ b/src/pygeos.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #include <float.h>

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #include <math.h>
@@ -400,7 +399,6 @@ static void Ydd_b_p_func(char** args, const npy_intp* dimensions, const npy_intp
 #endif
   GEOSGeometry* in1 = NULL;
   GEOSPreparedGeometry* in1_prepared = NULL;
-  GEOSGeometry *geom = NULL;
   const GEOSPreparedGeometry* prepared_geom_tmp = NULL;
   char ret;
 
@@ -438,6 +436,7 @@ static void Ydd_b_p_func(char** args, const npy_intp* dimensions, const npy_intp
 #if GEOS_SINCE_3_12_0
       ret = func(ctx, prepared_geom_tmp, in2, in3);
 #else
+      GEOSGeometry *geom = NULL;
       errstate = create_point(ctx, in2, in3, NULL, SHAPELY_HANDLE_NAN_ALLOW, &geom);
       if (errstate != PGERR_SUCCESS) {
         if (destroy_prepared) {
@@ -2542,7 +2541,6 @@ static PyUFuncGenericFunction set_precision_funcs[1] = {&set_precision_func};
 static char points_dtypes[3] = {NPY_DOUBLE, NPY_INT, NPY_OBJECT};
 static void points_func(char** args, const npy_intp* dimensions, const npy_intp* steps,
                         void* data) {
-  GEOSCoordSequence* coord_seq = NULL;
   GEOSGeometry** geom_arr;
 
   // check the ordinate dimension before calling GEOSCoordSeq_create_r
@@ -2959,9 +2957,6 @@ static PyUFuncGenericFunction create_collection_funcs[1] = {&create_collection_f
 static char bounds_dtypes[2] = {NPY_OBJECT, NPY_DOUBLE};
 static void bounds_func(char** args, const npy_intp* dimensions, const npy_intp* steps, void* data) {
   GEOSGeometry *envelope = NULL, *in1;
-  const GEOSGeometry* ring;
-  const GEOSCoordSequence* coord_seq;
-  int size;
   char *ip1 = args[0], *op1 = args[1];
   double *x1, *y1, *x2, *y2;
 
@@ -3214,8 +3209,10 @@ static char to_wkb_dtypes[7] = {NPY_OBJECT, NPY_BOOL, NPY_INT,
                                 NPY_INT,    NPY_BOOL, NPY_INT,
                                 NPY_OBJECT};
 static void to_wkb_func(char** args, const npy_intp* dimensions, const npy_intp* steps, void* data) {
-  char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *ip4 = args[3], *ip5 = args[4],
-       *ip6 = args[5], *op1 = args[6];
+  char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *ip4 = args[3], *ip5 = args[4], *op1 = args[6];
+#if GEOS_SINCE_3_10_0
+  char *ip6 = args[5];
+#endif
   npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2], is4 = steps[3], is5 = steps[4],
            is6 = steps[5], os1 = steps[6];
   npy_intp n = dimensions[0];

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,5 +1,4 @@
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #include <structmember.h>


### PR DESCRIPTION
This refactors the setuptools-based build with a few changes:

- Rename `get_geos_paths()` to `get_ext_options()`, which also embeds NumPy include dir.
- Also use `define_macros` (aka `-D`) for `GEOS_USE_ONLY_R_API`, `NPY_NO_DEPRECATED_API`, and `NPY_TARGET_VERSION`
- Remove custom `build_ext` cmdclass, which used to embed NumPy include dir. This references a PR from 8 years ago as a workaround for some issue that is probably historic by now (although I don't fully understand what the issue was)
- Use ruff check / format on setup.py to bring it to the same standard as other Python sources
- Resolve a few basic C-level warnings; there are still other unresolved warnings
- Remove macros from source files, as they are moved to `define_macros` in setup.py
- Add `-v` for verbose builds in CI to see compilation commands and warnings

I'd think it's fine for the 2.1 release series to keep with setuptools-based build, but future 2.2 development should aim to have a [meson-python build](https://mesonbuild.com/meson-python/) (I have some [work-in-progress here](https://github.com/mwtoews/shapely/tree/meson-python)).