### PR TITLE
DEPR: deprecate positional args in some functions

### DIFF
--- a/shapely/_geometry.py
+++ b/shapely/_geometry.py
@@ -5,7 +5,11 @@ import numpy as np
 
 from shapely import _geometry_helpers, geos_version, lib
 from shapely._enum import ParamEnum
-from shapely.decorators import multithreading_enabled, requires_geos
+from shapely.decorators import (
+    deprecate_positional,
+    multithreading_enabled,
+    requires_geos,
+)
 
 __all__ = [
     "GeometryType",
@@ -629,6 +633,16 @@ def get_geometry(geometry, index, **kwargs):
     return lib.get_geometry(geometry, np.intc(index), **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   get_parts(geometry, return_index=False)
+# shapely 2.1: shows deprecation warning about positional 'return_index'
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometry'
+#   get_parts(geometry, *, return_index=False)
+
+
+@deprecate_positional(["return_index"])
 def get_parts(geometry, return_index=False):
     """Get parts of each GeometryCollection or Multi* geometry object.
 
@@ -647,6 +661,14 @@ def get_parts(geometry, return_index=False):
     return_index : bool, default False
         If True, will return a tuple of ndarrays of (parts, indexes), where
         indexes are the indexes of the original geometries in the source array.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``return_index`` is specified as
+        a positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     Returns
     -------
@@ -682,6 +704,16 @@ MultiPoint([(4, 5), (6, 7)])], return_index=True)
     return _geometry_helpers.get_parts(geometry)[0]
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   get_rings(geometry, return_index=False)
+# shapely 2.1: shows deprecation warning about positional 'return_index'
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometry'
+#   get_rings(geometry, *, return_index=False)
+
+
+@deprecate_positional(["return_index"])
 def get_rings(geometry, return_index=False):
     """Get rings of Polygon geometry object.
 
@@ -698,6 +730,14 @@ def get_rings(geometry, return_index=False):
     return_index : bool, default False
         If True, will return a tuple of ndarrays of (rings, indexes), where
         indexes are the indexes of the original geometries in the source array.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``return_index`` is specified as
+        a positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     Returns
     -------

--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -6,7 +6,11 @@ from shapely import Geometry, GeometryType, lib
 from shapely._enum import ParamEnum
 from shapely._geometry import get_parts
 from shapely.algorithms._oriented_envelope import _oriented_envelope_min_area_vectorized
-from shapely.decorators import multithreading_enabled, requires_geos
+from shapely.decorators import (
+    deprecate_positional,
+    multithreading_enabled,
+    requires_geos,
+)
 from shapely.errors import UnsupportedGEOSVersionError
 
 __all__ = [
@@ -120,6 +124,19 @@ MultiLineString, MultiPoint, Point, Polygon
     return lib.boundary(geometry, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   buffer(geometry, distance, quad_segs=8, ...)
+# shapely 2.1: shows deprecation warning about positional 'quad_segs', etc.
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'distance'
+#   buffer(geometry, distance, *, quad_segs=8, ...)
+
+
+@deprecate_positional(
+    ["quad_segs", "cap_style", "join_style", "mitre_limit", "single_sided"],
+    category=DeprecationWarning,
+)
 @multithreading_enabled
 def buffer(
     geometry,
@@ -167,6 +184,15 @@ def buffer(
         Only buffer at one side of the geometry.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``quad_segs``,  ``cap_style``,
+        ``join_style``, ``mitre_limit`` or ``single_sided`` are
+        specified as positional arguments. In a future release, these will
+        need to be specified as keyword arguments.
 
     Examples
     --------
@@ -229,6 +255,18 @@ def buffer(
     )
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   offset_curve(geometry, distance, quad_segs=8, ...)
+# shapely 2.1: shows deprecation warning about positional 'quad_segs', etc.
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'distance'
+#   offset_curve(geometry, distance, *, quad_segs=8, ...)
+
+
+@deprecate_positional(
+    ["quad_segs", "join_style", "mitre_limit"], category=DeprecationWarning
+)
 @multithreading_enabled
 def offset_curve(
     geometry, distance, quad_segs=8, join_style="round", mitre_limit=5.0, **kwargs
@@ -266,6 +304,14 @@ def offset_curve(
         buffered vertex by more than this limit.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``quad_segs``, ``join_style`` or
+        ``mitre_limit`` are specified as positional arguments. In a future
+        release, these will need to be specified as keyword arguments.
 
     Examples
     --------
@@ -575,7 +621,7 @@ def build_area(geometry, **kwargs):
 
 
 @multithreading_enabled
-def make_valid(geometry, method="linework", keep_collapsed=True, **kwargs):
+def make_valid(geometry, *, method="linework", keep_collapsed=True, **kwargs):
     """Repair invalid geometries.
 
     Two ``methods`` are available:
@@ -1014,6 +1060,16 @@ def segmentize(geometry, max_segment_length, **kwargs):
     return lib.segmentize(geometry, max_segment_length, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   simplify(geometry, tolerance, preserve_topology=True, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'preserve_topology'
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'tolerance'
+#   simplify(geometry, tolerance, *, preserve_topology=True, **kwargs)
+
+
+@deprecate_positional(["preserve_topology"], category=DeprecationWarning)
 @multithreading_enabled
 def simplify(geometry, tolerance, preserve_topology=True, **kwargs):
     """Return a simplified version of an input geometry.
@@ -1033,6 +1089,14 @@ def simplify(geometry, tolerance, preserve_topology=True, **kwargs):
         this is computationally more expensive.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``preserve_topology`` is specified as
+        a positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     Examples
     --------
@@ -1061,7 +1125,7 @@ def simplify(geometry, tolerance, preserve_topology=True, **kwargs):
 
 @requires_geos("3.12.0")
 @multithreading_enabled
-def coverage_simplify(geometry, tolerance, simplify_boundary=True):
+def coverage_simplify(geometry, tolerance, *, simplify_boundary=True):
     """Return a simplified version of an input geometry using coverage simplification.
 
     Assumes that the geometry forms a polygonal coverage. Under this assumption, the
@@ -1212,6 +1276,18 @@ def snap(geometry, reference, tolerance, **kwargs):
     return lib.snap(geometry, reference, tolerance, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   voronoi_polygons(geometry, tolerance=0.0, extend_to=None, ...)
+# shapely 2.1: shows deprecation warning about positional 'extend_to'
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'tolerance'
+#   voronoi_polygons(geometry, tolerance=0.0, extend_to=None, ...)
+
+
+@deprecate_positional(
+    ["extend_to", "only_edges", "ordered"], category=DeprecationWarning
+)
 @multithreading_enabled
 def voronoi_polygons(
     geometry, tolerance=0.0, extend_to=None, only_edges=False, ordered=False, **kwargs
@@ -1242,6 +1318,14 @@ def voronoi_polygons(
         .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``extend_to``, ``only_edges`` or
+        ``ordered`` are specified as positional arguments. In a future
+        release, these will need to be specified as keyword arguments.
 
     Examples
     --------

--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -9,10 +9,21 @@ from shapely.decorators import deprecate_positional
 __all__ = ["count_coordinates", "get_coordinates", "set_coordinates", "transform"]
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0: only supported XY and XYZ geometries
+#   transform(geometry, transformation, include_z=False)
+# shapely 2.1: shows deprecation warning about positional 'include_z' arg
+#   transform(geometry, transformation, include_z=False, *, interleaved=True)
+# shapely 2.2(?): enforce keyword-only arguments after 'transformation'
+#   transform(geometry, transformation, *, include_z=False, interleaved=True)
+
+
+@deprecate_positional(["include_z"], category=DeprecationWarning)
 def transform(
     geometry,
     transformation,
     include_z: bool | None = False,
+    *,
     interleaved: bool = True,
 ):
     """Apply a function to the coordinates of a geometry.
@@ -46,6 +57,14 @@ def transform(
         two-dimensional array.
 
         .. versionadded:: 2.1.0
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``include_z`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -100,10 +119,13 @@ interleaved=False, include_z=True)
         has_z = shapely.has_z(geometry_arr)
         result = np.empty_like(geometry_arr)
         result[has_z] = transform(
-            geometry_arr[has_z], transformation, True, interleaved
+            geometry_arr[has_z], transformation, include_z=True, interleaved=interleaved
         )
         result[~has_z] = transform(
-            geometry_arr[~has_z], transformation, False, interleaved
+            geometry_arr[~has_z],
+            transformation,
+            include_z=False,
+            interleaved=interleaved,
         )
     else:
         # TODO: expose include_m
@@ -166,9 +188,9 @@ def count_coordinates(geometry):
 # Note: future plan is to change this signature over a few releases:
 # shapely 2.0: only supported XY and XYZ geometries
 #   get_coordinates(geometry, include_z=False, return_index=False)
-# shapely 2.1: adds include_m at end, shows deprecation warning about position keywords
+# shapely 2.1: shows deprecation warning about positional 'include_z' and 'return_index'
 #   get_coordinates(geometry, include_z=False, return_index=False, *, include_m=False)
-# shapely 2.2(?): enforces keyword position arguments after geometry
+# shapely 2.2(?): enforce keyword-only arguments after 'geometry'
 #   get_coordinates(geometry, *, include_z=False, include_m=False, return_index=False)
 
 

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -5,7 +5,7 @@ import numpy as np
 from shapely import Geometry, GeometryType, lib
 from shapely._enum import ParamEnum
 from shapely._geometry_helpers import collections_1d, simple_geometries_1d
-from shapely.decorators import multithreading_enabled
+from shapely.decorators import deprecate_positional, multithreading_enabled
 from shapely.io import from_wkt
 
 __all__ = [
@@ -40,9 +40,26 @@ def _xyz_to_coords(x, y, z):
     return np.stack(coords, axis=-1)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0: only supported XY and XYZ geometries
+#   points(coords, y=None, z=None, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   points(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+# shapely 2.2(?): enforce keyword-only arguments after 'z'
+#   points(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+
+
 @multithreading_enabled
+@deprecate_positional(["indices"], category=DeprecationWarning)
 def points(
-    coords, y=None, z=None, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs
+    coords,
+    y=None,
+    z=None,
+    indices=None,
+    *,
+    handle_nan=HandleNaN.allow,
+    out=None,
+    **kwargs,
 ):
     """Create an array of points.
 
@@ -111,9 +128,26 @@ def points(
         )
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0: only supported XY and XYZ geometries
+#   linestrings(coords, y=None, z=None, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   linestrings(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+# shapely 2.2(?): enforce keyword-only arguments after 'z'
+#   linestrings(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+
+
 @multithreading_enabled
+@deprecate_positional(["indices"], category=DeprecationWarning)
 def linestrings(
-    coords, y=None, z=None, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs
+    coords,
+    y=None,
+    z=None,
+    indices=None,
+    *,
+    handle_nan=HandleNaN.allow,
+    out=None,
+    **kwargs,
 ):
     """Create an array of linestrings.
 
@@ -188,9 +222,26 @@ def linestrings(
         )
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0: only supported XY and XYZ geometries
+#   linearrings(coords, y=None, z=None, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   linearrings(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+# shapely 2.2(?): enforce keyword-only arguments after 'z'
+#   linearrings(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
+
+
 @multithreading_enabled
+@deprecate_positional(["indices"], category=DeprecationWarning)
 def linearrings(
-    coords, y=None, z=None, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs
+    coords,
+    y=None,
+    z=None,
+    indices=None,
+    *,
+    handle_nan=HandleNaN.allow,
+    out=None,
+    **kwargs,
 ):
     """Create an array of linearrings.
 

--- a/shapely/creation.py
+++ b/shapely/creation.py
@@ -41,7 +41,7 @@ def _xyz_to_coords(x, y, z):
 
 
 # Note: future plan is to change this signature over a few releases:
-# shapely 2.0: only supported XY and XYZ geometries
+# shapely 2.0:
 #   points(coords, y=None, z=None, indices=None, out=None, **kwargs)
 # shapely 2.1: shows deprecation warning about positional 'indices' arg
 #   points(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
@@ -49,8 +49,8 @@ def _xyz_to_coords(x, y, z):
 #   points(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
 
 
-@multithreading_enabled
 @deprecate_positional(["indices"], category=DeprecationWarning)
+@multithreading_enabled
 def points(
     coords,
     y=None,
@@ -129,7 +129,7 @@ def points(
 
 
 # Note: future plan is to change this signature over a few releases:
-# shapely 2.0: only supported XY and XYZ geometries
+# shapely 2.0:
 #   linestrings(coords, y=None, z=None, indices=None, out=None, **kwargs)
 # shapely 2.1: shows deprecation warning about positional 'indices' arg
 #   linestrings(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
@@ -137,8 +137,8 @@ def points(
 #   linestrings(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
 
 
-@multithreading_enabled
 @deprecate_positional(["indices"], category=DeprecationWarning)
+@multithreading_enabled
 def linestrings(
     coords,
     y=None,
@@ -223,7 +223,7 @@ def linestrings(
 
 
 # Note: future plan is to change this signature over a few releases:
-# shapely 2.0: only supported XY and XYZ geometries
+# shapely 2.0:
 #   linearrings(coords, y=None, z=None, indices=None, out=None, **kwargs)
 # shapely 2.1: shows deprecation warning about positional 'indices' arg
 #   linearrings(coords, y=None, z=None, indices=None, *, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
@@ -231,8 +231,8 @@ def linestrings(
 #   linearrings(coords, y=None, z=None, *, indices=None, handle_nan=HandleNaN.allow, out=None, **kwargs)  # noqa: E501
 
 
-@multithreading_enabled
 @deprecate_positional(["indices"], category=DeprecationWarning)
+@multithreading_enabled
 def linearrings(
     coords,
     y=None,
@@ -320,8 +320,18 @@ def linearrings(
         )
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   polygons(geometries, holes=None, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   polygons(geometries, holes=None, indices=None, *, out=None, **kwargs)
+# shapely 2.2(?): enforce keyword-only arguments after 'holes'
+#   polygons(geometries, holes=None, *, indices=None, out=None, **kwargs)
+
+
+@deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
-def polygons(geometries, holes=None, indices=None, out=None, **kwargs):
+def polygons(geometries, holes=None, indices=None, *, out=None, **kwargs):
     """Create an array of polygons.
 
     Parameters
@@ -348,6 +358,14 @@ def polygons(geometries, holes=None, indices=None, out=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``indices`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     Examples
     --------
@@ -416,6 +434,16 @@ def polygons(geometries, holes=None, indices=None, out=None, **kwargs):
     return lib.polygons(geometries, holes, out=out, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   box(xmin, ymin, xmax, ymax, ccw=True, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'ccw' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'ymax'
+#   box(xmin, ymin, xmax, ymax, *, ccw=True, **kwargs)
+
+
+@deprecate_positional(["ccw"], category=DeprecationWarning)
 @multithreading_enabled
 def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
     """Create box polygons.
@@ -438,6 +466,14 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``ccw`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
+
     Examples
     --------
     >>> import shapely
@@ -450,8 +486,18 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
     return lib.box(xmin, ymin, xmax, ymax, ccw, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   multipoints(geometries, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   multipoints(geometries, indices=None, *, out=None, **kwargs)
+# shapely 2.2(?): enforce keyword-only arguments after 'indices'
+#   multipoints(geometries, *, indices=None, out=None, **kwargs)
+
+
+@deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
-def multipoints(geometries, indices=None, out=None, **kwargs):
+def multipoints(geometries, indices=None, *, out=None, **kwargs):
     """Create multipoints from arrays of points.
 
     Parameters
@@ -469,6 +515,14 @@ def multipoints(geometries, indices=None, out=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``indices`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     Examples
     --------
@@ -517,8 +571,18 @@ def multipoints(geometries, indices=None, out=None, **kwargs):
         return collections_1d(geometries, indices, typ, out=out)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   multilinestrings(geometries, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   multilinestrings(geometries, indices=None, *, out=None, **kwargs)
+# shapely 2.2(?): enforce keyword-only arguments after 'indices'
+#   multilinestrings(geometries, *, indices=None, out=None, **kwargs)
+
+
+@deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
-def multilinestrings(geometries, indices=None, out=None, **kwargs):
+def multilinestrings(geometries, indices=None, *, out=None, **kwargs):
     """Create multilinestrings from arrays of linestrings.
 
     Parameters
@@ -536,6 +600,14 @@ def multilinestrings(geometries, indices=None, out=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``indices`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -555,8 +627,18 @@ def multilinestrings(geometries, indices=None, out=None, **kwargs):
         return collections_1d(geometries, indices, typ, out=out)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   multipolygons(geometries, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   multipolygons(geometries, indices=None, *, out=None, **kwargs)
+# shapely 2.2(?): enforce keyword-only arguments after 'indices'
+#   multipolygons(geometries, *, indices=None, out=None, **kwargs)
+
+
+@deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
-def multipolygons(geometries, indices=None, out=None, **kwargs):
+def multipolygons(geometries, indices=None, *, out=None, **kwargs):
     """Create multipolygons from arrays of polygons.
 
     Parameters
@@ -575,6 +657,14 @@ def multipolygons(geometries, indices=None, out=None, **kwargs):
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
 
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``indices`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
+
     See Also
     --------
     multipoints
@@ -592,6 +682,16 @@ def multipolygons(geometries, indices=None, out=None, **kwargs):
         return collections_1d(geometries, indices, typ, out=out)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   geometrycollections(geometries, indices=None, out=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'indices' arg
+#   geometrycollections(geometries, indices=None, *, out=None, **kwargs)
+# shapely 2.2(?): enforce keyword-only arguments after 'indices'
+#   geometrycollections(geometries, *, indices=None, out=None, **kwargs)
+
+
+@deprecate_positional(["indices"], category=DeprecationWarning)
 @multithreading_enabled
 def geometrycollections(geometries, indices=None, out=None, **kwargs):
     """Create geometrycollections from arrays of geometries.
@@ -611,6 +711,14 @@ def geometrycollections(geometries, indices=None, out=None, **kwargs):
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
         Ignored if ``indices`` is provided.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``indices`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -103,7 +103,7 @@ def deprecate_positional(should_be_kwargs, category=DeprecationWarning):
 
             # check signature to see which positional args were used
             sig = inspect.signature(func)
-            args_bind = sig.bind(*args)
+            args_bind = sig.bind_partial(*args)
             warn_args = [
                 f"`{arg}`"
                 for arg in args_bind.arguments.keys()

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -122,7 +122,7 @@ def deprecate_positional(should_be_kwargs, category=DeprecationWarning):
                     else:
                         args = ", ".join(warn_args[:-1]) + ", and " + warn_args[-1]
                 msg = (
-                    f"positional argument{plr} {args} for `{func.__qualname__}` "
+                    f"positional argument{plr} {args} for `{func.__name__}` "
                     f"{isare} deprecated.  Please use keyword argument{plr} instead."
                 )
                 warnings.warn(msg, category=category, stacklevel=2)

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -15,6 +15,7 @@ import shapely
 from shapely._geometry_helpers import _geom_factory
 from shapely.constructive import BufferCapStyle, BufferJoinStyle
 from shapely.coords import CoordinateSequence
+from shapely.decorators import deprecate_positional
 from shapely.errors import GeometryTypeError, GEOSException, ShapelyDeprecationWarning
 
 GEOMETRY_TYPES = [
@@ -447,6 +448,17 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.oriented_envelope(self)
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   buffer(self, geometry, distance, quad_segs=16, ...)
+    # shapely 2.1: shows deprecation warning about positional 'quad_segs', etc.
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
+    #   buffer(self, geometry, distance, *, quad_segs=16, ...)
+    @deprecate_positional(
+        ["quad_segs", "cap_style", "join_style", "mitre_limit", "single_sided"],
+        category=DeprecationWarning,
+    )
     def buffer(
         self,
         distance,
@@ -521,6 +533,12 @@ class BaseGeometry(shapely.Geometry):
         The return value is a strictly two-dimensional geometry. All
         Z coordinates of the original geometry will be ignored.
 
+        .. deprecated:: 2.1.0
+            A deprecation warning is shown if ``quad_segs``,  ``cap_style``,
+            ``join_style``, ``mitre_limit`` or ``single_sided`` are
+            specified as positional arguments. In a future release, these will
+            need to be specified as keyword arguments.
+
         Examples
         --------
         >>> from shapely import BufferCapStyle
@@ -579,6 +597,15 @@ class BaseGeometry(shapely.Geometry):
             single_sided=single_sided,
         )
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   simplify(self, tolerance, preserve_topology=True)
+    # shapely 2.1: shows deprecation warning about positional 'preserve_topology'
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'tolerance'
+    #   simplify(self, tolerance, *, preserve_topology=True)
+
+    @deprecate_positional(["preserve_topology"], category=DeprecationWarning)
     def simplify(self, tolerance, preserve_topology=True):
         """Return a simplified geometry produced by the Douglas-Peucker algorithm.
 
@@ -609,6 +636,15 @@ class BaseGeometry(shapely.Geometry):
     # Overlay operations
     # ---------------------------
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   difference(self, other, grid_size=None)
+    # shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   difference(self, other, *, grid_size=None)
+
+    @deprecate_positional(["grid_size"], category=DeprecationWarning)
     def difference(self, other, grid_size=None):
         """Return the difference of the geometries.
 
@@ -616,6 +652,15 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.difference(self, other, grid_size=grid_size)
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   intersection(self, other, grid_size=None)
+    # shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   intersection(self, other, *, grid_size=None)
+
+    @deprecate_positional(["grid_size"], category=DeprecationWarning)
     def intersection(self, other, grid_size=None):
         """Return the intersection of the geometries.
 
@@ -623,6 +668,15 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.intersection(self, other, grid_size=grid_size)
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   symmetric_difference(self, other, grid_size=None)
+    # shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   symmetric_difference(self, other, *, grid_size=None)
+
+    @deprecate_positional(["grid_size"], category=DeprecationWarning)
     def symmetric_difference(self, other, grid_size=None):
         """Return the symmetric difference of the geometries.
 
@@ -630,6 +684,15 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.symmetric_difference(self, other, grid_size=grid_size)
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   union(self, other, grid_size=None)
+    # shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   union(self, other, *, grid_size=None)
+
+    @deprecate_positional(["grid_size"], category=DeprecationWarning)
     def union(self, other, grid_size=None):
         """Return the union of the geometries.
 
@@ -853,6 +916,15 @@ class BaseGeometry(shapely.Geometry):
     # Linear referencing
     # ------------------
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   line_locate_point(self, other, normalized=False)
+    # shapely 2.1: shows deprecation warning about positional 'normalized'
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   line_locate_point(self, other, *, normalized=False)
+
+    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def line_locate_point(self, other, normalized=False):
         """Return the distance of this geometry to a point nearest the specified point.
 
@@ -865,6 +937,15 @@ class BaseGeometry(shapely.Geometry):
             shapely.line_locate_point(self, other, normalized=normalized)
         )
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   project(self, other, normalized=False)
+    # shapely 2.1: shows deprecation warning about positional 'normalized'
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'other'
+    #   project(self, other, *, normalized=False)
+
+    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def project(self, other, normalized=False):
         """Return the distance of geometry to a point nearest the specified point.
 
@@ -877,6 +958,15 @@ class BaseGeometry(shapely.Geometry):
             shapely.line_locate_point(self, other, normalized=normalized)
         )
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   line_interpolate_point(self, distance, normalized=False)
+    # shapely 2.1: shows deprecation warning about positional 'normalized'
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
+    #   line_interpolate_point(self, distance, *, normalized=False)
+
+    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def line_interpolate_point(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry.
 
@@ -890,6 +980,15 @@ class BaseGeometry(shapely.Geometry):
         """
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   interpolate(self, distance, normalized=False)
+    # shapely 2.1: shows deprecation warning about positional 'normalized'
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
+    #   interpolate(self, distance, *, normalized=False)
+
+    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def interpolate(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry.
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -450,13 +450,13 @@ class BaseGeometry(shapely.Geometry):
 
     # Note: future plan is to change this signature over a few releases:
     # shapely 2.0:
-    #   buffer(self, geometry, distance, quad_segs=16, ...)
-    # shapely 2.1: shows deprecation warning about positional 'quad_segs', etc.
+    #   buffer(self, geometry, distance, quad_segs=16, cap_style="round", ...)
+    # shapely 2.1: shows deprecation warning about positional 'cap_style', etc.
     #   same signature as 2.0
-    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
-    #   buffer(self, geometry, distance, *, quad_segs=16, ...)
+    # shapely 2.2(?): enforce keyword-only arguments after 'quad_segs'
+    #   buffer(self, geometry, distance, quad_segs=16, *, cap_style="round", ...)
     @deprecate_positional(
-        ["quad_segs", "cap_style", "join_style", "mitre_limit", "single_sided"],
+        ["cap_style", "join_style", "mitre_limit", "single_sided"],
         category=DeprecationWarning,
     )
     def buffer(

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -769,7 +769,7 @@ class BaseGeometry(shapely.Geometry):
         """
         return _maybe_unpack(shapely.dwithin(self, other, distance))
 
-    def equals_exact(self, other, tolerance=0.0, normalize=False):
+    def equals_exact(self, other, tolerance=0.0, *, normalize=False):
         """Return True if the geometries are equivalent within the tolerance.
 
         Refer to :func:`~shapely.equals_exact` for full documentation.
@@ -802,7 +802,9 @@ class BaseGeometry(shapely.Geometry):
         bool
 
         """
-        return _maybe_unpack(shapely.equals_exact(self, other, tolerance, normalize))
+        return _maybe_unpack(
+            shapely.equals_exact(self, other, tolerance, normalize=normalize)
+        )
 
     def almost_equals(self, other, decimal=6):
         """Return True if all coordinates are equal to a specified decimal place.

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 import shapely
+from shapely.decorators import deprecate_positional
 from shapely.geometry.base import JOIN_STYLE, BaseGeometry
 from shapely.geometry.point import Point
 
@@ -125,6 +126,17 @@ class LineString(BaseGeometry):
         """
         return self.coords.xy
 
+    # Note: future plan is to change this signature over a few releases:
+    # shapely 2.0:
+    #   offset_curve(self, distance, quad_segs=16, ...)
+    # shapely 2.1: shows deprecation warning about positional 'quad_segs', etc.
+    #   same signature as 2.0
+    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
+    #   offset_curve(self, distance, *, quad_segs=16, ...)
+
+    @deprecate_positional(
+        ["quad_segs", "join_style", "mitre_limit"], category=DeprecationWarning
+    )
     def offset_curve(
         self,
         distance,

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -162,7 +162,13 @@ class LineString(BaseGeometry):
             raise ValueError("Cannot compute offset from zero-length line segment")
         elif not np.isfinite(distance):
             raise ValueError("offset_curve distance must be finite")
-        return shapely.offset_curve(self, distance, quad_segs, join_style, mitre_limit)
+        return shapely.offset_curve(
+            self,
+            distance,
+            quad_segs=quad_segs,
+            join_style=join_style,
+            mitre_limit=mitre_limit,
+        )
 
     def parallel_offset(
         self,

--- a/shapely/linear.py
+++ b/shapely/linear.py
@@ -1,7 +1,7 @@
 """Linear geometry functions."""
 
 from shapely import lib
-from shapely.decorators import multithreading_enabled
+from shapely.decorators import deprecate_positional, multithreading_enabled
 from shapely.errors import UnsupportedGEOSVersionError
 
 __all__ = [
@@ -12,7 +12,16 @@ __all__ = [
     "shortest_line",
 ]
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   line_interpolate_point(line, distance, normalized=False, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'normalized' arg
+#    same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'normalized'
+#   line_interpolate_point(line, distance, *, normalized=False, **kwargs)
 
+
+@deprecate_positional(["normalized"], category=DeprecationWarning)
 @multithreading_enabled
 def line_interpolate_point(line, distance, normalized=False, **kwargs):
     """Return a point interpolated at given distance on a line.
@@ -55,6 +64,16 @@ def line_interpolate_point(line, distance, normalized=False, **kwargs):
         return lib.line_interpolate_point(line, distance)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   line_locate_point(line, other, normalized=False, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'normalized' arg
+#    same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'normalized'
+#   line_locate_point(line, other, *, normalized=False, **kwargs)
+
+
+@deprecate_positional(["normalized"], category=DeprecationWarning)
 @multithreading_enabled
 def line_locate_point(line, other, normalized=False, **kwargs):
     """Return the distance to the line origin of given point.

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -626,15 +626,15 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
     # Filter out cases in which to return a point
     if start_dist == end_dist:
-        return geom.interpolate(start_dist, normalized)
+        return geom.interpolate(start_dist, normalized=normalized)
     elif not normalized and start_dist >= geom.length and end_dist >= geom.length:
-        return geom.interpolate(geom.length, normalized)
+        return geom.interpolate(geom.length, normalized=normalized)
     elif not normalized and -start_dist >= geom.length and -end_dist >= geom.length:
-        return geom.interpolate(0, normalized)
+        return geom.interpolate(0, normalized=normalized)
     elif normalized and start_dist >= 1 and end_dist >= 1:
-        return geom.interpolate(1, normalized)
+        return geom.interpolate(1, normalized=normalized)
     elif normalized and -start_dist >= 1 and -end_dist >= 1:
-        return geom.interpolate(0, normalized)
+        return geom.interpolate(0, normalized=normalized)
 
     if normalized:
         start_dist *= geom.length

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -1035,7 +1035,7 @@ def within(a, b, **kwargs):
 
 
 @multithreading_enabled
-def equals_exact(a, b, tolerance=0.0, normalize=False, **kwargs):
+def equals_exact(a, b, tolerance=0.0, *, normalize=False, **kwargs):
     """Return True if the geometries are structurally equivalent within a given
     tolerance.
 

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -3,7 +3,11 @@
 import numpy as np
 
 from shapely import Geometry, GeometryType, lib
-from shapely.decorators import multithreading_enabled, requires_geos
+from shapely.decorators import (
+    deprecate_positional,
+    multithreading_enabled,
+    requires_geos,
+)
 
 __all__ = [
     "coverage_union",
@@ -21,6 +25,16 @@ __all__ = [
 ]
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   difference(a, b, grid_size=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'b'
+#   difference(a, b, *, grid_size=None, **kwargs)
+
+
+@deprecate_positional(["grid_size"], category=DeprecationWarning)
 @multithreading_enabled
 def difference(a, b, grid_size=None, **kwargs):
     """Return the part of geometry A that does not intersect with geometry B.
@@ -42,6 +56,14 @@ def difference(a, b, grid_size=None, **kwargs):
         Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``grid_size`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -76,6 +98,16 @@ def difference(a, b, grid_size=None, **kwargs):
     return lib.difference(a, b, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   intersection(a, b, grid_size=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'b'
+#   intersection(a, b, *, grid_size=None, **kwargs)
+
+
+@deprecate_positional(["grid_size"], category=DeprecationWarning)
 @multithreading_enabled
 def intersection(a, b, grid_size=None, **kwargs):
     """Return the geometry that is shared between input geometries.
@@ -95,6 +127,14 @@ def intersection(a, b, grid_size=None, **kwargs):
         Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``grid_size`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -126,6 +166,16 @@ def intersection(a, b, grid_size=None, **kwargs):
     return lib.intersection(a, b, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   intersection_all(geometries, axis=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'axis' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometries'
+#   intersection_all(geometries, *, axis=None, **kwargs)
+
+
+@deprecate_positional(["axis"], category=DeprecationWarning)
 @multithreading_enabled
 def intersection_all(geometries, axis=None, **kwargs):
     """Return the intersection of multiple geometries.
@@ -145,6 +195,14 @@ def intersection_all(geometries, axis=None, **kwargs):
         first axis.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``axis`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -173,6 +231,16 @@ def intersection_all(geometries, axis=None, **kwargs):
     return lib.intersection_all(geometries, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   symmetric_difference(a, b, grid_size=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'b'
+#   symmetric_difference(a, b, *, grid_size=None, **kwargs)
+
+
+@deprecate_positional(["grid_size"], category=DeprecationWarning)
 @multithreading_enabled
 def symmetric_difference(a, b, grid_size=None, **kwargs):
     """Return the geometry with the portions of input geometries that do not intersect.
@@ -192,6 +260,14 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
         Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``grid_size`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -223,6 +299,16 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     return lib.symmetric_difference(a, b, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   symmetric_difference_all(geometries, axis=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'axis' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometries'
+#   symmetric_difference_all(geometries, *, axis=None, **kwargs)
+
+
+@deprecate_positional(["axis"], category=DeprecationWarning)
 @multithreading_enabled
 def symmetric_difference_all(geometries, axis=None, **kwargs):
     """Return the symmetric difference of multiple geometries.
@@ -242,6 +328,14 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
         first axis.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``axis`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -272,6 +366,16 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     return lib.symmetric_difference_all(geometries, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   union(a, b, grid_size=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'b'
+#   union(a, b, *, grid_size=None, **kwargs)
+
+
+@deprecate_positional(["grid_size"], category=DeprecationWarning)
 @multithreading_enabled
 def union(a, b, grid_size=None, **kwargs):
     """Merge geometries into one.
@@ -291,6 +395,14 @@ def union(a, b, grid_size=None, **kwargs):
         Precision grid size; will use the highest precision of the inputs by default.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``grid_size`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -324,6 +436,16 @@ def union(a, b, grid_size=None, **kwargs):
     return lib.union(a, b, **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   union_all(geometries, grid_size=None, axis=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'grid_size' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometries'
+#   union_all(geometries, *, grid_size=None, axis=None, **kwargs)
+
+
+@deprecate_positional(["grid_size", "axis"], category=DeprecationWarning)
 @multithreading_enabled
 def union_all(geometries, grid_size=None, axis=None, **kwargs):
     """Return the union of multiple geometries.
@@ -354,6 +476,14 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
         first axis.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``grid_size`` or ``axis`` are
+        specified as positional arguments. In a future release, these will
+        need to be specified as keyword arguments.
 
     See Also
     --------
@@ -447,6 +577,16 @@ def coverage_union(a, b, **kwargs):
     return coverage_union_all([a, b], **kwargs)
 
 
+# Note: future plan is to change this signature over a few releases:
+# shapely 2.0:
+#   coverage_union_all(geometries, axis=None, **kwargs)
+# shapely 2.1: shows deprecation warning about positional 'axis' arg
+#   same signature as 2.0
+# shapely 2.2(?): enforce keyword-only arguments after 'geometries'
+#   coverage_union_all(geometries, *, axis=None, **kwargs)
+
+
+@deprecate_positional(["axis"], category=DeprecationWarning)
 @multithreading_enabled
 def coverage_union_all(geometries, axis=None, **kwargs):
     """Return the union of multiple polygons of a geometry collection.
@@ -469,6 +609,14 @@ def coverage_union_all(geometries, axis=None, **kwargs):
         first axis.
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
+
+    Notes
+    -----
+
+    .. deprecated:: 2.1.0
+        A deprecation warning is shown if ``axis`` is specified as a
+        positional argument. This will need to be specified as a keyword
+        argument in a future release.
 
     See Also
     --------
@@ -560,7 +708,7 @@ def disjoint_subset_union(a, b, **kwargs):
 
 @requires_geos("3.12.0")
 @multithreading_enabled
-def disjoint_subset_union_all(geometries, axis=None, **kwargs):
+def disjoint_subset_union_all(geometries, *, axis=None, **kwargs):
     """Return the union of multiple polygons.
 
     This is an optimized version of union which assumes inputs can be divided into

--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -79,7 +79,7 @@ def test_format_point(format_spec, coords, expt_wkt, same_python_float):
 
 def test_format_polygon():
     # check basic cases
-    poly = Point(0, 0).buffer(10, 2)
+    poly = Point(0, 0).buffer(10, quad_segs=2)
     assert f"{poly}" == poly.wkt
     assert format(poly, "") == poly.wkt
     assert format(poly, "x") == poly.wkb_hex.lower()

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -282,16 +282,11 @@ def test_array_argument_buffer():
 def test_buffer_deprecate_positional():
     point = Point(1, 1)
     with pytest.deprecated_call(
-        match="positional argument `quad_segs` for `buffer` is deprecated"
-    ):
-        point.buffer(1.0, 8)
-    with pytest.deprecated_call(
-        match="positional arguments `quad_segs` and `cap_style` "
-        "for `buffer` are deprecated"
+        match="positional argument `cap_style` for `buffer` is deprecated"
     ):
         point.buffer(1.0, 8, "round")
     with pytest.deprecated_call(
-        match="positional arguments `quad_segs`, `cap_style`, and `join_style` "
+        match="positional arguments `cap_style` and `join_style` "
         "for `buffer` are deprecated"
     ):
         point.buffer(1.0, 8, "round", "round")

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -277,3 +277,98 @@ def test_array_argument_buffer():
     # check scalar
     result = point.buffer(distances[0])
     assert isinstance(result, Polygon)
+
+
+def test_buffer_deprecate_positional():
+    point = Point(1, 1)
+    with pytest.deprecated_call(
+        match="positional argument `quad_segs` for `buffer` is deprecated"
+    ):
+        point.buffer(1.0, 8)
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs` and `cap_style` "
+        "for `buffer` are deprecated"
+    ):
+        point.buffer(1.0, 8, "round")
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs`, `cap_style`, and `join_style` "
+        "for `buffer` are deprecated"
+    ):
+        point.buffer(1.0, 8, "round", "round")
+    with pytest.deprecated_call():
+        point.buffer(1.0, 8, "round", "round", 5.0)
+    with pytest.deprecated_call():
+        point.buffer(1.0, 8, "round", "round", 5.0, False)
+
+
+def test_simplify_deprecate_positional():
+    linestring = LineString([(0, 0), (1, 1)])
+    with pytest.deprecated_call(
+        match="positional argument `preserve_topology` for `simplify` is deprecated"
+    ):
+        linestring.simplify(1.0, True)
+
+
+def test_difference_deprecate_positional():
+    point = Point(1, 1)
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `difference` is deprecated"
+    ):
+        point.difference(point, None)
+
+
+def test_intersection_deprecate_positional():
+    point = Point(1, 1)
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `intersection` is deprecated"
+    ):
+        point.intersection(point, None)
+
+
+def test_symmetric_difference_deprecate_positional():
+    point = Point(1, 1)
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `symmetric_difference` is deprecated"
+    ):
+        point.symmetric_difference(point, None)
+
+
+def test_union_deprecate_positional():
+    point = Point(1, 1)
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `union` is deprecated"
+    ):
+        point.union(point, None)
+
+
+def test_line_locate_point_deprecate_positional():
+    line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `line_locate_point` is deprecated"
+    ):
+        line_string.line_locate_point(Point(1, 1), False)
+
+
+def test_project_deprecate_positional():
+    line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `project` is deprecated"
+    ):
+        line_string.project(Point(1, 1), False)
+
+
+def test_line_interpolate_point_deprecate_positional():
+    line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `line_interpolate_point` "
+        "is deprecated"
+    ):
+        line_string.line_interpolate_point(0, False)
+
+
+def test_interpolate_deprecate_positional():
+    line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `interpolate` is deprecated"
+    ):
+        line_string.interpolate(0, False)

--- a/shapely/tests/geometry/test_linestring.py
+++ b/shapely/tests/geometry/test_linestring.py
@@ -212,3 +212,21 @@ def test_linestring_array_coercion():
     assert arr.size == 1
     assert arr.dtype == np.dtype("object")
     assert arr.item() == line
+
+
+def test_offset_curve_deprecate_positional():
+    line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
+    with pytest.deprecated_call(
+        match="positional argument `quad_segs` for `offset_curve` is deprecated"
+    ):
+        line_string.offset_curve(1.0, 8)
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs` and `join_style` "
+        "for `offset_curve` are deprecated"
+    ):
+        line_string.offset_curve(1.0, 8, "round")
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs`, `join_style`, and `mitre_limit` "
+        "for `offset_curve` are deprecated"
+    ):
+        line_string.offset_curve(1.0, 8, "round", 5.0)

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -352,7 +352,7 @@ class TestPolygon:
             (0.0, 0.0),
         ]
 
-        ec = list(Point(0.0, 0.0).buffer(1.0, 1).exterior.coords)
+        ec = list(Point(0.0, 0.0).buffer(1.0, quad_segs=1).exterior.coords)
         assert isinstance(ec, list)  # TODO: this is a poor test
 
         # Test chained access to interiors

--- a/shapely/tests/legacy/test_operations.py
+++ b/shapely/tests/legacy/test_operations.py
@@ -28,7 +28,7 @@ class OperationsTestCase(unittest.TestCase):
 
         # Buffer
         assert isinstance(point.buffer(10.0), Polygon)
-        assert isinstance(point.buffer(10.0, 32), Polygon)
+        assert isinstance(point.buffer(10.0, quad_segs=32), Polygon)
 
         # Simplify
         p = loads(

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -1301,3 +1301,65 @@ def test_orient_polygons_non_polygonal_input():
     arr = np.array([Point(0, 0), LineString([(0, 0), (1, 1)]), None])
     result = shapely.orient_polygons(arr)
     assert_geometries_equal(result, arr)
+
+
+def test_buffer_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `quad_segs` for `buffer` is deprecated"
+    ):
+        shapely.buffer(point, 1.0, 8)
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs` and `cap_style` "
+        "for `buffer` are deprecated"
+    ):
+        shapely.buffer(point, 1.0, 8, "round")
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs`, `cap_style`, and `join_style` "
+        "for `buffer` are deprecated"
+    ):
+        shapely.buffer(point, 1.0, 8, "round", "round")
+    with pytest.deprecated_call():
+        shapely.buffer(point, 1.0, 8, "round", "round", 5.0)
+    with pytest.deprecated_call():
+        shapely.buffer(point, 1.0, 8, "round", "round", 5.0, False)
+
+
+def test_offset_curve_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `quad_segs` for `offset_curve` is deprecated"
+    ):
+        shapely.offset_curve(line_string, 1.0, 8)
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs` and `join_style` "
+        "for `offset_curve` are deprecated"
+    ):
+        shapely.offset_curve(line_string, 1.0, 8, "round")
+    with pytest.deprecated_call(
+        match="positional arguments `quad_segs`, `join_style`, and `mitre_limit` "
+        "for `offset_curve` are deprecated"
+    ):
+        shapely.offset_curve(line_string, 1.0, 8, "round", 5.0)
+
+
+def test_simplify_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `preserve_topology` for `simplify` is deprecated"
+    ):
+        shapely.simplify(line_string, 1.0, True)
+
+
+def test_voronoi_polygons_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `extend_to` for `voronoi_polygons` is deprecated"
+    ):
+        shapely.voronoi_polygons(multi_point, 0.0, None)
+    with pytest.deprecated_call(
+        match="positional arguments `extend_to` and `only_edges` "
+        "for `voronoi_polygons` are deprecated"
+    ):
+        shapely.voronoi_polygons(multi_point, 0.0, None, False)
+    with pytest.deprecated_call(
+        match="positional arguments `extend_to`, `only_edges`, and `ordered` "
+        "for `voronoi_polygons` are deprecated"
+    ):
+        shapely.voronoi_polygons(multi_point, 0.0, None, False, False)

--- a/shapely/tests/test_coordinates.py
+++ b/shapely/tests/test_coordinates.py
@@ -202,7 +202,7 @@ def test_get_coords_zm(geoms, x, y, z, m, include_z, include_m):
     assert_equal(actual, np.array(expected, np.float64).T)
 
 
-def test_get_coords_pos_args_deprecation_warning():
+def test_get_coords_deprecate_positional():
     with pytest.deprecated_call(
         match="positional argument `include_z` for `get_coordinates` is deprecated"
     ):
@@ -415,7 +415,7 @@ def test_transform_auto_coordinate_dimension_mixed_interleaved():
     )
 
 
-def test_transform_pos_args_deprecation_warning():
+def test_transform_deprecate_positional():
     with pytest.deprecated_call(
         match="positional argument `include_z` for `transform` is deprecated"
     ):

--- a/shapely/tests/test_coordinates.py
+++ b/shapely/tests/test_coordinates.py
@@ -413,3 +413,10 @@ def test_transform_auto_coordinate_dimension_mixed_interleaved():
         shapely.get_coordinates(line_string_z, include_z=True) + [1, 2, 3],
         shapely.get_coordinates(new_geom[1], include_z=True),
     )
+
+
+def test_transform_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `include_z` for `transform` is deprecated"
+    ):
+        transform(line_string_z, lambda x: x + 1, False)

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -1,3 +1,5 @@
+"""See test_creation_indices.py for tests with 'indices' parameter."""
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -37,18 +39,6 @@ def box_tpl(x1, y1, x2, y2):
 def test_points_from_coords():
     actual = shapely.points([[0, 0], [2, 2]])
     assert_geometries_equal(actual, [shapely.Point(0, 0), shapely.Point(2, 2)])
-
-
-def test_points_from_coords_indices():
-    actual = shapely.points([[0, 1], [2, 3]], indices=[0, 1])
-    assert_geometries_equal(actual, [shapely.Point(0, 1), shapely.Point(2, 3)])
-
-
-def test_points_pos_args_deprecation_warning():
-    with pytest.deprecated_call(
-        match="positional argument `indices` for `points` is deprecated"
-    ):
-        shapely.points([[0, 1], [2, 3]], None, None, [0, 1])
 
 
 def test_points_from_xy():
@@ -163,24 +153,6 @@ def test_linestrings_from_coords():
             LineString([(0, 0), (2, 2)]),
         ],
     )
-
-
-def test_linestrings_from_coords_indices():
-    actual = shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], indices=[0, 0, 1, 1])
-    assert_geometries_equal(
-        actual,
-        [
-            LineString([(0, 1), (2, 3)]),
-            LineString([(4, 5), (6, 7)]),
-        ],
-    )
-
-
-def test_linestrings_pos_args_deprecation_warning():
-    with pytest.deprecated_call(
-        match="positional argument `indices` for `linestrings` is deprecated"
-    ):
-        shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], None, None, [0, 0, 1, 1])
 
 
 def test_linestrings_from_xy():
@@ -330,23 +302,6 @@ def test_linearrings_empty():
 def test_linearrings_from_xy():
     actual = shapely.linearrings([0, 1, 2, 0], [3, 4, 5, 3])
     assert_geometries_equal(actual, LinearRing([(0, 3), (1, 4), (2, 5), (0, 3)]))
-
-
-def test_linearrings_from_coords():
-    actual = shapely.linearrings([[0, 1], [1, 1], [1, 0]])
-    assert_geometries_equal(actual, LinearRing([(0, 1), (1, 1), (1, 0), (0, 1)]))
-
-
-def test_linearrings_from_coords_indices():
-    actual = shapely.linearrings([[0, 1], [1, 1], [1, 0]], indices=[0, 0, 0])
-    assert_geometries_equal(actual, LinearRing([(0, 1), (1, 1), (1, 0), (0, 1)]))
-
-
-def test_linearrings_pos_args_deprecation_warning():
-    with pytest.deprecated_call(
-        match="positional argument `indices` for `linearrings` is deprecated"
-    ):
-        shapely.linearrings([[0, 1], [1, 1], [1, 0]], None, None, [0, 0, 0])
 
 
 def test_linearrings_unclosed():

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -39,6 +39,18 @@ def test_points_from_coords():
     assert_geometries_equal(actual, [shapely.Point(0, 0), shapely.Point(2, 2)])
 
 
+def test_points_from_coords_indices():
+    actual = shapely.points([[0, 1], [2, 3]], indices=[0, 1])
+    assert_geometries_equal(actual, [shapely.Point(0, 1), shapely.Point(2, 3)])
+
+
+def test_points_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `points` is deprecated"
+    ):
+        shapely.points([[0, 1], [2, 3]], None, None, [0, 1])
+
+
 def test_points_from_xy():
     actual = shapely.points(2, [0, 1])
     assert_geometries_equal(actual, [shapely.Point(2, 0), shapely.Point(2, 1)])
@@ -151,6 +163,24 @@ def test_linestrings_from_coords():
             LineString([(0, 0), (2, 2)]),
         ],
     )
