### PR TITLE
DEPR: remove BaseGeometry.almost_equals()

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -873,46 +873,6 @@ class BaseGeometry(shapely.Geometry):
             shapely.equals_exact(self, other, tolerance, normalize=normalize)
         )
 
-    def almost_equals(self, other, decimal=6):
-        """Return True if all coordinates are equal to a specified decimal place.
-
-        .. deprecated:: 1.8.0
-            The 'almost_equals()' method is deprecated
-            and will be removed in Shapely 2.1 because the name is
-            confusing. The 'equals_exact()' method should be used
-            instead.
-
-        Refers to approximate coordinate equality, which requires
-        coordinates to be approximately equal and in the same order for
-        all components of a geometry.
-
-        Because of this it is possible for "equals()" to be True for two
-        geometries and "almost_equals()" to be False.
-
-        Examples
-        --------
-        >>> from shapely import LineString
-        >>> LineString(
-        ...     [(0, 0), (2, 2)]
-        ... ).equals_exact(
-        ...     LineString([(0, 0), (1, 1), (2, 2)]),
-        ...     1e-6
-        ... )
-        False
-
-        Returns
-        -------
-        bool
-
-        """
-        warn(
-            "The 'almost_equals()' method is deprecated and will be "
-            "removed in Shapely 2.1; use 'equals_exact()' instead",
-            ShapelyDeprecationWarning,
-            stacklevel=2,
-        )
-        return self.equals_exact(other, 0.5 * 10 ** (-decimal))
-
     def relate_pattern(self, other, pattern):
         """Return True if the DE-9IM relationship code satisfies the pattern."""
         return _maybe_unpack(shapely.relate_pattern(self, other, pattern))

--- a/shapely/tests/legacy/test_equality.py
+++ b/shapely/tests/legacy/test_equality.py
@@ -1,7 +1,6 @@
 import pytest
 
 from shapely import Point, Polygon
-from shapely.errors import ShapelyDeprecationWarning
 
 
 def test_equals_exact():
@@ -27,21 +26,9 @@ def test_equals_exact():
     assert not p1.equals_exact(p3, 1e-5)
 
 
-def test_almost_equals_default():
-    p1 = Point(1.0, 1.0)
-    p2 = Point(1.0 + 1e-7, 1.0 + 1e-7)  # almost equal to 6 places
-    p3 = Point(1.0 + 1e-6, 1.0 + 1e-6)  # not almost equal
-    with pytest.warns(ShapelyDeprecationWarning):
-        assert p1.almost_equals(p2)
-    with pytest.warns(ShapelyDeprecationWarning):
-        assert not p1.almost_equals(p3)
-
-
-def test_almost_equals():
+def test_almost_equals_removed():
+    # deprecated shapely 2.0, removed 2.1
     p1 = Point(1.0, 1.0)
     p2 = Point(1.1, 1.1)
-    assert not p1.equals(p2)
-    with pytest.warns(ShapelyDeprecationWarning):
-        assert p1.almost_equals(p2, 0)
-    with pytest.warns(ShapelyDeprecationWarning):
-        assert not p1.almost_equals(p2, 1)
+    with pytest.raises(AttributeError):
+        assert p1.almost_equals(p2)

--- a/shapely/tests/legacy/test_equality.py
+++ b/shapely/tests/legacy/test_equality.py
@@ -1,5 +1,3 @@
-import pytest
-
 from shapely import Point, Polygon
 
 
@@ -24,11 +22,3 @@ def test_equals_exact():
     hole2 = [(1, 1), (1, -1), (-1, -1), (-1, 1.01)]
     p3 = Polygon(shell, holes=[hole2])
     assert not p1.equals_exact(p3, 1e-5)
-
-
-def test_almost_equals_removed():
-    # deprecated shapely 2.0, removed 2.1
-    p1 = Point(1.0, 1.0)
-    p2 = Point(1.1, 1.1)
-    with pytest.raises(AttributeError):
-        assert p1.almost_equals(p2)


### PR DESCRIPTION
This removes `BaseGeometry.almost_equals()` as it has noted for a few years that it will be removed for shapely 2.1.

There are a few relevant xrefs:

- #1555 (ping @snowman2)
- #1604
- 26cafd027ab26a6b728ce8a3d26f0b9c8b114bf1

Is there anything further to consider? Or just remove it? (I have no string opinions on the matter, just reviewing 2.1 deprecations)