### PR TITLE
BUG: Gracefully handle calling orient() on empty polygon

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -321,6 +321,9 @@ shapely.lib.registry[3] = Polygon
 
 def orient(polygon, sign=1.0):
     """Return an oriented polygon."""
+    if polygon.is_empty:
+        return polygon
+
     s = float(sign)
     rings = []
     ring = polygon.exterior

--- a/shapely/tests/legacy/test_orient.py
+++ b/shapely/tests/legacy/test_orient.py
@@ -42,7 +42,7 @@ class OrientTestCase(unittest.TestCase):
     def test_empty_polygon(self):
         polygon = Polygon()
         assert orient(polygon) == polygon
-    
+
     def test_polygon(self):
         polygon = Polygon([(0, 0), (0, 1), (1, 0)])
         polygon_reversed = Polygon(polygon.exterior.coords[::-1])

--- a/shapely/tests/legacy/test_orient.py
+++ b/shapely/tests/legacy/test_orient.py
@@ -14,6 +14,10 @@ from shapely.ops import orient
 
 
 class OrientTestCase(unittest.TestCase):
+    def test_empty(self):
+        polygon = Polygon()
+        assert orient(polygon) == polygon
+
     def test_point(self):
         point = Point(0, 0)
         assert orient(point, 1) == point

--- a/shapely/tests/legacy/test_orient.py
+++ b/shapely/tests/legacy/test_orient.py
@@ -14,10 +14,6 @@ from shapely.ops import orient
 
 
 class OrientTestCase(unittest.TestCase):
-    def test_empty(self):
-        polygon = Polygon()
-        assert orient(polygon) == polygon
-
     def test_point(self):
         point = Point(0, 0)
         assert orient(point, 1) == point
@@ -43,6 +39,10 @@ class OrientTestCase(unittest.TestCase):
         assert orient(linearring, 1) == linearring
         assert orient(linearring, -1) == linearring
 
+    def test_empty_polygon(self):
+        polygon = Polygon()
+        assert orient(polygon) == polygon
+    
     def test_polygon(self):
         polygon = Polygon([(0, 0), (0, 1), (1, 0)])
         polygon_reversed = Polygon(polygon.exterior.coords[::-1])


### PR DESCRIPTION
I recently had a user run into an error they couldn't figure out. Upon analyzing the issue, I pinpointed it to a very simple use case of trying to call `shapely.geometry.polygon.orient()` on an empty `Polygon` as follows:

```python
from shapely.geometry import Polygon
from shapely.geometry.polygon import orient
orient(Polygon())
```

This yields the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sebastian/python-virtualenvs/pyrobosim/lib/python3.12/site-packages/shapely/geometry/polygon.py", line 346, in orient
    if signed_area(ring) / s >= 0.0:
       ^^^^^^^^^^^^^^^^^
  File "/home/sebastian/python-virtualenvs/pyrobosim/lib/python3.12/site-packages/shapely/algorithms/cga.py", line 11, in signed_area
    xs, ys = np.vstack([coords, coords[1]]).T
                                ~~~~~~^^^
IndexError: index 1 is out of bounds for axis 0 with size 0
```

Here is a simple check on polygon emptiness to prevent this in the future!