### PR TITLE
MAINT: drop Python 3.9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,28 +17,28 @@ jobs:
         geos: [3.9.5, 3.10.6, 3.11.4, 3.12.2, 3.13.0, main]
         include:
           # 2020
-          - python: 3.9
+          - python: "3.10"
             geos: 3.9.5
-            numpy: 1.20.3
+            numpy: 1.21.6
           # 2021
           - python: "3.10"
             geos: 3.10.6
-            numpy: 1.21.3
+            numpy: 1.21.6
           # 2022
           - python: "3.11"
             geos: 3.11.4
-            numpy: 1.23.4
+            numpy: 1.23.5
           # 2023
           - python: "3.12"
             geos: 3.12.2
-            numpy: 1.26.2
+            numpy: 1.26.4
             matplotlib: true
             doctest: true
             extra_pytest_args: "-W error"  # error on warnings
           # 2024
           - python: "3.13"
             geos: 3.13.0
-            numpy: 2.1.1
+            numpy: 2.1.3
           # free threaded Python (no numpy version to indicate installing nightly cython and numpy)
           - os: ubuntu-22.04
             python: "3.13t"
@@ -47,7 +47,7 @@ jobs:
           - os: macos-14
             python: "3.12"
             geos: 3.12.2
-            numpy: 2.0.0
+            numpy: 2.0.2
           # dev
           - python: "3.12"
             geos: main
@@ -55,9 +55,9 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: 3.9
+            python: 3.10
             geos: 3.9.5
-            numpy: 1.20.3
+            numpy: 1.21.6
           - os: windows-2019
             architecture: x86
             python: "3.11"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: 3.10
+            python: "3.10"
             geos: 3.9.5
             numpy: 1.21.6
           - os: windows-2019

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,7 @@ Bug fixes:
 
 Improvements:
 
-- Require GEOS >= 3.9, NumPy >= 1.20, and Python >= 3.9 (#1802, #1885, #2124)
+- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
 - Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
   to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default

--- a/README.rst
+++ b/README.rst
@@ -105,9 +105,9 @@ Requirements
 
 Shapely 2.1 requires
 
-* Python >=3.9
+* Python >=3.10
 * GEOS >=3.9
-* NumPy >=1.20
+* NumPy >=1.21
 
 Installing Shapely
 ==================

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -4,17 +4,17 @@
 # docker run --rm shapely/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log
 
 
-FROM python:3.9-slim-buster
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update && apt-get install -y build-essential valgrind curl --no-install-recommends
 
-RUN pip install cmake numpy Cython pytest pytest-valgrind
+RUN pip install cmake numpy setuptools Cython pytest pytest-valgrind
 
 WORKDIR /code
 
-ENV PYTHONMALLOC malloc
+ENV PYTHONMALLOC=malloc
 
-ENV LD_LIBRARY_PATH /usr/local/lib
+ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # Build GEOS
 RUN export GEOS_VERSION=3.10.3 && \

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -15,7 +15,7 @@ API changes:
 
 Improvements:
 
-- Require GEOS >= 3.9, NumPy >= 1.20, and Python >= 3.9 (#1802, #1885, #2124)
+- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
 - Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and
   ``shapely.linearrings()`` to allow, skip, or error on nonfinite (NaN / Inf)
   coordinates. The default behaviour (allow) is backwards compatible (#1594).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,8 @@ ignore = [
     "PLW0603",
     # compare-to-empty-string
     "PLC1901",
+    # requiring | in isinstance
+    "UP038",
 
     ### Additional checks that don't pass yet
     # Useless statement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,15 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.20",
+    "numpy>=1.21",
 ]
 
 [project.optional-dependencies]

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -1,7 +1,5 @@
 """Methods that operate on the coordinates of geometries."""
 
-from typing import Optional
-
 import numpy as np
 
 import shapely
@@ -13,7 +11,7 @@ __all__ = ["transform", "count_coordinates", "get_coordinates", "set_coordinates
 def transform(
     geometry,
     transformation,
-    include_z: Optional[bool] = False,
+    include_z: bool | None = False,
     interleaved: bool = True,
 ):
     """Apply a function to the coordinates of a geometry.

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -666,7 +666,7 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
     coords = list(geom.coords)
     current_distance = 0
-    for p1, p2 in zip(coords, coords[1:]):
+    for p1, p2 in zip(coords, coords[1:]):  # noqa
         if start_dist < current_distance < end_dist:
             vertex_list.append(p1)
         elif current_distance >= end_dist:

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -1,7 +1,7 @@
 """STRtree spatial index for efficient spatial queries."""
 
 from collections.abc import Iterable
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 
@@ -273,7 +273,7 @@ tree.geometries.take(arr_indices[1])]).T.tolist()
         indices = self._tree.query(geometry, predicate)
         return indices[1] if is_scalar else indices
 
-    def nearest(self, geometry) -> Union[Any, None]:
+    def nearest(self, geometry) -> Any | None:
         """Return the index of the nearest geometry in the tree.
 
         This is determined for each input geometry based on distance within


### PR DESCRIPTION
As discussed in https://github.com/shapely/shapely/issues/2119, similar like https://github.com/shapely/shapely/pull/2127 for Python 3.8.