+
+
+def test_linestrings_from_coords_indices():
+    actual = shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], indices=[0, 0, 1, 1])
+    assert_geometries_equal(
+        actual,
+        [
+            LineString([(0, 1), (2, 3)]),
+            LineString([(4, 5), (6, 7)]),
+        ],
+    )
+
+
+def test_linestrings_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `linestrings` is deprecated"
+    ):
+        shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], None, None, [0, 0, 1, 1])
 
 
 def test_linestrings_from_xy():
@@ -300,6 +330,23 @@ def test_linearrings_empty():
 def test_linearrings_from_xy():
     actual = shapely.linearrings([0, 1, 2, 0], [3, 4, 5, 3])
     assert_geometries_equal(actual, LinearRing([(0, 3), (1, 4), (2, 5), (0, 3)]))
+
+
+def test_linearrings_from_coords():
+    actual = shapely.linearrings([[0, 1], [1, 1], [1, 0]])
+    assert_geometries_equal(actual, LinearRing([(0, 1), (1, 1), (1, 0), (0, 1)]))
+
+
+def test_linearrings_from_coords_indices():
+    actual = shapely.linearrings([[0, 1], [1, 1], [1, 0]], indices=[0, 0, 0])
+    assert_geometries_equal(actual, LinearRing([(0, 1), (1, 1), (1, 0), (0, 1)]))
+
+
+def test_linearrings_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `linearrings` is deprecated"
+    ):
+        shapely.linearrings([[0, 1], [1, 1], [1, 0]], None, None, [0, 0, 0])
 
 
 def test_linearrings_unclosed():

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -694,6 +694,13 @@ def test_box_nan(coords):
     assert shapely.box(*coords) is None
 
 
