### PR TITLE
MNT: Add Python 3.13t free threading support to the extensions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,9 @@ jobs:
           # once Cython has an official release that supports free threading we can remove this
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: |
-            pip install --pre cython &&
+            # For free threading support in Cython install a pre-release version of Cython
+            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
+            pip install $PRE_FLAG cython &&
             pip install numpy setuptools wheel
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.baseimage }}_geos:${{ env.GEOS_VERSION }}
@@ -208,10 +210,14 @@ jobs:
           # once Cython and numpy have official releases that support free threading we can remove this
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: |
-            pip install --pre cython &&
+            # For free threading support in Cython install a pre-release version of Cython
+            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
+            pip install $PRE_FLAG cython &&
             pip install numpy setuptools wheel
           CIBW_BEFORE_BUILD_WINDOWS:
-            pip install --pre cython &&
+            # For free threading support in Cython install a pre-release version of Cython
+            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
+            pip install $PRE_FLAG cython &&
             pip install numpy setuptools wheel &&
             pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: |
             # For free threading support in Cython install a pre-release version of Cython
-            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
-            pip install $PRE_FLAG cython &&
+            python -c "import sysconfig, subprocess; subprocess.check_call(['pip', 'install', '--pre', 'cython'] if sysconfig.get_config_var('Py_GIL_DISABLED') else ['pip', 'install', 'cython'])" &&
             pip install numpy setuptools wheel
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.baseimage }}_geos:${{ env.GEOS_VERSION }}
@@ -211,13 +210,11 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: |
             # For free threading support in Cython install a pre-release version of Cython
-            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
-            pip install $PRE_FLAG cython &&
+            python -c "import sysconfig, subprocess; subprocess.check_call(['pip', 'install', '--pre', 'cython'] if sysconfig.get_config_var('Py_GIL_DISABLED') else ['pip', 'install', 'cython'])" &&
             pip install numpy setuptools wheel
           CIBW_BEFORE_BUILD_WINDOWS:
             # For free threading support in Cython install a pre-release version of Cython
-            PRE_FLAG="$(python -c"import sysconfig; print('--pre' if sysconfig.get_config_var('Py_GIL_DISABLED') else '')")" &&
-            pip install $PRE_FLAG cython &&
+            python -c "import sysconfig, subprocess; subprocess.check_call(['pip', 'install', '--pre', 'cython'] if sysconfig.get_config_var('Py_GIL_DISABLED') else ['pip', 'install', 'cython'])" &&
             pip install numpy setuptools wheel &&
             pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,13 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
+          # TEMP don't use automated/isolated build environment, but manually
+          # install build dependencies so we can build with cython 3.1.0a0
+          # once Cython has an official release that supports free threading we can remove this
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD: |
+            pip install --pre cython &&
+            pip install numpy setuptools wheel
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.baseimage }}_geos:${{ env.GEOS_VERSION }}
           CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.baseimage }}_geos:${{ env.GEOS_VERSION }}
@@ -196,7 +203,17 @@ jobs:
             GEOS_INCLUDE_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\include'
           CIBW_BEFORE_ALL_MACOS: ./ci/install_geos.sh
           CIBW_BEFORE_ALL_WINDOWS: ci\install_geos.cmd
-          CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
+          # TEMP don't use automated/isolated build environment, but manually
+          # install build dependencies so we can build with cython 3.1.0a0
+          # once Cython and numpy have official releases that support free threading we can remove this
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD: |
+            pip install --pre cython &&
+            pip install numpy setuptools wheel
+          CIBW_BEFORE_BUILD_WINDOWS:
+            pip install --pre cython &&
+            pip install numpy setuptools wheel &&
+            pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}
 
       - name: Upload artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,10 @@ jobs:
           - python: "3.13"
             geos: 3.13.0
             numpy: 2.1.1
+          # free threaded Python (no numpy version to indicate installing nightly cython and numpy)
+          - os: ubuntu-22.04
+            python: "3.13t"
+            geos: 3.13.0
           # apple silicon
           - os: macos-14
             python: "3.12"
@@ -96,7 +100,7 @@ jobs:
         if: ${{ matrix.geos == 'main' }}
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796  # v5.3.1
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
@@ -126,8 +130,8 @@ jobs:
           pip config set global.progress_bar off
           pip install --upgrade wheel setuptools
           if [ -z "${{ matrix.numpy }}" ]; then
-            pip install --upgrade --pre Cython pytest pytest-cov coveralls;
-            pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+            pip install --upgrade --pre pytest pytest-cov coveralls;
+            pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           else
             pip install --upgrade Cython numpy==${{ matrix.numpy }} pytest pytest-cov coveralls;
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ skip = ["pp*", "*_i686", "*_ppc64le", "*_s390x"]
 build-verbosity = 1
 test-requires = "pytest"
 test-command = "pytest --pyargs shapely.tests"
+free-threaded-support = true
 
 [tool.coverage.run]
 source = ["shapely"]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import versioneer
 
 # Skip Cython build if not available
 try:
+    import cython
     from Cython.Build import cythonize
 except ImportError:
     cythonize = None
@@ -183,10 +184,12 @@ else:
             **ext_options,
         ),
     ]
-
+    compiler_directives = {"language_level": "3"}
+    if cython.__version__ >= "3.1.0":
+        compiler_directives.update({"freethreading_compatible": True})
     ext_modules += cythonize(
         cython_modules,
-        compiler_directives={"language_level": "3"},
+        compiler_directives=compiler_directives,
     )
 
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -43,6 +43,11 @@ PyMODINIT_FUNC PyInit_lib(void) {
     return NULL;
   }
 
+  /* Work with freethreaded Python */
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+  #endif
+
   if (init_geos(m) < 0) {
     return NULL;
   };


### PR DESCRIPTION
This declares the package as supporting nogil Python releases. I have tested it locally and it works as expected. Without this I get a warning that shapely doesn't support the nogil free threading, without this it runs as expected and passes the tests.

Some links for information on what I am updating here.

Update to the module definition:
https://py-free-threading.github.io/porting/#__tabbed_1_1

CI testing:
Added installation from the deadsnakes setup-python version, which I think will only work on the ubuntu runner:
https://py-free-threading.github.io/ci/

cibuildwheel support to build the free threaded wheels:
https://cibuildwheel.pypa.io/en/stable/options/#free-threaded-support

xref: #2137