### PR TITLE
COMPAT: MultiPoint/LineString constructor to iterate directly over in put to avoid getitem access

### DIFF
--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -44,10 +44,9 @@ class MultiLineString(BaseMultipartGeometry):
             return lines
 
         lines = getattr(lines, "geoms", lines)
-        m = len(lines)
         subs = []
-        for i in range(m):
-            line = linestring.LineString(lines[i])
+        for item in lines:
+            line = linestring.LineString(item)
             if line.is_empty:
                 raise EmptyPartError(
                     "Can't create MultiLineString with empty component"

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -48,10 +48,9 @@ class MultiPoint(BaseMultipartGeometry):
         elif isinstance(points, MultiPoint):
             return points
 
-        m = len(points)
         subs = []
-        for i in range(m):
-            p = point.Point(points[i])
+        for item in points:
+            p = point.Point(item)
             if p.is_empty:
                 raise EmptyPartError("Can't create MultiPoint with empty component")
             subs.append(p)


### PR DESCRIPTION
Closes #2122

This avoids the warning if the sequence of points/lines being passed is a pandas series. I didn't add a test that covers the original use case, because that would require pandas and for now we don't have any optional (geo)pandas usage in the tests, which would be good to keep that way. 
But I think it is also a valid python code simplification in itself.