### PR TITLE
Use int32 offsets in to_ragged_array

### DIFF
--- a/shapely/_ragged_array.py
+++ b/shapely/_ragged_array.py
@@ -63,7 +63,7 @@ def _get_arrays_point(arr, include_z):
 
 
 def _indices_to_offsets(indices, n):
-    offsets = np.insert(np.bincount(indices).cumsum(), 0, 0)
+    offsets = np.insert(np.bincount(indices).cumsum(dtype=np.int32), 0, 0)
     if len(offsets) != n + 1:
         # last geometries might be empty or missing
         offsets = np.pad(
@@ -103,7 +103,7 @@ def _get_arrays_multilinestring(arr, include_z):
 
     # the coords and offsets into the coordinates of the linestrings
     coords, indices = get_coordinates(arr_flat, return_index=True, include_z=include_z)
-    offsets1 = np.insert(np.bincount(indices).cumsum(), 0, 0)
+    offsets1 = np.insert(np.bincount(indices).cumsum(dtype=np.int32), 0, 0)
 
     return coords, (offsets1, offsets2)
 
@@ -116,7 +116,7 @@ def _get_arrays_polygon(arr, include_z):
 
     # the coords and offsets into the coordinates of the rings
     coords, indices = get_coordinates(arr_flat, return_index=True, include_z=include_z)
-    offsets1 = np.insert(np.bincount(indices).cumsum(), 0, 0)
+    offsets1 = np.insert(np.bincount(indices).cumsum(dtype=np.int32), 0, 0)
 
     return coords, (offsets1, offsets2)
 
@@ -130,11 +130,11 @@ def _get_arrays_multipolygon(arr, include_z):
     # explode/flatten the Polygons into Rings
     arr_flat2, ring_indices = get_rings(arr_flat, return_index=True)
     # the offsets into the exterior/interior rings of the multipolygon parts
-    offsets2 = np.insert(np.bincount(ring_indices).cumsum(), 0, 0)
+    offsets2 = np.insert(np.bincount(ring_indices).cumsum(dtype=np.int32), 0, 0)
 
     # the coords and offsets into the coordinates of the rings
     coords, indices = get_coordinates(arr_flat2, return_index=True, include_z=include_z)
-    offsets1 = np.insert(np.bincount(indices).cumsum(), 0, 0)
+    offsets1 = np.insert(np.bincount(indices).cumsum(dtype=np.int32), 0, 0)
 
     return coords, (offsets1, offsets2, offsets3)
 

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -164,10 +164,11 @@ def test_linestrings():
             [10.0, 40.0],
         ]
     )
-    expected_offsets = np.array([0, 3, 7, 7, 7, 10, 10, 10])
+    expected_offsets = np.array([0, 3, 7, 7, 7, 10, 10, 10], dtype="int32")
     assert typ == shapely.GeometryType.LINESTRING
     assert_allclose(coords, expected)
     assert len(offsets) == 1
+    assert offsets[0].dtype == np.int32
     assert_allclose(offsets[0], expected_offsets)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
@@ -218,6 +219,8 @@ def test_polygons():
     assert typ == shapely.GeometryType.POLYGON
     assert_allclose(coords, expected)
     assert len(offsets) == 2
+    assert offsets[0].dtype == np.int32
+    assert offsets[1].dtype == np.int32
     assert_allclose(offsets[0], expected_offsets1)
     assert_allclose(offsets[1], expected_offsets2)
 
@@ -257,6 +260,7 @@ def test_multipoints():
     assert typ == shapely.GeometryType.MULTIPOINT
     assert_allclose(coords, expected)
     assert len(offsets) == 1
+    assert offsets[0].dtype == np.int32
     assert_allclose(offsets[0], expected_offsets)
 
     result = shapely.from_ragged_array(typ, coords, offsets)
@@ -305,6 +309,8 @@ def test_multilinestrings():
     assert typ == shapely.GeometryType.MULTILINESTRING
     assert_allclose(coords, expected)
     assert len(offsets) == 2
+    assert offsets[0].dtype == np.int32
+    assert offsets[1].dtype == np.int32
     assert_allclose(offsets[0], expected_offsets1)
     assert_allclose(offsets[1], expected_offsets2)
 
@@ -365,6 +371,9 @@ def test_multipolygons():
     assert typ == shapely.GeometryType.MULTIPOLYGON
     assert_allclose(coords, expected)
     assert len(offsets) == 3
+    assert offsets[0].dtype == np.int32
+    assert offsets[1].dtype == np.int32
+    assert offsets[2].dtype == np.int32
     assert_allclose(offsets[0], expected_offsets1)
     assert_allclose(offsets[1], expected_offsets2)
     assert_allclose(offsets[2], expected_offsets3)


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/2163, see the issue for context.

Should we check for potential overflow? (this will happen if the coordinates itself have more than 32GB data)