### PR TITLE
ENH: Add `include_m` to `get_coordinates`, warn with positional args

### DIFF
--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -200,7 +200,7 @@ def get_coordinates(geometry, include_z=False, return_index=False, *, include_m=
         ndarray of integers. For multidimensional arrays, this indexes into the
         flattened array (in C contiguous order).
 
-    .. versionchanged:: 2.1.0
+    .. deprecated:: 2.1.0
         A deprecation warning is shown if ``include_z`` or ``return_index`` are
         specified as positional arguments. In a future release, these will
         need to be specified as keyword arguments.
@@ -224,6 +224,7 @@ def get_coordinates(geometry, include_z=False, return_index=False, *, include_m=
     [[1.0, 2.0, 3.0]]
 
     If geometries don't have Z or M dimension, these values will be NaN:
+
     >>> pt = Point(1, 2)
     >>> shapely.get_coordinates(pt, include_z=True).tolist()
     [[1.0, 2.0, nan]]

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -200,6 +200,9 @@ def get_coordinates(geometry, include_z=False, return_index=False, *, include_m=
         ndarray of integers. For multidimensional arrays, this indexes into the
         flattened array (in C contiguous order).
 
+    Notes
+    -----
+
     .. deprecated:: 2.1.0
         A deprecation warning is shown if ``include_z`` or ``return_index`` are
         specified as positional arguments. In a future release, these will
@@ -231,7 +234,7 @@ def get_coordinates(geometry, include_z=False, return_index=False, *, include_m=
     >>> shapely.get_coordinates(pt, include_z=True, include_m=True).tolist()
     [[1.0, 2.0, nan, nan]]
 
-    When return_index=True, indexes are returned also:
+    When ``return_index=True``, indexes are returned also:
 
     >>> geometries = [LineString([(2, 2), (4, 4)]), Point(0, 0)]
     >>> coordinates, index = shapely.get_coordinates(geometries, return_index=True)

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import shapely
 from shapely import lib
+from shapely.decorators import deprecate_positional
 
 __all__ = ["count_coordinates", "get_coordinates", "set_coordinates", "transform"]
 
@@ -105,7 +106,9 @@ interleaved=False, include_z=True)
             geometry_arr[~has_z], transformation, False, interleaved
         )
     else:
-        coordinates = lib.get_coordinates(geometry_arr, include_z, False)
+        # TODO: expose include_m
+        include_m = False
+        coordinates = lib.get_coordinates(geometry_arr, include_z, include_m, False)
         if interleaved:
             new_coordinates = transformation(coordinates)
         else:
@@ -160,32 +163,54 @@ def count_coordinates(geometry):
     return lib.count_coordinates(np.asarray(geometry, dtype=np.object_))
 
 
-def get_coordinates(geometry, include_z=False, return_index=False):
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0: only supported XY and XYZ geometries
+#   get_coordinates(geometry, include_z=False, return_index=False)
+# shapely 2.1: adds include_m at end, shows deprecation warning about position keywords
+#   get_coordinates(geometry, include_z=False, return_index=False, *, include_m=False)
+# shapely 2.2(?): enforces keyword position arguments after geometry
+#   get_coordinates(geometry, *, include_z=False, include_m=False, return_index=False)
+
+
+@deprecate_positional(["include_z", "return_index"], category=DeprecationWarning)
+def get_coordinates(geometry, include_z=False, return_index=False, *, include_m=False):
     """Get coordinates from a geometry array as an array of floats.
 
     The shape of the returned array is (N, 2), with N being the number of
-    coordinate pairs. With the default of ``include_z=False``, three-dimensional
-    data is ignored. When specifying ``include_z=True``, the shape of the
-    returned array is (N, 3).
+    coordinate pairs. The shape of the data may also be (N, 3) or (N, 4),
+    depending on ``include_z`` and ``include_m`` options.
 
     Parameters
     ----------
     geometry : Geometry or array_like
         Geometry or geometries to get the coordinates of.
-    include_z : bool, default False
-        If, True include the third dimension in the output. If a geometry
-        has no third dimension, the z-coordinates will be NaN.
+    include_z, include_m : bool, default False
+        If both are False, return XY (2D) geometries.
+        If both are True, return XYZM (4D) geometries.
+        If either are True, return XYZ or XYM (3D) geometries.
+        If a geometry has no Z or M dimension, extra coordinate data will be NaN.
+
+        .. versionadded:: 2.1.0
+            The ``include_m`` parameter was added to support XYM (3D) and
+            XYZM (4D) geometries available with GEOS 3.12.0 or later.
+            With older GEOS versions, M dimension coordinates will be NaN.
+
     return_index : bool, default False
         If True, also return the index of each returned geometry as a separate
         ndarray of integers. For multidimensional arrays, this indexes into the
         flattened array (in C contiguous order).
 
+    .. versionchanged:: 2.1.0
+        A deprecation warning is shown if ``include_z`` or ``return_index`` are
+        specified as positional arguments. In a future release, these will
+        need to be specified as keyword arguments.
+
     Examples
     --------
     >>> import shapely
     >>> from shapely import LineString, Point
-    >>> shapely.get_coordinates(Point(0, 0)).tolist()
-    [[0.0, 0.0]]
+    >>> shapely.get_coordinates(Point(1, 2)).tolist()
+    [[1.0, 2.0]]
     >>> shapely.get_coordinates(LineString([(2, 2), (4, 4)])).tolist()
     [[2.0, 2.0], [4.0, 4.0]]
     >>> shapely.get_coordinates(None)
@@ -193,10 +218,17 @@ def get_coordinates(geometry, include_z=False, return_index=False):
 
     By default the third dimension is ignored:
 
-    >>> shapely.get_coordinates(Point(0, 0, 0)).tolist()
-    [[0.0, 0.0]]
-    >>> shapely.get_coordinates(Point(0, 0, 0), include_z=True).tolist()
-    [[0.0, 0.0, 0.0]]
+    >>> shapely.get_coordinates(Point(1, 2, 3)).tolist()
+    [[1.0, 2.0]]
+    >>> shapely.get_coordinates(Point(1, 2, 3), include_z=True).tolist()
+    [[1.0, 2.0, 3.0]]
+
+    If geometries don't have Z or M dimension, these values will be NaN:
+    >>> pt = Point(1, 2)
+    >>> shapely.get_coordinates(pt, include_z=True).tolist()
+    [[1.0, 2.0, nan]]
+    >>> shapely.get_coordinates(pt, include_z=True, include_m=True).tolist()
+    [[1.0, 2.0, nan, nan]]
 
     When return_index=True, indexes are returned also:
 
@@ -207,7 +239,7 @@ def get_coordinates(geometry, include_z=False, return_index=False):
 
     """
     return lib.get_coordinates(
-        np.asarray(geometry, dtype=np.object_), include_z, return_index
+        np.asarray(geometry, dtype=np.object_), include_z, include_m, return_index
     )
 
 

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -1,6 +1,8 @@
 """Decorators for Shapely functions."""
 
+import inspect
 import os
+import warnings
 from functools import wraps
 
 import numpy as np
@@ -88,3 +90,44 @@ def multithreading_enabled(func):
                 arr.flags.writeable = old_flag
 
     return wrapped
+
+
+def deprecate_positional(should_be_kwargs, category=DeprecationWarning):
+    """Show warning if positional arguments are used that should be keyword."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # call the function first, to make sure the signature matches
+            ret_value = func(*args, **kwargs)
+
+            # check signature to see which positional args were used
+            sig = inspect.signature(func)
+            args_bind = sig.bind(*args)
+            warn_args = [
+                f"`{arg}`"
+                for arg in args_bind.arguments.keys()
+                if arg in should_be_kwargs
+            ]
+            if warn_args:
+                if len(warn_args) == 1:
+                    plr = ""
+                    isare = "is"
+                    args = warn_args[0]
+                else:
+                    plr = "s"
+                    isare = "are"
+                    if len(warn_args) < 3:
+                        args = " and ".join(warn_args)
+                    else:
+                        args = ", ".join(warn_args[:-1]) + ", and " + warn_args[-1]
+                msg = (
+                    f"positional argument{plr} {args} for `{func.__qualname__}` "
+                    f"{isare} deprecated.  Please use keyword argument{plr} instead."
+                )
+                warnings.warn(msg, category=category, stacklevel=2)
+            return ret_value
+
+        return wrapper
+
+    return decorator

--- a/src/coords.c
+++ b/src/coords.c
@@ -15,7 +15,7 @@
 
 /* These function prototypes enables that these functions can call themselves */
 static char get_coordinates(GEOSContextHandle_t, GEOSGeometry*, PyArrayObject*, npy_intp*,
-                            int);
+                            int, int);
 static void* set_coordinates(GEOSContextHandle_t, GEOSGeometry*, PyArrayObject*,
                              npy_intp*, int);
 
@@ -23,7 +23,8 @@ static void* set_coordinates(GEOSContextHandle_t, GEOSGeometry*, PyArrayObject*,
 position `cursor` in the array `out`. Increases the cursor correspondingly.
 Returns 0 on error, 1 on success */
 static char get_coordinates_simple(GEOSContextHandle_t ctx, GEOSGeometry* geom, int type,
-                                   PyArrayObject* out, npy_intp* cursor, int include_z) {
+                                   PyArrayObject* out, npy_intp* cursor,
+                                   int include_z, int include_m) {
   unsigned int n;
   double *buf;
   const GEOSCoordSequence* seq;
@@ -50,7 +51,7 @@ static char get_coordinates_simple(GEOSContextHandle_t ctx, GEOSGeometry* geom, 
   }
 
   buf = PyArray_GETPTR2(out, *cursor, 0);
-  if (!coordseq_to_buffer(ctx, seq, buf, n, include_z, 0)) {
+  if (!coordseq_to_buffer(ctx, seq, buf, n, include_z, include_m)) {
     return 0;
   }
   *cursor += n;
@@ -62,7 +63,8 @@ static char get_coordinates_simple(GEOSContextHandle_t ctx, GEOSGeometry* geom, 
 ring (exterior ring, interior ring 1, ..., interior ring N).
 Returns 0 on error, 1 on success */
 static char get_coordinates_polygon(GEOSContextHandle_t ctx, GEOSGeometry* geom,
-                                    PyArrayObject* out, npy_intp* cursor, int include_z) {
+                                    PyArrayObject* out, npy_intp* cursor,
+                                    int include_z, int include_m) {
   int n, i;
   GEOSGeometry* ring;
 
@@ -70,7 +72,7 @@ static char get_coordinates_polygon(GEOSContextHandle_t ctx, GEOSGeometry* geom,
   if (ring == NULL) {
     return 0;
   }
-  if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z)) {
+  if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z, include_m)) {
     return 0;
   }
 
@@ -83,7 +85,7 @@ static char get_coordinates_polygon(GEOSContextHandle_t ctx, GEOSGeometry* geom,
     if (ring == NULL) {
       return 0;
     }
-    if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z)) {
+    if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z, include_m)) {
       return 0;
     }
   }
@@ -95,7 +97,7 @@ subgeometry. The call to `get_coordinates` is a recursive call so that nested
 collections are allowed. Returns 0 on error, 1 on success */
 static char get_coordinates_collection(GEOSContextHandle_t ctx, GEOSGeometry* geom,
                                        PyArrayObject* out, npy_intp* cursor,
-                                       int include_z) {
+                                       int include_z, int include_m) {
   int n, i;
   GEOSGeometry* sub_geom;
 
@@ -108,7 +110,7 @@ static char get_coordinates_collection(GEOSContextHandle_t ctx, GEOSGeometry* ge
     if (sub_geom == NULL) {
       return 0;
     }
-    if (!get_coordinates(ctx, sub_geom, out, cursor, include_z)) {
+    if (!get_coordinates(ctx, sub_geom, out, cursor, include_z, include_m)) {
       return 0;
     }
   }
@@ -119,14 +121,15 @@ static char get_coordinates_collection(GEOSContextHandle_t ctx, GEOSGeometry* ge
 array `out`. The value of the cursor is increased correspondingly. Returns 0
 on error, 1 on success*/
 static char get_coordinates(GEOSContextHandle_t ctx, GEOSGeometry* geom,
-                            PyArrayObject* out, npy_intp* cursor, int include_z) {
+                            PyArrayObject* out, npy_intp* cursor,
+                            int include_z, int include_m) {
   int type = GEOSGeomTypeId_r(ctx, geom);
   if ((type == 0) || (type == 1) || (type == 2)) {
-    return get_coordinates_simple(ctx, geom, type, out, cursor, include_z);
+    return get_coordinates_simple(ctx, geom, type, out, cursor, include_z, include_m);
   } else if (type == 3) {
-    return get_coordinates_polygon(ctx, geom, out, cursor, include_z);
+    return get_coordinates_polygon(ctx, geom, out, cursor, include_z, include_m);
   } else if ((type >= 4) && (type <= 7)) {
-    return get_coordinates_collection(ctx, geom, out, cursor, include_z);
+    return get_coordinates_collection(ctx, geom, out, cursor, include_z, include_m);
   } else {
     return 0;
   }
@@ -389,7 +392,7 @@ finish:
   return result;
 }
 
-PyObject* GetCoords(PyArrayObject* arr, int include_z, int return_index) {
+PyObject* GetCoords(PyArrayObject* arr, int include_z, int include_m, int return_index) {
   npy_intp coord_dim;
   NpyIter* iter;
   NpyIter_IterNextFunc* iternext;
@@ -404,11 +407,7 @@ PyObject* GetCoords(PyArrayObject* arr, int include_z, int return_index) {
   if (size == -1) {
     return NULL;
   }
-  if (include_z) {
-    coord_dim = 3;
-  } else {
-    coord_dim = 2;
-  }
+  coord_dim = 2 + include_z + include_m;
   npy_intp dims[2] = {size, coord_dim};
   PyArrayObject* result = (PyArrayObject*)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
   if (result == NULL) {
@@ -476,7 +475,7 @@ PyObject* GetCoords(PyArrayObject* arr, int include_z, int return_index) {
     first to the last coordinate belonging to this geometry later */
     i = cursor;
     /* get the coordinates (updates "cursor") */
-    if (!get_coordinates(ctx, geom, result, &cursor, include_z)) {
+    if (!get_coordinates(ctx, geom, result, &cursor, include_z, include_m)) {
       errstate = PGERR_GEOS_EXCEPTION;
       goto finish;
     }
@@ -607,9 +606,10 @@ PyObject* PyCountCoords(PyObject* self, PyObject* args) {
 PyObject* PyGetCoords(PyObject* self, PyObject* args) {
   PyObject* arr;
   int include_z;
+  int include_m;
   int return_index;
 
-  if (!PyArg_ParseTuple(args, "Opp", &arr, &include_z, &return_index)) {
+  if (!PyArg_ParseTuple(args, "Oppp", &arr, &include_z, &include_m, &return_index)) {
     return NULL;
   }
   if (!PyArray_Check(arr)) {
@@ -620,7 +620,7 @@ PyObject* PyGetCoords(PyObject* self, PyObject* args) {
     PyErr_SetString(PyExc_TypeError, "Array should be of object dtype");
     return NULL;
   }
-  return GetCoords((PyArrayObject*)arr, include_z, return_index);
+  return GetCoords((PyArrayObject*)arr, include_z, include_m, return_index);
 }
 
 PyObject* PySetCoords(PyObject* self, PyObject* args) {

--- a/src/coords.c
+++ b/src/coords.c
@@ -72,7 +72,8 @@ static char get_coordinates_polygon(GEOSContextHandle_t ctx, GEOSGeometry* geom,
   if (ring == NULL) {
     return 0;
   }
-  if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z, include_m)) {
+  if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor,
+                              include_z, include_m)) {
     return 0;
   }
 
@@ -85,7 +86,8 @@ static char get_coordinates_polygon(GEOSContextHandle_t ctx, GEOSGeometry* geom,
     if (ring == NULL) {
       return 0;
     }
-    if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor, include_z, include_m)) {
+    if (!get_coordinates_simple(ctx, ring, GEOS_LINEARRING, out, cursor,
+                                include_z, include_m)) {
       return 0;
     }
   }

--- a/src/geos.c
+++ b/src/geos.c
@@ -1149,7 +1149,7 @@ enum ShapelyErrorCode coordseq_from_buffer(GEOSContextHandle_t ctx, const double
 /* Copy coordinates of a GEOSCoordSequence to an array
  *
  * Note: this function assumes that the buffer is from a C-contiguous array,
- * and that the dimension of the buffer is only 2D or 3D.
+ * and that the dimension of the buffer can be 2, 3 or 4.
  *
  * Returns 0 on error, 1 on success.
  */
@@ -1170,6 +1170,7 @@ int coordseq_to_buffer(GEOSContextHandle_t ctx, const GEOSCoordSequence* coord_s
   for (i = 0; i < size; i++, cp1 += 8 * dims) {
     cp2 = cp1;
     for (j = 0; j < dims; j++, cp2 += 8) {
+      if (j == 2 && !has_z && has_m) j = 3;  /* jump to last ordinate, fill with Nan */
       if (!GEOSCoordSeq_getOrdinate_r(ctx, coord_seq, i, j, (double*)cp2)) {
         return 0;
       }

--- a/src/lib.c
+++ b/src/lib.c
@@ -22,7 +22,7 @@ static PyMethodDef GeosModule[] = {
     {"count_coordinates", PyCountCoords, METH_VARARGS,
      "Counts the total amount of coordinates in a array with geometry objects"},
     {"get_coordinates", PyGetCoords, METH_VARARGS,
-     "Gets the coordinates as an (N, 2) shaped ndarray of floats"},
+     "Gets the coordinates as an (N, 2), (N, 3), or (N, 4) shaped ndarray of floats"},
     {"set_coordinates", PySetCoords, METH_VARARGS,
      "Sets coordinates to a geometry array"},
     {"_setup_signal_checks", PySetupSignalChecks, METH_VARARGS,

--- a/src/pygeos.c
+++ b/src/pygeos.c
@@ -65,6 +65,12 @@ char equals_identical_simple(GEOSContextHandle_t ctx, const GEOSGeometry* geom1,
     return 0;
   }
 
+#if !GEOS_SINCE_3_10_0
+  // Correction to hasZ for GEOS<3.10 to avoid false detection of hasM
+  hasZ1 = dims1 == 3;
+  hasZ2 = dims2 == 3;
+#endif // !GEOS_SINCE_3_10_0
+
   int hasM = 0;
   if ((dims1 == 3) & (hasZ1 == 0)) {
     hasM = 1;


### PR DESCRIPTION
This enhancement allows `shapely.get_coordinates()` to get M coordinate data with `include_m=True`. For shapely 2.1, this argument is after the keyword-only (`, *,`) marker. A DeprecationWarning is shown if the function is called with positional arguments for `include_z` or `return_index`, since a future version of shapely may require these as keyword-only. In the code I'm suggesting this be changed to a keyword-only signature with shapely 2.2, but this change schedule can be postponed later if needed.

From a low-level API, here are some notes:

- No changes to [`coordseq_to_buffer(..., int has_z, int has_m)`](https://github.com/shapely/shapely/blob/d62b3a9cfc35638789b4a31d2e83bad672a0753f/src/geos.h#L209-L210) which has a compatible signature with `has_m`.
- Change `GetCoords()` and `PyGetCoords()` (aka `shapely.lib.get_coordinates()`) to have signature order `..., include_z, include_m, return_index`.
- With C API in src/coords.c, change all `get_coordinates*()` functions to add `include_m` at the end.

Next steps:

- Update `set_coordinates` and check `coordseq_from_buffer` and other low- and high-level API functions
- Update `transform()` with `include_m: bool | None = False`
- Update `to_ragged_array` with `include_m=None`