+def test_box_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `ccw` for `box` is deprecated"
+    ):
+        shapely.box(0, 0, 1, 1, True)
+
+
 def test_prepare():
     arr = np.array([shapely.points(1, 1), None, shapely.box(0, 0, 1, 1)])
     assert arr[0]._geom_prepared == 0

--- a/shapely/tests/test_creation_indices.py
+++ b/shapely/tests/test_creation_indices.py
@@ -527,3 +527,24 @@ def test_multipolygons():
 def test_incompatible_types(geometries, func):
     with pytest.raises(TypeError):
         func(geometries, indices=[0])
+
+
+def test_points_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `points` is deprecated"
+    ):
+        shapely.points([[0, 1], [2, 3]], None, None, [0, 1])
+
+
+def test_linestrings_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `linestrings` is deprecated"
+    ):
+        shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], None, None, [0, 0, 1, 1])
+
+
+def test_linearrings_pos_args_deprecation_warning():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `linearrings` is deprecated"
+    ):
+        shapely.linearrings([[0, 1], [1, 1], [1, 0]], None, None, [0, 0, 0])

--- a/shapely/tests/test_creation_indices.py
+++ b/shapely/tests/test_creation_indices.py
@@ -529,22 +529,57 @@ def test_incompatible_types(geometries, func):
         func(geometries, indices=[0])
 
 
