### PR TITLE
FIX: allow .coords to include M coordinates if present

### DIFF
--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -8,10 +8,13 @@ class CoordinateSequence:
 
     Examples
     --------
-      >>> from shapely.wkt import loads
-      >>> g = loads('POINT (0.0 0.0)')
-      >>> list(g.coords)
-      [(0.0, 0.0)]
+    >>> from shapely.wkt import loads
+    >>> g = loads('POINT (0.0 0.0)')
+    >>> list(g.coords)
+    [(0.0, 0.0)]
+    >>> g = loads('POINT M (1 2 4)')
+    >>> g.coords[:]
+    [(1.0, 2.0, 4.0)]
 
     """
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -28,6 +28,8 @@ GEOMETRY_TYPES = [
     "GeometryCollection",
 ]
 
+_geos_ge_312 = shapely.geos_version >= (3, 12, 0)
+
 
 def geom_factory(g, parent=None):
     """Create a Shapely geometry instance from a pointer to a GEOS geometry.
@@ -216,7 +218,9 @@ class BaseGeometry(shapely.Geometry):
     @property
     def coords(self):
         """Access to geometry's coordinates (CoordinateSequence)."""
-        coords_array = shapely.get_coordinates(self, include_z=self.has_z)
+        has_z = self.has_z
+        has_m = self.has_m if _geos_ge_312 else False
+        coords_array = shapely.get_coordinates(self, include_z=has_z, include_m=has_m)
         return CoordinateSequence(coords_array)
 
     @property

--- a/shapely/tests/geometry/test_coords.py
+++ b/shapely/tests/geometry/test_coords.py
@@ -1,8 +1,17 @@
 import numpy as np
 import pytest
 
-from shapely import LineString
-from shapely.tests.common import line_string, line_string_z, point, point_z
+from shapely import LineString, geos_version
+from shapely.tests.common import (
+    line_string,
+    line_string_m,
+    line_string_z,
+    line_string_zm,
+    point,
+    point_m,
+    point_z,
+    point_zm,
+)
 
 
 class TestCoords:
@@ -100,3 +109,19 @@ def test_coords_array_copy(geom):
             np.array(coord_seq, copy=False)
     else:
         assert np.array(coord_seq, copy=False) is np.array(coord_seq, copy=False)
+
+
+@pytest.mark.skipif(geos_version < (3, 12, 0), reason="GEOS < 3.12")
+def test_coords_with_m():
+    assert point_m.coords[:] == [(2.0, 3.0, 5.0)]
+    assert point_zm.coords[:] == [(2.0, 3.0, 4.0, 5.0)]
+    assert line_string_m.coords[:] == [
+        (0.0, 0.0, 1.0),
+        (1.0, 0.0, 2.0),
+        (1.0, 1.0, 3.0),
+    ]
+    assert line_string_zm.coords[:] == [
+        (0.0, 0.0, 4.0, 1.0),
+        (1.0, 0.0, 4.0, 2.0),
+        (1.0, 1.0, 4.0, 3.0),
+    ]


### PR DESCRIPTION
This minor fix is an oversight related to #2234 where M coordinates should appear in the `.coords` property if present in the geometry.