### PR TITLE
DOC: Improve visibility of the Geometry creation functions

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -152,10 +152,13 @@ plane.
 Geometric Objects
 =================
 
-Geometric objects are created in the typical Python fashion, using the classes
-themselves as instance factories. A few of their intrinsic properties will be
-discussed in this sections, others in the following sections on operations and
-serializations.
+Single geometric objects can be created in the typical Python fashion, using
+the classes themselves as instance factories. To create multiple geometric
+objects it is significantly faster to use the
+:ref:`Geometry creation <ref-creation>` functions.
+
+A few of their intrinsic properties will be discussed in this sections, others
+in the following sections on operations and serializations.
 
 Instances of ``Point``, ``LineString``, and ``LinearRing`` have as their most
 important attribute a finite sequence of coordinates that determines their

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -289,6 +289,9 @@ Points
   >>> point = Point(0.0, 0.0)
   >>> q = Point((0.0, 0.0))
 
+An array of `Point` instances can be created efficiently with
+:func:`~shapely.points`.
+
 A `Point` has zero area and zero length.
 
 .. code-block:: pycon
@@ -341,6 +344,9 @@ LineStrings
 
   The `LineString` constructor takes an ordered sequence of 2 or more
   ``(x, y[, z])`` point tuples.
+
+An array of `LineString` instances can be created efficiently with
+:func:`~shapely.linestrings`.
 
 The constructed `LineString` object represents one or more connected linear
 splines between the points. Repeated points in the ordered sequence are
@@ -416,6 +422,9 @@ LinearRings
   The `LinearRing` constructor takes an ordered sequence of ``(x, y[, z])``
   point tuples.
 
+An array of `LinearRing` instances can be created efficiently with
+:func:`~shapely.linearrings`.
+
 The sequence may be explicitly closed by passing identical values in the first
 and last indices. Otherwise, the sequence will be implicitly closed by copying
 the first tuple to the last index. As with a `LineString`, repeated points in
@@ -484,6 +493,9 @@ Polygons
   the `LinearRing` case. The second is an optional unordered sequence of
   ring-like sequences specifying the interior boundaries or "holes" of the
   feature.
+
+An array of `Polygon` instances can be created efficiently with
+:func:`~shapely.polygons`.
 
 Rings of a `valid` `Polygon` may not cross each other, but may touch at a
 single point only.  Again, Shapely will not prevent the creation of invalid
@@ -630,6 +642,9 @@ Collections of Points
   The `MultiPoint` constructor takes a sequence of ``(x, y[, z ])`` point
   tuples.
 
+An array of `MultiPoint` instances can be created efficiently with
+:func:`~shapely.multipoints`.
+
 A `MultiPoint` has zero area and zero length.
 
 .. code-block:: pycon
@@ -672,6 +687,9 @@ Collections of Lines
 
   The `MultiLineString` constructor takes a sequence of line-like sequences or
   objects.
+
+An array of `MultiLineString` instances can be created efficiently with
+:func:`~shapely.multilinestrings`.
 
 .. plot:: code/multilinestring.py
 
@@ -731,6 +749,9 @@ Collections of Polygons
 More clearly, the constructor also accepts an unordered sequence of `Polygon`
 instances, thereby making copies.
 
+An array of `MultiPolygon` instances can be created efficiently with
+:func:`~shapely.multipolygons`.
+
 .. code-block:: pycon
 
   >>> from shapely import MultiPolygon
@@ -768,6 +789,9 @@ An "empty" feature is one with a point set that coincides with the empty set;
 not ``None``, but like ``set([])``. Empty features can be created by calling
 the various constructors with no arguments. Almost no operations are supported
 by empty features.
+
+An array of empty feature instances can be created efficiently with
+:func:`~shapely.empty`.
 
 .. code-block:: pycon
 

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -149,9 +149,9 @@ def linestrings(
     out=None,
     **kwargs,
 ):
-    """Create an array of linestrings.
+    """Create an array of LineStrings.
 
-    This function will raise an exception if a linestring contains less than
+    This function will raise an exception if a LineString contains less than
     two points.
 
     Parameters
@@ -694,7 +694,7 @@ def multipolygons(geometries, indices=None, *, out=None, **kwargs):
 @deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def geometrycollections(geometries, indices=None, out=None, **kwargs):