-def test_points_pos_args_deprecation_warning():
+def test_points_deprecate_positional():
     with pytest.deprecated_call(
         match="positional argument `indices` for `points` is deprecated"
     ):
         shapely.points([[0, 1], [2, 3]], None, None, [0, 1])
 
 
-def test_linestrings_pos_args_deprecation_warning():
+def test_linestrings_deprecate_positional():
     with pytest.deprecated_call(
         match="positional argument `indices` for `linestrings` is deprecated"
     ):
         shapely.linestrings([[0, 1], [2, 3], [4, 5], [6, 7]], None, None, [0, 0, 1, 1])
 
 
-def test_linearrings_pos_args_deprecation_warning():
+def test_linearrings_deprecate_positional():
     with pytest.deprecated_call(
         match="positional argument `indices` for `linearrings` is deprecated"
     ):
         shapely.linearrings([[0, 1], [1, 1], [1, 0]], None, None, [0, 0, 0])
+
+
+def test_polygons_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `polygons` is deprecated"
+    ):
+        shapely.polygons([linear_ring, linear_ring], None, [0, 1])
+
+
+def test_multipoints_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `multipoints` is deprecated"
+    ):
+        shapely.multipoints([point, point], [0, 1])
+
+
+def test_multilinestrings_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `multilinestrings` is deprecated"
+    ):
+        shapely.multilinestrings([line_string, line_string], [0, 1])
+
+
+def test_multipolygons_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `multipolygons` is deprecated"
+    ):
+        shapely.multipolygons([polygon, polygon], [0, 1])
+
+
+def test_geometrycollections_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `indices` for `geometrycollections` is deprecated"
+    ):
+        shapely.geometrycollections([point, polygon], [0, 1])

