### PR TITLE
DOC: fix typo in LinearRing manual - can be constructed using a sequence of Points

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -466,7 +466,7 @@ instance, respectively.
   >>> LinearRing(ring)
   <LINEARRING (0 0, 1 1, 1 0, 0 0)>
 
-As with `LineString`, a sequence of `Point` instances is not a valid
+As with `LineString`, a sequence of `Point` instances is a valid
 constructor parameter.
 
 .. _polygons:


### PR DESCRIPTION
Pretty sure this isn't right. LinearRing instances can be constructed using a sequence of points, like LineStrings