### PR TITLE
TST: minor bump to geos-3.13.0 and numpy-2.1.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta2, main]
+        geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0, main]
         include:
           # 2020
           - python: 3.9
@@ -37,7 +37,7 @@ jobs:
             extra_pytest_args: "-W error"  # error on warnings
           # 2024
           - python: "3.13"
-            geos: 3.13.0beta2
+            geos: 3.13.0
             numpy: 2.1.1
           # apple silicon
           - os: macos-14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-2019]
         architecture: [x64]
-        geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta1, main]
+        geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0beta2, main]
         include:
           # 2020
           - python: 3.9
@@ -37,8 +37,8 @@ jobs:
             extra_pytest_args: "-W error"  # error on warnings
           # 2024
           - python: "3.13"
-            geos: 3.13.0beta1
-            numpy: 2.1.0
+            geos: 3.13.0beta2
+            numpy: 2.1.1
           # apple silicon
           - os: macos-14
             python: "3.12"


### PR DESCRIPTION
Test latest deps, released today.

Holding until geos-3.13 is released, then I'll modify this PR.