-    """Create geometrycollections from arrays of geometries.
+    """Create an array of GeometryCollections.
 
     Parameters
     ----------

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -199,8 +199,8 @@ def linestrings(
 
     See Also
     --------
-    linearrings
-    multilinestrings
+    linearrings : Create an array of LinearRings.
+    multilinestrings : Create an array of MultiLineStrings.
 
     Examples
     --------
@@ -301,9 +301,9 @@ def linearrings(
 
     See Also
     --------
-    linestrings
-    polygons
-    multipolygons
+    linestrings : Create an array of LineStrings.
+    polygons : Create an array of Polygons.
+    multipolygons : Create an array of MultiPolygons.
 
     Examples
     --------
@@ -634,8 +634,8 @@ def multilinestrings(geometries, indices=None, *, out=None, **kwargs):
 
     See Also
     --------
-    linestrings
-    multipoints
+    linestrings : Create an array of LineStrings.
+    multipoints : Create an array of MultiPoints.
 
     """
     typ = GeometryType.MULTILINESTRING

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -102,7 +102,7 @@ def points(
 
     See Also
     --------
-    multipoints
+    multipoints : Create an array of MultiPoints.
 
     Examples
     --------
@@ -380,7 +380,7 @@ def polygons(geometries, holes=None, indices=None, *, out=None, **kwargs):
 
     See Also
     --------
-    linearrings
+    linearrings : Create an array of LinearRings.
 
     Examples
     --------
@@ -489,6 +489,10 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
         positional argument. This will need to be specified as a keyword
         argument in a future release.
 
+    See Also
+    --------
+    polygons : Create an array of Polygons.
+
     Examples
     --------
     >>> import shapely
@@ -541,7 +545,7 @@ def multipoints(geometries, indices=None, *, out=None, **kwargs):
 
     See Also
     --------
-    points
+    points : Create an array of Points.
 
     Examples
     --------
@@ -687,8 +691,8 @@ def multipolygons(geometries, indices=None, *, out=None, **kwargs):
 
     See Also
     --------
-    multipoints
-    polygons
+    multipoints : Create an array of MultiPoints.
+    polygons : Create an array of Polygons.
 
     """
     typ = GeometryType.MULTIPOLYGON
@@ -743,7 +747,7 @@ def geometrycollections(geometries, indices=None, out=None, **kwargs):
 
     See Also
     --------
-    multipoints
+    multipoints : Create an array of MultiPoints.
 
     """
     typ = GeometryType.GEOMETRYCOLLECTION
@@ -817,7 +821,8 @@ def destroy_prepared(geometry, **kwargs):
 
     See Also
     --------
-    prepare
+    prepare : Prepare a geometry, improving performance of other operations.
+    is_prepared : Identify whether a geometry is prepared already.
 
     """
     return lib.destroy_prepared(geometry, **kwargs)

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -61,7 +61,7 @@ def points(
     out=None,
     **kwargs,
 ):
-    """Create an array of points.
+    """Create an array of Points.
 
     Parameters
     ----------
@@ -99,6 +99,10 @@ def points(
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
+
+    See Also
+    --------
+    multipoints
 
     Examples
     --------
@@ -193,6 +197,11 @@ def linestrings(
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
+    See Also
+    --------
+    linearrings
+    multilinestrings
+
     Examples
     --------
     >>> import shapely
@@ -243,12 +252,12 @@ def linearrings(
     out=None,
     **kwargs,
 ):
-    """Create an array of linearrings.
+    """Create an array of LinearRings.
 
-    If the provided coords do not constitute a closed linestring, or if there
+    If the provided coords do not constitute a closed LineString, or if there
     are only 3 provided coords, the first
     coordinate is duplicated at the end to close the ring. This function will
-    raise an exception if a linearring contains less than three points or if
+    raise an exception if a LinearRing contains less than three points or if
     the terminal coordinates contain NaN (not-a-number).
 
     Parameters
@@ -293,6 +302,8 @@ def linearrings(
     See Also
     --------
     linestrings
+    polygons
+    multipolygons
 
     Examples
     --------
@@ -332,17 +343,17 @@ def linearrings(
 @deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def polygons(geometries, holes=None, indices=None, *, out=None, **kwargs):
-    """Create an array of polygons.
+    """Create an array of Polygons.
 
     Parameters
     ----------
     geometries : array_like
-        An array of linearrings or coordinates (see linearrings).
+        An array of LinearRings or coordinates (see :func:`~linearrings`).
         Unless ``indices`` are given (see description below), this
         include the outer shells only. The ``holes`` argument should be used
         to create polygons with holes.
     holes : array_like, optional
-        An array of lists of linearrings that constitute holes for each shell.
+        An array of lists of LinearRings that constitute holes for each shell.
         Not to be used in combination with ``indices``.
     indices : array_like, optional
         Indices into the target array where input geometries belong. If
@@ -366,6 +377,10 @@ def polygons(geometries, holes=None, indices=None, *, out=None, **kwargs):
         A deprecation warning is shown if ``indices`` is specified as a
         positional argument. This will need to be specified as a keyword
         argument in a future release.
+
+    See Also
+    --------
+    linearrings
 
     Examples
     --------
@@ -446,7 +461,7 @@ def polygons(geometries, holes=None, indices=None, *, out=None, **kwargs):
 @deprecate_positional(["ccw"], category=DeprecationWarning)
 @multithreading_enabled
 def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
-    """Create box polygons.
+    """Create a box Polygon.
 
     Parameters
     ----------
@@ -498,12 +513,12 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
 @deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def multipoints(geometries, indices=None, *, out=None, **kwargs):
-    """Create multipoints from arrays of points.
+    """Create an array of MultiPoints.
 
     Parameters
     ----------
     geometries : array_like
-        An array of points or coordinates (see points).
+        An array of Points or coordinates (see :func:`~points`).
     indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
@@ -523,6 +538,10 @@ def multipoints(geometries, indices=None, *, out=None, **kwargs):
         A deprecation warning is shown if ``indices`` is specified as a
         positional argument. This will need to be specified as a keyword
         argument in a future release.
+
+    See Also
+    --------
+    points
 
     Examples
     --------
@@ -583,12 +602,12 @@ def multipoints(geometries, indices=None, *, out=None, **kwargs):
 @deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def multilinestrings(geometries, indices=None, *, out=None, **kwargs):
-    """Create multilinestrings from arrays of linestrings.
+    """Create an array of MultiLineStrings.
 
     Parameters
     ----------
     geometries : array_like
-        An array of linestrings or coordinates (see linestrings).
+        An array of LineStrings or coordinates (see :func:`~linestrings`).
     indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
@@ -611,6 +630,7 @@ def multilinestrings(geometries, indices=None, *, out=None, **kwargs):
 
     See Also
     --------
+    linestrings
     multipoints
 
     """
@@ -639,12 +659,12 @@ def multilinestrings(geometries, indices=None, *, out=None, **kwargs):
 @deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def multipolygons(geometries, indices=None, *, out=None, **kwargs):
-    """Create multipolygons from arrays of polygons.
+    """Create an array of MultiPolygons.
 
     Parameters
     ----------
     geometries : array_like
-        An array of polygons or coordinates (see polygons).
+        An array of Polygons or coordinates (see :func:`~polygons`).
     indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
@@ -668,6 +688,7 @@ def multipolygons(geometries, indices=None, *, out=None, **kwargs):
     See Also
     --------
     multipoints
+    polygons
 
     """
     typ = GeometryType.MULTIPOLYGON

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -20,7 +20,7 @@ class GeometryCollection(BaseMultipartGeometry):
 
     See Also
     --------
-    geometrycollections : Create geometrycollections from arrays of geometries.
+    geometrycollections : Create an array of GeometryCollections.
     empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -18,6 +18,11 @@ class GeometryCollection(BaseMultipartGeometry):
     geoms : sequence
         A sequence of Shapely geometry instances
 
+    See Also
+    --------
+    geometrycollections
+    empty
+
     Examples
     --------
     Create a GeometryCollection with a Point and a LineString

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -20,8 +20,8 @@ class GeometryCollection(BaseMultipartGeometry):
 
     See Also
     --------
-    geometrycollections
-    empty
+    geometrycollections : Create geometrycollections from arrays of geometries.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -26,7 +26,7 @@ class LineString(BaseGeometry):
 
     See Also
     --------
-    linestrings : Create an array of linestrings.
+    linestrings : Create an array of LineStrings.
     empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -25,8 +25,8 @@ class LineString(BaseGeometry):
 
     See Also
     --------
-    linestrings
-    empty
+    linestrings : Create an array of linestrings.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -23,6 +23,11 @@ class LineString(BaseGeometry):
         an array-like with shape (N, 2) or (N, 3).
         Also can be a sequence of Point objects, or combination of both.
 
+    See Also
+    --------
+    linestrings
+    empty
+
     Examples
     --------
     Create a LineString with two segments

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -26,8 +26,8 @@ class MultiLineString(BaseMultipartGeometry):
 
     See Also
     --------
-    multilinestrings
-    empty
+    multilinestrings : Create multilinestrings from arrays of linestrings.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -26,7 +26,7 @@ class MultiLineString(BaseMultipartGeometry):
 
     See Also
     --------
-    multilinestrings : Create multilinestrings from arrays of linestrings.
+    multilinestrings : Create an array of MultiLineStrings.
     empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -24,6 +24,11 @@ class MultiLineString(BaseMultipartGeometry):
     geoms : sequence
         A sequence of LineStrings
 
+    See Also
+    --------
+    multilinestrings
+    empty
+
     Examples
     --------
     Construct a MultiLineString containing two LineStrings.

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -26,6 +26,11 @@ class MultiPoint(BaseMultipartGeometry):
     geoms : sequence
         A sequence of Points
 
+    See Also
+    --------
+    multipoints
+    empty
+
     Examples
     --------
     Construct a MultiPoint containing two Points

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -28,8 +28,8 @@ class MultiPoint(BaseMultipartGeometry):
 
     See Also
     --------
-    multipoints
-    empty
+    multipoints : Create multipoints from arrays of points.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -28,7 +28,7 @@ class MultiPoint(BaseMultipartGeometry):
 
     See Also
     --------
-    multipoints : Create multipoints from arrays of points.
+    multipoints : Create an array of MultiPoints.
     empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -27,8 +27,8 @@ class MultiPolygon(BaseMultipartGeometry):
 
     See Also
     --------
-    multipolygons
-    empty
+    multipolygons : Create multipolygons from arrays of polygons.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -25,6 +25,11 @@ class MultiPolygon(BaseMultipartGeometry):
     geoms : sequence
         A sequence of `Polygon` instances
 
+    See Also
+    --------
+    multipolygons
+    empty
+
     Examples
     --------
     Construct a MultiPolygon from a sequence of coordinate tuples

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -27,7 +27,7 @@ class MultiPolygon(BaseMultipartGeometry):
 
     See Also
     --------
-    multipolygons : Create multipolygons from arrays of polygons.
+    multipolygons : Create an array of MultiPolygons.
     empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -32,8 +32,8 @@ class Point(BaseGeometry):
 
     See Also
     --------
-    points
-    empty
+    points : Create an array of points.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -30,6 +30,11 @@ class Point(BaseGeometry):
     x, y, z, m : float
         Coordinate values
 
+    See Also
+    --------
+    points
+    empty
+
     Examples
     --------
     Constructing the Point using separate parameters for x and y:

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -35,6 +35,11 @@ class LinearRing(LineString):
         an array-like with shape (N, 2) or (N, 3).
         Also can be a sequence of Point objects.
 
+    See Also
+    --------
+    linearrings
+    empty
+
     Notes
     -----
     Rings are automatically closed. There is no need to specify a final
@@ -208,6 +213,12 @@ class Polygon(BaseGeometry):
         The ring which bounds the positive space of the polygon.
     interiors : sequence
         A sequence of rings which bound all existing holes.
+
+    See Also
+    --------
+    polygons
+    box
+    empty
 
     Examples
     --------

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -37,8 +37,8 @@ class LinearRing(LineString):
 
     See Also
     --------
-    linearrings
-    empty
+    linearrings : Create an array of linearrings.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Notes
     -----
@@ -216,9 +216,9 @@ class Polygon(BaseGeometry):
 
     See Also
     --------
-    polygons
-    box
-    empty
+    polygons : Create an array of polygons.
+    box : Create box polygons.
+    empty : Create a geometry array prefilled with None or with empty geometries.
 
     Examples
     --------

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -294,8 +294,9 @@ def is_prepared(geometry, **kwargs):
 
     See Also
     --------
-    is_valid_input : check if an object is a geometry or None
-    prepare : prepare a geometry
+    is_valid_input : Check if an object is a geometry or None.
+    prepare : Prepare a geometry.
+    destroy_prepared : Destroy the prepared state of a geometry.
 
     Examples
     --------


### PR DESCRIPTION
Improve visibility of the Geometry creation functions:
- Add "See Also" links in the Constructor docstrings to the relevant bulk/array functions.
- Add references to them in the user guide.

Resolves #1925 
Resolves #1954