### PR TITLE
PERF: prepare single geometry input to contains_xy and intersects_xy

### DIFF
--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -1261,6 +1261,8 @@ def contains_xy(geom, x, y=None, **kwargs):
     if y is None:
         coords = np.asarray(x)
         x, y = coords[:, 0], coords[:, 1]
+    if isinstance(geom, lib.Geometry):
+        lib.prepare(geom)
     return lib.contains_xy(geom, x, y, **kwargs)
 
 
@@ -1310,4 +1312,6 @@ def intersects_xy(geom, x, y=None, **kwargs):
     if y is None:
         coords = np.asarray(x)
         x, y = coords[:, 0], coords[:, 1]
+    if isinstance(geom, lib.Geometry):
+        lib.prepare(geom)
     return lib.intersects_xy(geom, x, y, **kwargs)

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -143,18 +143,20 @@ def test_xy_array(a, func, func_bin):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func, func_bin", XY_PREDICATES)
 def test_xy_array_broadcast(a, func, func_bin):
+    a2 = shapely.transform(a, lambda x: x)  # makes a copy
     with ignore_invalid(shapely.is_empty(a) and shapely.geos_version < (3, 12, 0)):
         # Empty geometries give 'invalid value encountered' in all predicates
         # (see https://github.com/libgeos/geos/issues/515)
-        actual = func(a, [0, 1, 2], [1, 2, 3])
+        actual = func(a2, [0, 1, 2], [1, 2, 3])
         expected = func_bin(a, [Point(0, 1), Point(1, 2), Point(2, 3)])
     np.testing.assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize("func", [funcs[0] for funcs in XY_PREDICATES])
 def test_xy_array_2D(func):
-    actual = func(polygon, [0, 1, 2], [1, 2, 3])
-    expected = func(polygon, [[0, 1], [1, 2], [2, 3]])
+    polygon2 = shapely.transform(polygon, lambda x: x)  # makes a copy
+    actual = func(polygon2, [0, 1, 2], [1, 2, 3])
+    expected = func(polygon2, [[0, 1], [1, 2], [2, 3]])
     np.testing.assert_allclose(actual, expected)
 
 
@@ -168,7 +170,8 @@ def test_xy_prepared(func, func_bin):
 @pytest.mark.parametrize("func", [funcs[0] for funcs in XY_PREDICATES])
 def test_xy_with_kwargs(func):
     out = np.empty((), dtype=np.uint8)
-    actual = func(point, point.x, point.y, out=out)
+    point2 = shapely.transform(point, lambda x: x)  # makes a copy
+    actual = func(point2, point2.x, point2.y, out=out)
     assert actual is out
     assert actual.dtype == np.uint8
 


### PR DESCRIPTION
Closes #1734

See https://github.com/shapely/shapely/issues/1726#issuecomment-1399434147 for example of performance impact

Still need to update the docstring, if we want to do this.