### PR TITLE
DEPR: deprecate 'resolution' argument for BaseGeometry.buffer()

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -561,7 +561,7 @@ class BaseGeometry(shapely.Geometry):
         if resolution is not None:
             warn(
                 "The 'resolution' argument is deprecated. Use 'quad_segs' instead",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             quad_segs = resolution

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -471,9 +471,6 @@ class BaseGeometry(shapely.Geometry):
         ----------
         distance : float
             The distance to buffer around the object.
-        resolution : int, optional
-            The resolution of the buffer around each vertex of the
-            object.
         quad_segs : int, optional
             Sets the number of line segments used to approximate an
             angle fillet.
@@ -510,8 +507,8 @@ class BaseGeometry(shapely.Geometry):
             the regular buffer.  The End Cap Style for single-sided
             buffers is always ignored, and forced to the equivalent of
             CAP_FLAT.
-        quadsegs : int, optional
-            Deprecated alias for `quad_segs`.
+        quadsegs, resolution : int, optional
+            Deprecated aliases for `quad_segs`.
         **kwargs : dict, optional
             For backwards compatibility of renamed parameters. If an unsupported
             kwarg is passed, a `ValueError` will be raised.
@@ -560,9 +557,13 @@ class BaseGeometry(shapely.Geometry):
             )
             quad_segs = quadsegs
 
-        # TODO deprecate `resolution` keyword for shapely 2.1
         resolution = kwargs.pop("resolution", None)
         if resolution is not None:
+            warn(
+                "The 'resolution' argument is deprecated. Use 'quad_segs' instead",
+                FutureWarning,
+                stacklevel=2,
+            )
             quad_segs = resolution
         if kwargs:
             kwarg = list(kwargs.keys())[0]  # noqa

--- a/shapely/tests/legacy/test_buffer.py
+++ b/shapely/tests/legacy/test_buffer.py
@@ -167,7 +167,7 @@ def test_deprecated_quadsegs():
 
 def test_deprecated_resolution():
     point = geometry.Point(0, 0)
-    with pytest.warns(FutureWarning):
+    with pytest.deprecated_call(match="Use 'quad_segs' instead"):
         result = point.buffer(1, resolution=1)
     expected = point.buffer(1, quad_segs=1)
     assert result.equals(expected)

--- a/shapely/tests/legacy/test_buffer.py
+++ b/shapely/tests/legacy/test_buffer.py
@@ -165,8 +165,9 @@ def test_deprecated_quadsegs():
     assert result.equals(expected)
 
 
-def test_resolution_alias():
+def test_deprecated_resolution():
     point = geometry.Point(0, 0)
-    result = point.buffer(1, resolution=1)
+    with pytest.warns(FutureWarning):
+        result = point.buffer(1, resolution=1)
     expected = point.buffer(1, quad_segs=1)
     assert result.equals(expected)


### PR DESCRIPTION
Back in shapely-1.8, the `BaseGeometry.buffer()` function used `resolution=`
https://github.com/shapely/shapely/blob/9cf3cdfae7c9aa01b56c7151a51e6a517cceabdd/shapely/geometry/base.py#L541-L543
Since shapely-2.0 this has been renamed `quad_segs=`. This shows a FutureWarning if `resolution` is used.