### PR TITLE
TST: fix testing with older GEOS versions (3.9 to 3.11)

### DIFF
--- a/shapely/tests/test_io.py
+++ b/shapely/tests/test_io.py
@@ -1319,7 +1319,7 @@ def test_to_geojson_exceptions():
         shapely.to_geojson(1)
 
 
-@pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")
+@pytest.mark.skipif(shapely.geos_version < (3, 10, 2), reason="GEOS < 3.10.2")
 @pytest.mark.parametrize(
     "geom",
     [
@@ -1341,6 +1341,12 @@ def test_geojson_all_types(geom):
     type_id = shapely.get_type_id(geom)
     if type_id == shapely.GeometryType.LINEARRING:
         pytest.skip("Linearrings are not preserved in GeoJSON")
+    elif (
+        geom.is_empty
+        and type_id == shapely.GeometryType.POINT
+        and shapely.geos_version < (3, 10, 2)
+    ):
+        pytest.skip("GEOS < 3.10.2 with POINT EMPTY")  # TRAC-1139
     geojson = shapely.to_geojson(geom)
     actual = shapely.from_geojson(geojson)
     assert not actual.has_z


### PR DESCRIPTION
This PR allows older point-releases of GEOS to be successfully tested with shapely, usually by skipping over older upstream bugs and expected behaviours. For example [GEOS 3.10.2 on Ubuntu jammy](https://packages.ubuntu.com/jammy/libgeos-c1v5) previously raise a segfault.

I've manually checked this PR with a few GEOS version ranges (linux x64 only):

- GEOS 3.9.0 to 3.9.5 ([NEWS](https://github.com/libgeos/geos/blob/3.9/NEWS))
- GEOS 3.10.1 to 3.10.6 (not including GEOS 3.10.0) ([NEWS](https://github.com/libgeos/geos/blob/3.10/NEWS))
- GEOS 3.11.0 to 3.11.4 ([NEWS.md](https://github.com/libgeos/geos/blob/3.11/NEWS.md))