### PR TITLE
DOC/RLS: starts changelog for 2.0.7

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -62,6 +62,14 @@ Packaging:
 
 - Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
 
+2.0.7 (2025-01-30)
+------------------
+
+Bug fixes:
+
+- Fix compilation error on certain Linux platforms, such as Alpine (#1945).
+- Fix to prevent crash when reading nonlinear types from WKB/WKT (#2160).
+- Fix the ``project`` method to return a Python float (#2093).
 
 2.0.6 (2024-08-19)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,10 +9,6 @@ Bug fixes:
 - Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13. (#1907)
 - Fixes GeoJSON serialization of empty points (#2118)
 - Fixes `__geo_interface__` handling of empty points (#2120)
-- Fixes crash when reading nonlinear geometry types (CircularString,
-  CompoundCurve, MultiCurve, CurvePolygon, MultiSurface) from WKB/WKT with
-  GEOS >= 3.13; these types are not yet supported in Shapely and now raise a
-  ``NotImplementedError`` (#2160)
 
 Improvements:
 
@@ -68,7 +64,10 @@ Packaging:
 Bug fixes:
 
 - Fix compilation error on certain Linux platforms, such as Alpine (#1945).
-- Fix to prevent crash when reading nonlinear types from WKB/WKT (#2160).
+- Fixes crash when reading nonlinear geometry types (CircularString,
+  CompoundCurve, MultiCurve, CurvePolygon, MultiSurface) from WKB/WKT with
+  GEOS >= 3.13; these types are not yet supported in Shapely and now raise a
+  ``NotImplementedError`` (#2160)
 - Fix the ``project`` method to return a Python float (#2093).
 
 2.0.6 (2024-08-19)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "Please cite this software using these metadata."
 type: software
 title: Shapely
-version: "2.0.6"
-date-released: "2024-08-19"
+version: "2.0.7"
+date-released: "2025-01-30"
 doi: 10.5281/zenodo.5597138
 abstract: "Manipulation and analysis of geometric objects in the Cartesian plane."
 repository-artifact: https://pypi.org/project/Shapely

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ os.environ["SPHINX_DOC_BUILD"] = "1"
 # -- Project information -----------------------------------------------------
 
 project = 'Shapely'
-copyright = '2011-2023, Sean Gillies and Shapely contributors'
+copyright = '2011-2025, Sean Gillies and Shapely contributors'
 
 # The full version, including alpha/beta/rc tags.
 import shapely

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -20,6 +20,17 @@ Improvements:
   ``shapely.linearrings()`` to allow, skip, or error on nonfinite (NaN / Inf)
   coordinates. The default behaviour (allow) is backwards compatible (#1594).
 
+.. _version-2-0-7:
+
+Version 2.0.7 (2025-01-30)
+--------------------------
+
+Bug fixes:
+
+- Fix compilation error on certain Linux platforms, such as Alpine (#1945).
+- Fix to prevent crash when reading nonlinear types from WKB/WKT (#2160).
+- Fix the ``project`` method to return a Python float (#2093).
+
 .. _version-2-0-6:
 
 Version 2.0.6 (2024-08-19)

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -28,7 +28,10 @@ Version 2.0.7 (2025-01-30)
 Bug fixes:
 
 - Fix compilation error on certain Linux platforms, such as Alpine (#1945).
-- Fix to prevent crash when reading nonlinear types from WKB/WKT (#2160).
+- Fixes crash when reading nonlinear geometry types (CircularString,
+  CompoundCurve, MultiCurve, CurvePolygon, MultiSurface) from WKB/WKT with
+  GEOS >= 3.13; these types are not yet supported in Shapely and now raise a
+  ``NotImplementedError`` (#2160)
 - Fix the ``project`` method to return a Python float (#2093).
 
 .. _version-2-0-6:


### PR DESCRIPTION
For doing a quick 2.0.7 (https://github.com/shapely/shapely/issues/2208)