--- a/shapely/tests/test_geometry.py
+++ b/shapely/tests/test_geometry.py
@@ -369,6 +369,13 @@ def test_get_parts_invalid_geometry(geom):
         shapely.get_parts(geom)
 
 
+def test_get_parts_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `return_index` for `get_parts` is deprecated"
+    ):
+        shapely.get_parts(multi_point, False)
+
+
 @pytest.mark.parametrize(
     "geom",
     [
@@ -429,6 +436,13 @@ def test_get_rings_invalid_dimensions(geom):
     """Only 1D inputs are supported"""
     with pytest.raises(ValueError, match="Array should be one dimensional"):
         shapely.get_parts(geom)
+
+
+def test_get_rings_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `return_index` for `get_rings` is deprecated"
+    ):
+        shapely.get_rings(polygon, False)
 
 
 def test_get_precision():

--- a/shapely/tests/test_linear.py
+++ b/shapely/tests/test_linear.py
@@ -90,6 +90,14 @@ def test_line_interpolate_point_nan():
     assert shapely.line_interpolate_point(line_string, np.nan) is None
 
 
+def test_line_interpolate_point_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `line_interpolate_point` "
+        "is deprecated"
+    ):
+        shapely.line_interpolate_point(line_string, 0, False)
+
+
 def test_line_locate_point_geom_array():
     point = shapely.points(0, 1)
     actual = shapely.line_locate_point([line_string, linear_ring], point)
