### PR TITLE
ENH: Add m to points() / Point() functions

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -67,7 +67,8 @@ cdef int _create_simple_geometry(
     const double[:, :] coord_view,
     Py_ssize_t idx,
     unsigned int n_coords,
-    unsigned int dims,
+    char has_z,
+    char has_m,
     int geometry_type,
     char is_ring,
     int handle_nan,
@@ -82,7 +83,7 @@ cdef int _create_simple_geometry(
     cdef unsigned int actual_n_coords = 0
 
     errstate = PyGEOS_CoordSeq_FromBuffer(
-        geos_handle, &coord_view[idx, 0], n_coords, dims,
+        geos_handle, &coord_view[idx, 0], n_coords, has_z, has_m,
         is_ring, handle_nan, &seq
     )
     if errstate != PGERR_SUCCESS:
@@ -126,14 +127,25 @@ def _create_simple_geometry_raise_error(int errstate):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def simple_geometries_1d(object coordinates, object indices, int geometry_type, int handle_nan, object out = None):
+def simple_geometries_1d(object coordinates, object indices, int options, object out = None):
     cdef Py_ssize_t idx = 0
     cdef unsigned int coord_idx = 0
     cdef Py_ssize_t geom_idx = 0
     cdef unsigned int n_coords = 0
+    cdef int geometry_type = 0
+    cdef char has_z = 0
+    cdef char has_m = 0
+    cdef int handle_nan = 0
     cdef unsigned int ring_closure = 0
     cdef GEOSGeometry *geom = NULL
     cdef GEOSCoordSequence *seq = NULL
+
+    # unpack options from integer made by creation.py
+    geometry_type = options & 0b1111
+    has_z = options >> 5 & 0b1
+    has_m = options >> 6 & 0b1
+    handle_nan = options >> 7
+    # print(f"{geometry_type=}, {has_z=}, {has_m=}, {handle_nan=}")
 
     # Cast input arrays and define memoryviews for later usage
     coordinates = np.asarray(coordinates, dtype=np.float64, order="C")
@@ -148,8 +160,8 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
         raise ValueError("geometries and indices do not have equal size.")
 
     cdef unsigned int dims = coordinates.shape[1]
-    if dims not in {2, 3}:
-        raise ValueError("coordinates should be N by 2 or N by 3.")
+    if dims not in {2, 3, 4}:
+        raise ValueError("coordinates should be (N, 2), (N, 3) or (N, 4).")
 
     if geometry_type not in {0, 1, 2}:
         raise ValueError(f"Invalid geometry_type: {geometry_type}.")
@@ -188,8 +200,8 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
                         f"Index {geom_idx} is missing from the input indices."
                     )
             errstate = _create_simple_geometry(
-                geos_handle, coord_view, idx, n_coords, dims, geometry_type,
-                is_ring, handle_nan, &geom
+                geos_handle, coord_view, idx, n_coords, has_z, has_m,
+                geometry_type, is_ring, handle_nan, &geom
             )
             if errstate != PGERR_SUCCESS:
                 return _create_simple_geometry_raise_error(errstate)
@@ -479,6 +491,9 @@ def _from_ragged_array_multi_linear(
     cdef unsigned int dims = coordinates.shape[1]
     if dims not in {2, 3}:
         raise ValueError("coordinates should be N by 2 or N by 3.")
+    # TODO: update better handling of has_z and has_m
+    cdef char has_z = dims == 3
+    cdef char has_m = 0
 
     cdef int linear_type
     cdef char is_ring
@@ -511,8 +526,8 @@ def _from_ragged_array_multi_linear(
                     k2 = offsets1[k + 1]
                     n_coords = k2 - k1
                     errstate = _create_simple_geometry(
-                        geos_handle, coordinates, k1, n_coords, dims, linear_type,
-                        is_ring, handle_nan, &linear
+                        geos_handle, coordinates, k1, n_coords, has_z, has_m,
+                        linear_type, is_ring, handle_nan, &linear
                     )
                     if errstate != PGERR_SUCCESS:
                         _deallocate_arr(geos_handle, temp_linear_view, linear_idx)
@@ -598,6 +613,9 @@ def _from_ragged_array_multipolygon(
     cdef unsigned int dims = coordinates.shape[1]
     if dims not in {2, 3}:
         raise ValueError("coordinates should be N by 2 or N by 3.")
+    # TODO: update better handling of has_z and has_m
+    cdef char has_z = dims == 3
+    cdef char has_m = 0
 
     cdef int ring_type = 2
     cdef int geometry_type = 6  # MultiPolygon
@@ -631,8 +649,8 @@ def _from_ragged_array_multipolygon(
                         k2 = offsets1[k + 1]
                         n_coords = k2 - k1
                         errstate = _create_simple_geometry(
-                            geos_handle, coordinates, k1, n_coords, dims, ring_type,
-                            is_ring, handle_nan, &ring
+                            geos_handle, coordinates, k1, n_coords, has_z, has_m,
+                            ring_type, is_ring, handle_nan, &ring
                         )
                         if errstate != PGERR_SUCCESS:
                             _deallocate_arr(geos_handle, temp_rings_view, rings_idx)

--- a/shapely/_pygeos_api.pxd
+++ b/shapely/_pygeos_api.pxd
@@ -54,5 +54,5 @@ cdef extern from "c_api.h":
     char PyGEOS_GetGEOSGeometry(PyObject *obj, GEOSGeometry **out) nogil
     int PyGEOS_CoordSeq_FromBuffer(
         GEOSContextHandle_t ctx, const double* buf, unsigned int size,
-        unsigned int dims, char is_ring, int handle_nan,
+        char has_z, char has_m, char is_ring, int handle_nan,
         GEOSCoordSequence** coord_seq) nogil

--- a/shapely/tests/legacy/test_create_inconsistent_dimensionality.py
+++ b/shapely/tests/legacy/test_create_inconsistent_dimensionality.py
@@ -188,9 +188,13 @@ def test_create_from_geojson(geojson):
     with pytest.raises((ValueError, TypeError)) as exc:
         shape(geojson).wkt
     assert exc.match(
-        "Inconsistent coordinate dimensionality|Input operand 0 does not have enough "
-        "dimensions|ufunc 'linestrings' not supported for the input types|setting an "
-        "array element with a sequence. The requested array has an inhomogeneous shape"
+        "|".join(
+            [
+                "Inconsistent coordinate dimensionality",
+                "Input operand 0 does not have enough dimensions",
+                "setting an array element with a sequence",
+            ]
+        )
     )
 
 
@@ -200,9 +204,13 @@ def test_create_directly(constructor, args):
     with pytest.raises((ValueError, TypeError)) as exc:
         constructor(*args)
     assert exc.match(
-        "Inconsistent coordinate dimensionality|Input operand 0 does not have enough "
-        "dimensions|ufunc 'linestrings' not supported for the input types|setting an "
-        "array element with a sequence. The requested array has an inhomogeneous shape"
+        "|".join(
+            [
+                "Inconsistent coordinate dimensionality",
+                "Input operand 0 does not have enough dimensions",
+                "setting an array element with a sequence",
+            ]
+        )
     )
 
 

--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -37,8 +37,14 @@ def box_tpl(x1, y1, x2, y2):
 
 
 def test_points_from_coords():
-    actual = shapely.points([[0, 0], [2, 2]])
-    assert_geometries_equal(actual, [shapely.Point(0, 0), shapely.Point(2, 2)])
+    actual = shapely.points([[1, 2], [5, 6]])
+    assert_geometries_equal(actual, [shapely.Point(1, 2), shapely.Point(5, 6)])
+    actual = shapely.points([[1, 2, 3], [5, 6, 7]])
+    assert_geometries_equal(actual, [shapely.Point(1, 2, 3), shapely.Point(5, 6, 7)])
+    actual = shapely.points([[1, 2, 3, 4], [5, 6, 7, 8]])
+    assert_geometries_equal(
+        actual, [shapely.Point(1, 2, 3, 4), shapely.Point(5, 6, 7, 8)]
+    )
 
 
 def test_points_from_xy():
@@ -51,11 +57,23 @@ def test_points_from_xyz():
     assert_geometries_equal(actual, [shapely.Point(1, 1, 0), shapely.Point(1, 1, 1)])
 
 
-def test_points_invalid_ndim():
-    with pytest.raises(ValueError, match="dimension should be 2 or 3, got 4"):
-        shapely.points([0, 1, 2, 3])
+def test_points_from_xym():
+    actual = shapely.points(1, 2, m=[5, 6])
+    expected = [shapely.Point(1, 2, None, 5), shapely.Point(1, 2, None, 6)]
+    assert_geometries_equal(actual, expected)
 
-    with pytest.raises(ValueError, match="dimension should be 2 or 3, got 1"):
+
+def test_points_from_xyzm():
+    actual = shapely.points(1, 2, [3, 4], m=[5, 6])
+    expected = [shapely.Point(1, 2, 3, 5), shapely.Point(1, 2, 4, 6)]
+    assert_geometries_equal(actual, expected)
+
+
+def test_points_invalid_ndim():
+    with pytest.raises(ValueError, match="dimension should be 2, 3 or 4, got 5"):
+        shapely.points([0, 1, 2, 3, 4])
+
+    with pytest.raises(ValueError, match="dimension should be 2, 3 or 4, got 1"):
         shapely.points([0])
 
 
@@ -85,10 +103,11 @@ def test_points_nan_3D_all_nan_becomes_empty():
 
 @pytest.mark.skipif(shapely.geos_version < (3, 12, 0), reason="GEOS < 3.12")
 @pytest.mark.parametrize(
-    "coords,expected_wkt",
+    "coords, coords_has_m, expected_wkt",
     [
         pytest.param(
             [np.nan, np.nan],
+            False,
             "POINT (NaN NaN)",
             marks=pytest.mark.skipif(
                 shapely.geos_version < (3, 13, 0), reason="GEOS < 3.13"
@@ -96,19 +115,40 @@ def test_points_nan_3D_all_nan_becomes_empty():
         ),
         pytest.param(
             [np.nan, np.nan, np.nan],
+            False,
             "POINT Z (NaN NaN NaN)",
             marks=pytest.mark.skipif(
                 shapely.geos_version < (3, 13, 0), reason="GEOS < 3.13"
             ),
         ),
-        ([1, np.nan], "POINT (1 NaN)"),
-        ([np.nan, 1], "POINT (NaN 1)"),
-        ([np.nan, 1, np.nan], "POINT Z (NaN 1 NaN)"),
-        ([np.nan, np.nan, 1], "POINT Z (NaN NaN 1)"),
+        pytest.param(
+            [np.nan, np.nan, np.nan],
+            True,
+            "POINT M (NaN NaN NaN)",
+            marks=pytest.mark.skipif(
+                shapely.geos_version < (3, 13, 0), reason="GEOS < 3.13"
+            ),
+        ),
+        pytest.param(
+            [np.nan, np.nan, np.nan, np.nan],
+            True,
+            "POINT ZM (NaN NaN NaN NaN)",
+            marks=pytest.mark.skipif(
+                shapely.geos_version < (3, 13, 0), reason="GEOS < 3.13"
+            ),
+        ),
+        ([1, np.nan], False, "POINT (1 NaN)"),
+        ([np.nan, 1], False, "POINT (NaN 1)"),
+        ([np.nan, 1, np.nan], False, "POINT Z (NaN 1 NaN)"),
+        ([np.nan, np.nan, 1], False, "POINT Z (NaN NaN 1)"),
+        ([np.nan, 1, np.nan], True, "POINT M (NaN 1 NaN)"),
+        ([np.nan, np.nan, 1], True, "POINT M (NaN NaN 1)"),
+        ([np.nan, 1, np.nan, 1], True, "POINT ZM (NaN 1 NaN 1)"),
+        ([np.nan, np.nan, 1, np.nan], True, "POINT ZM (NaN NaN 1 NaN)"),
     ],
 )
-def test_points_handle_nan_allow(coords, expected_wkt):
-    actual = shapely.points(coords, handle_nan="allow")
+def test_points_handle_nan_allow(coords, coords_has_m, expected_wkt):
+    actual = shapely.points(coords, coords_has_m=coords_has_m, handle_nan="allow")
     assert actual.wkt == expected_wkt
 
 
@@ -129,6 +169,23 @@ def test_points_handle_nan(coords, handle_nan, expected_wkt):
     assert actual.wkt in expected_wkt
 
 
+@pytest.mark.skipif(shapely.geos_version < (3, 12, 0), reason="GEOS < 3.12")
+@pytest.mark.parametrize(
+    "coords,handle_nan,expected_wkt",
+    [
+        ([0, np.nan, 1], "skip", "POINT M EMPTY"),
+        ([0, 1, np.nan], "skip", "POINT M EMPTY"),
+        ([0, 1, 2], "error", "POINT M (0 1 2)"),
+        ([0, np.nan, 1, 2], "skip", "POINT ZM EMPTY"),
+        ([0, 1, np.nan, 1], "skip", "POINT ZM EMPTY"),
+        ([0, 1, 2, 3], "error", "POINT ZM (0 1 2 3)"),
+    ],
+)
+def test_points_zm_handle_nan(coords, handle_nan, expected_wkt):
+    actual = shapely.points(coords, coords_has_m=True, handle_nan=handle_nan)
+    assert actual.wkt in expected_wkt
+
+
 @pytest.mark.parametrize(
     "coords",
     [
@@ -142,6 +199,21 @@ def test_points_handle_nan(coords, handle_nan, expected_wkt):
 def test_points_nan_handle_nan_err(coords):
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.points(coords, handle_nan="error")
+
+
+@pytest.mark.parametrize(
+    "coords",
+    [
+        [0, np.nan],
+        [np.nan, 0],
+        [0, 0, np.nan],
+        [0, np.inf],
+        [0, -np.inf],
+    ],
+)
+def test_points_m_nan_handle_nan_err(coords):
+    with pytest.raises(ValueError, match=".*NaN.*"):
+        shapely.points(coords, coords_has_m=True, handle_nan="error")
 
 
 def test_linestrings_from_coords():

--- a/shapely/tests/test_creation_indices.py
+++ b/shapely/tests/test_creation_indices.py
@@ -5,7 +5,16 @@ from numpy.testing import assert_array_equal
 import shapely
 from shapely import LinearRing, Polygon
 from shapely.testing import assert_geometries_equal
-from shapely.tests.common import empty_point, line_string, linear_ring, point, polygon
+from shapely.tests.common import (
+    empty_point,
+    line_string,
+    linear_ring,
+    point,
+    point_m,
+    point_z,
+    point_zm,
+    polygon,
+)
 
 pnts = shapely.points
 lstrs = shapely.linestrings
@@ -20,7 +29,7 @@ geom_coll = shapely.geometrycollections
     [
         np.empty((2,)),  # not enough dimensions
         np.empty((2, 4, 1)),  # too many dimensions
-        np.empty((2, 4)),  # wrong inner dimension size
+        np.empty((2, 5)),  # wrong inner dimension size
         None,
         np.full((2, 2), "foo", dtype=object),  # wrong type
     ],
@@ -100,6 +109,32 @@ def test_points():
         indices=np.array([0, 1], dtype=np.intp),
     )
     assert_geometries_equal(actual, [point, point])
+
+
+def test_points_z():
+    actual = shapely.points(
+        np.array([[2, 3, 4], [2, 3, 4]], dtype=float),
+        indices=np.array([0, 1], dtype=np.intp),
+    )
+    assert_geometries_equal(actual, [point_z, point_z])
+
+
+@pytest.mark.skipif(shapely.geos_version < (3, 12, 0), reason="GEOS < 3.12")
+def test_points_m():
+    actual = shapely.points(
+        np.array([[2, 3, 5], [2, 3, 5]], dtype=float),
+        indices=np.array([0, 1], dtype=np.intp),
+    )
+    assert_geometries_equal(actual, [point_m, point_m])
+
+
+@pytest.mark.skipif(shapely.geos_version < (3, 12, 0), reason="GEOS < 3.12")
+def test_points_zm():
+    actual = shapely.points(
+        np.array([[2, 3, 4, 5], [2, 3, 4, 5]], dtype=float),
+        indices=np.array([0, 1], dtype=np.intp),
+    )
+    assert_geometries_equal(actual, [point_zm, point_zm])
 
 
 def test_points_no_index_raises():

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -24,8 +24,8 @@ extern char PyGEOS_GetGEOSGeometry(PyObject* obj, GEOSGeometry** out) {
 }
 
 extern int PyGEOS_CoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
-                                      unsigned int size, unsigned int dims, char is_ring,
+                                      unsigned int size, char has_z, char has_m, char is_ring,
                                       int handle_nan, GEOSCoordSequence** coord_seq) {
-  return coordseq_from_buffer(ctx, buf, size, dims, is_ring, handle_nan, dims * 8, 8,
-                              coord_seq);
+  return coordseq_from_buffer(ctx, buf, size, has_z, has_m, is_ring, handle_nan,
+                              (2 + has_z + has_m) * 8, 8, coord_seq);
 }

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -33,12 +33,12 @@
 #define PyGEOS_GetGEOSGeometry_PROTO (PyObject * obj, GEOSGeometry * *out)
 
 /* extern int PyGEOS_CoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
-                                      unsigned int size, unsigned int dims, char is_ring,
+                                      unsigned int size, char has_z, char has_m, char is_ring,
                                       int handle_nan, GEOSCoordSequence** coord_seq)*/
 #define PyGEOS_CoordSeq_FromBuffer_NUM 2
 #define PyGEOS_CoordSeq_FromBuffer_RETURN int
 #define PyGEOS_CoordSeq_FromBuffer_PROTO                                             \
-  (GEOSContextHandle_t ctx, const double* buf, unsigned int size, unsigned int dims, \
+  (GEOSContextHandle_t ctx, const double* buf, unsigned int size, char has_z, char has_m, \
    char is_ring, int handle_nan, GEOSCoordSequence** coord_seq)
 
 /* Total number of C API pointers */

--- a/src/geos.h
+++ b/src/geos.h
@@ -194,7 +194,8 @@ int get_bounds(GEOSContextHandle_t ctx, GEOSGeometry* geom, double* xmin, double
 GEOSGeometry* create_box(GEOSContextHandle_t ctx, double xmin, double ymin, double xmax,
                          double ymax, char ccw);
 extern enum ShapelyErrorCode create_point(GEOSContextHandle_t ctx, double x, double y,
-                                          double* z, int handle_nan, GEOSGeometry** out);
+                                          double* z, double* m,
+                                          int handle_nan, GEOSGeometry** out);
 GEOSGeometry* PyGEOSForce2D(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double z);
 
@@ -202,7 +203,7 @@ enum ShapelyHandleNan { SHAPELY_HANDLE_NAN_ALLOW, SHAPELY_HANDLE_NAN_SKIP, SHAPE
 
 extern enum ShapelyErrorCode coordseq_from_buffer(GEOSContextHandle_t ctx,
                                                   const double* buf, unsigned int size,
-                                                  unsigned int dims, char is_ring,
+                                                  char has_z, char has_m, char is_ring,
                                                   int handle_nan, npy_intp cs1,
                                                   npy_intp cs2,
                                 GEOSCoordSequence** coord_seq);

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -164,7 +164,7 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
   // A dummy query to trigger the build of the tree (only if the tree is not empty)
   if (count_indexed > 0) {
     GEOSGeometry* dummy = NULL;
-    errstate = create_point(ctx, 0.0, 0.0, NULL, SHAPELY_HANDLE_NAN_ALLOW, &dummy);
+    errstate = create_point(ctx, 0.0, 0.0, NULL, NULL, SHAPELY_HANDLE_NAN_ALLOW, &dummy);
     if (errstate != PGERR_SUCCESS) {
       GEOSSTRtree_destroy_r(ctx, tree);
       GEOS_FINISH;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -437,7 +437,7 @@ static void Ydd_b_p_func(char** args, const npy_intp* dimensions, const npy_intp
       ret = func(ctx, prepared_geom_tmp, in2, in3);
 #else
       GEOSGeometry *geom = NULL;
-      errstate = create_point(ctx, in2, in3, NULL, SHAPELY_HANDLE_NAN_ALLOW, &geom);
+      errstate = create_point(ctx, in2, in3, NULL, NULL, SHAPELY_HANDLE_NAN_ALLOW, &geom);
       if (errstate != PGERR_SUCCESS) {
         if (destroy_prepared) {
           GEOSPreparedGeom_destroy_r(ctx, prepared_geom_tmp);
@@ -2728,9 +2728,9 @@ static void points_func(char** args, const npy_intp* dimensions, const npy_intp*
   GEOSGeometry** geom_arr;
 
   // check the ordinate dimension before calling GEOSCoordSeq_create_r
-  if (dimensions[1] < 2 || dimensions[1] > 3) {
+  if (dimensions[1] < 2 || dimensions[1] > 4) {
     PyErr_Format(PyExc_ValueError,
-                 "The ordinate (last) dimension should be 2 or 3, got %ld",
+                 "The ordinate (last) dimension should be 2, 3 or 4, got %ld",
                  dimensions[1]);
     return;
   }
@@ -2740,7 +2740,19 @@ static void points_func(char** args, const npy_intp* dimensions, const npy_intp*
                  "points function called with non-scalar parameters");
     return;
   }
-  int handle_nan = *(int*)args[1];
+  int options = *(int*)args[1];
+  /* unpack options from integer made by creation.py */
+  int geom_type = options & 0b1111;
+  char has_z = options >> 5 & 0b1;
+  char has_m = options >> 6 & 0b1;
+  int handle_nan = options >> 7;
+  // printf("options 0b%b: geom_type %i, has_z %i, has_m %i, handle_nan %i\n", options, geom_type, has_z, has_m, handle_nan);
+
+  if (geom_type != GEOS_POINT) {
+    PyErr_Format(PyExc_ValueError, "invalid geometry type: %i", geom_type);
+    return;
+  }
+
 
   // allocate a temporary array to store output GEOSGeometry objects
   geom_arr = malloc(sizeof(void*) * dimensions[0]);
@@ -2761,7 +2773,8 @@ static void points_func(char** args, const npy_intp* dimensions, const npy_intp*
     // the per-point coordinates are retrieved by looping 2 or 3 (=n_c1) times
     // over "ip1" with a stride of "cs1"
     errstate = create_point(ctx, *(double*)ip1, *(double*)(ip1 + cs1),
-                            n_c1 == 3 ? (double*)(ip1 + 2 * cs1) : NULL,
+                            has_z ? (double*)(ip1 + 2 * cs1) : NULL,
+                            has_m ? (double*)(ip1 + (2 + has_z) * cs1) : NULL,
                             handle_nan, &(geom_arr[i]));
     if (errstate != PGERR_SUCCESS) {
       destroy_geom_arr(ctx, geom_arr, i - 1);
@@ -2798,6 +2811,9 @@ static void linestrings_func(char** args, const npy_intp* dimensions, const npy_
                  "Linestrings function called with non-scalar parameters");
     return;
   }
+  /* TODO: complete has_z and has_m */
+  char has_z = dimensions[2] == 3;
+  char has_m = 0;
   int handle_nan = *(int*)args[1];
 
   // allocate a temporary array to store output GEOSGeometry objects
@@ -2812,8 +2828,8 @@ static void linestrings_func(char** args, const npy_intp* dimensions, const npy_
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
     }
-    errstate = coordseq_from_buffer(ctx, (double*)ip1, n_c1, n_c2, 0, handle_nan, cs1,
-                                    cs2, &coord_seq);
+    errstate = coordseq_from_buffer(ctx, (double*)ip1, n_c1, has_z, has_m,
+                                    0, handle_nan, cs1, cs2, &coord_seq);
     if (errstate != PGERR_SUCCESS) {
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
@@ -2859,6 +2875,9 @@ static void linearrings_func(char** args, const npy_intp* dimensions, const npy_
                  "Linearrings function called with non-scalar parameters");
     return;
   }
+  /* TODO: complete has_z and has_m */
+  char has_z = dimensions[2] == 3;
+  char has_m = 0;
   int handle_nan = *(int*)args[1];
 
   // allocate a temporary array to store output GEOSGeometry objects
@@ -2874,8 +2893,8 @@ static void linearrings_func(char** args, const npy_intp* dimensions, const npy_
       goto finish;
     }
     /* fill the coordinate sequence */
-    errstate = coordseq_from_buffer(ctx, (double*)ip1, n_c1, n_c2, 1, handle_nan, cs1,
-                                    cs2, &coord_seq);
+    errstate = coordseq_from_buffer(ctx, (double*)ip1, n_c1, has_z, has_m,
+                                    1, handle_nan, cs1, cs2, &coord_seq);
     if (errstate != PGERR_SUCCESS) {
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;


### PR DESCRIPTION
This enhancement adds M coordinate support for point geometries, for example:
```pycon
>>> import shapely
>>> shapely.points(1, 2, 3, m=4)
<POINT ZM (1 2 3 4)>
>>> shapely.Point(1, 2, None, 4)
<POINT M (1 2 4)>
```

Currently these creation functions "work" with GEOS<3.12.0, but the M coordinates are ignored, creating XY or XYZ geometries instead of XYM and XYZM geometries. Should these attempts with older GEOS raise warnings?

The main `shapely.points()` function adds a few keyword-only arguments, `m=None` (array_like, optional) and `coords_has_m=None` (bool, optional). The last is used to evaluate `coords` with shape (N, 3) as either XYZ (default with `coords_has_m=None` or `False`) or XYM (`coords_has_m=True`).

It also changes some of the C API to allow other geometries to accept M coordinates, but this is a "minimal" PR to enable just point creations. A few "TODO" notes are added for future work.

Both the ufunc `points` and Cython `simple_geometries_1d()` functions replace `handle_nan` with an `options` int. This keeps the ufunc signature `(d),()->()` with a scalar to pass the options for the array. These options contain a simple bitmask for `geom_type`, `has_z`, `has_m` and `handle_nan`.

Here is a summary of other low-level API changes:

- `PyGEOS_CoordSeq_FromBuffer()`: replaces `unsigned int dims` with `char has_z, char has_m`
- `coordseq_from_buffer()`: replaces `unsigned int dims` with `char has_z, char has_m`
- Replace `PyGEOS_create3DEmptyPoint(GEOSContextHandle_t ctx)` with `PyGEOS_createEmptyPoint(GEOSContextHandle_t ctx, char has_z, char has_m)`
- `PyGEOS_createPoint`: add `double* m` parameter
- `create_point`: add `double* m` parameter

Next steps:

- [ ] Add M to `linestrings` / `LineString`
- [ ] Add M to collections like `multipoints` / `MultiPoint`
