### PR TITLE
FIX: remove unnecessary precision with GEOS 3.13 repr

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -171,7 +171,7 @@ class BaseGeometry(shapely.Geometry):
     def __repr__(self):
         """Return a string representation of the geometry."""
         try:
-            wkt = super().__str__()
+            wkt = super().__str__()  # GeometryObject_ToWKT
         except (GEOSException, ValueError):
             # we never want a repr() to fail; that can be very confusing
             return f"<shapely.{self.__class__.__name__} Exception in WKT writer>"

--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -648,6 +648,9 @@ def test_to_wkt_large_float_no_trim():
 def test_repr():
     assert repr(point) == "<POINT (2 3)>"
     assert repr(point_z) == "<POINT Z (2 3 4)>"
+    # Default preserves precision; GH-2199
+    geom = shapely.from_wkt("LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)")
+    assert repr(geom) == "<LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)>"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This fixes some confusing geometry repr outputs using GEOS 3.13.0:
```pycon
>>> import shapely
>>> shapely.geos_version_string
3.13.0
>>> line = shapely.LineString([(0.1, 0.1), (0.49, 0.51), (1.01, 0.89)])
>>> line.wkt
LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
>>> line
<LINESTRING (0.1 0.1, 0.5 0.5, 1.01 0.9)>
```
the expected last line should be `<LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)>`.

This is was due to some logic in shapely for GEOS 3.13 that calls `GEOSWKTWriter_setRoundingPrecision` with a precision of 3 and trim enabled. This specific option combo does some weird things with some versions of GEOS (see https://github.com/libgeos/geos/pull/1199). A fix is to remove the call to setRoundingPrecision and keep GEOS' default.

Also, clean-up unused C code for `GeometryObject_repr`, since this is implemented in Python.