@@ -125,6 +133,13 @@ def test_line_locate_point_invalid_geometry(normalized):
 
     with pytest.raises(shapely.GEOSException):
         shapely.line_locate_point(polygon, point, normalized=normalized)
+
+
+def test_line_locate_point_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `normalized` for `line_locate_point` is deprecated"
+    ):
+        shapely.line_locate_point(line_string, point, False)
 
 
 def test_line_merge_geom_array():

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -409,3 +409,65 @@ def test_uary_union_alias():
     actual = shapely.unary_union(geoms, grid_size=1)
     expected = shapely.union_all(geoms, grid_size=1)
     assert shapely.equals(actual, expected)
+
+
+def test_difference_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `difference` is deprecated"
+    ):
+        shapely.difference(point, point, None)
+
+
+def test_intersection_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `intersection` is deprecated"
+    ):
+        shapely.intersection(point, point, None)
+
+
+def test_intersection_all_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `axis` for `intersection_all` is deprecated"
+    ):
+        shapely.intersection_all([point, point], None)
+
+
+def test_symmetric_difference_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `symmetric_difference` is deprecated"
+    ):
+        shapely.symmetric_difference(point, point, None)
+
+
+def test_symmetric_difference_all_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `axis` for `symmetric_difference_all` is deprecated"
+    ):
+        shapely.symmetric_difference_all([point, point], None)
+
+
+def test_union_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `union` is deprecated"
+    ):
+        shapely.union(point, point, None)
+
+
+def test_union_all_deprecate_positional():
+    with pytest.deprecated_call(
+        match="positional argument `grid_size` for `union_all` is deprecated"
+    ):
+        shapely.union_all([point, point], None)
+    with pytest.deprecated_call(
+        match="positional arguments `grid_size` and `axis` for `union_all` "
+        "are deprecated"
+    ):
+        shapely.union_all([point, point], None, None)
+
+
+def test_coverage_union_all_deprecate_positional():
+    data = [shapely.box(0, 0, 1, 1), shapely.box(1, 0, 2, 1)]
+    with pytest.deprecated_call(
+        match="positional argument `axis` for `coverage_union_all` is deprecated"
+    ):
+        shapely.coverage_union_all(data, None)


### PR DESCRIPTION
This adds a few deprecation warnings to a few functions:

- `shapely.transform()` - warns about positional `include_z`, also described in docs
- `shapely.points()` - warns about positional `indices`
- `shapely.linestrings()` - warns about positional `indices`
- `shapely.linearrings()` - warns about positional `indices`

The last three creation functions don't note the deprecation warning, as I'm guessing it's not commonly used? <s>The tests appeared to be missing use with indices, so these tests are added (both as positional and keyword).</s> (Found the creation tests with "indices" in a separate test file.)

Xref to #2234 that introduced the decorator function and raised warnings for `shapely.get_coordinates`.

Are there any other public functions that have positional arguments that should probably be shifted towards keyword-only over time? If so, mention them here, so the deprecation warnings can be introduced for shapely 2.1.