### PR TITLE
DEPR: deprecate 'project' and 'interpolate' linear referencing methods

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -840,7 +840,7 @@ Shapely supports linear referencing based on length or distance, evaluating the
 distance along a geometric object to the projection of a given point, or the
 point at a given distance along the object.
 
-.. method:: object.interpolate(distance[, normalized=False])
+.. method:: object.line_interpolate_point(distance[, normalized=False])
 
   Return a point at the specified distance along a linear geometric object.
 
@@ -849,26 +849,27 @@ fraction of the geometric object's length.
 
 .. code-block:: pycon
 
-  >>> ip = LineString([(0, 0), (0, 1), (1, 1)]).interpolate(1.5)
+  >>> line_string = LineString([(0, 0), (0, 1), (1, 1)])
+  >>> ip = line_string.line_interpolate_point(1.5)
   >>> ip
   <POINT (0.5 1)>
-  >>> LineString([(0, 0), (0, 1), (1, 1)]).interpolate(0.75, normalized=True)
+  >>> line_string.line_interpolate_point(0.75, normalized=True)
   <POINT (0.5 1)>
 
-.. method:: object.project(other[, normalized=False])
+.. method:: object.line_locate_point(other[, normalized=False])
 
   Returns the distance along this geometric object to a point nearest the
   `other` object.
 
 If the `normalized` arg is ``True``, return the distance normalized to the
-length of the object. The :meth:`~object.project` method is the inverse of
-:meth:`~object.interpolate`.
+length of the object. The :meth:`~object.line_locate_point` method is the
+inverse of :meth:`~object.line_interpolate_point`.
 
 .. code-block:: pycon
 
-  >>> LineString([(0, 0), (0, 1), (1, 1)]).project(ip)
+  >>> line_string.line_locate_point(ip)
   1.5
-  >>> LineString([(0, 0), (0, 1), (1, 1)]).project(ip, normalized=True)
+  >>> line_string.line_locate_point(ip, normalized=True)
   0.75
 
 For example, the linear referencing methods might be used to cut lines at a
@@ -882,13 +883,13 @@ specified distance.
           return [LineString(line)]
       coords = list(line.coords)
       for i, p in enumerate(coords):
-          pd = line.project(Point(p))
+          pd = line.line_locate_point(Point(p))
           if pd == distance:
               return [
                   LineString(coords[:i+1]),
                   LineString(coords[i:])]
           if pd > distance:
-              cp = line.interpolate(distance)
+              cp = line.line_interpolate_point(distance)
               return [
                   LineString(coords[:i] + [(cp.x, cp.y)]),
                   LineString([(cp.x, cp.y)] + coords[i:])]

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -895,29 +895,27 @@ class BaseGeometry(shapely.Geometry):
         If the normalized arg is True, return the distance normalized to the
         length of the linear geometry.
 
-        Alias of `project`.
+        Alias of deprecated `project`.
         """
         return _maybe_unpack(
             shapely.line_locate_point(self, other, normalized=normalized)
         )
 
-    # Note: future plan is to change this signature over a few releases:
-    # shapely 2.0:
-    #   project(self, other, normalized=False)
-    # shapely 2.1: shows deprecation warning about positional 'normalized'
-    #   same signature as 2.0
-    # shapely 2.2(?): enforce keyword-only arguments after 'other'
-    #   project(self, other, *, normalized=False)
-
-    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def project(self, other, normalized=False):
         """Return the distance of geometry to a point nearest the specified point.
 
         If the normalized arg is True, return the distance normalized to the
         length of the linear geometry.
 
-        Alias of `line_locate_point`.
+        .. deprecated:: 2.1
+            Use :meth:`line_locate_point` instead.
         """
+        warn(
+            "The 'project()' method is deprecated and will be "
+            "removed in a future version; use 'line_locate_point()' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return _maybe_unpack(
             shapely.line_locate_point(self, other, normalized=normalized)
         )
@@ -940,19 +938,10 @@ class BaseGeometry(shapely.Geometry):
         If the normalized arg is True, the distance will be interpreted as a
         fraction of the geometry's length.
 
-        Alias of `interpolate`.
+        Alias of deprecated `interpolate`.
         """
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
-    # Note: future plan is to change this signature over a few releases:
-    # shapely 2.0:
-    #   interpolate(self, distance, normalized=False)
-    # shapely 2.1: shows deprecation warning about positional 'normalized'
-    #   same signature as 2.0
-    # shapely 2.2(?): enforce keyword-only arguments after 'distance'
-    #   interpolate(self, distance, *, normalized=False)
-
-    @deprecate_positional(["normalized"], category=DeprecationWarning)
     def interpolate(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry.
 
@@ -962,8 +951,15 @@ class BaseGeometry(shapely.Geometry):
         If the normalized arg is True, the distance will be interpreted as a
         fraction of the geometry's length.
 
-        Alias of `line_interpolate_point`.
+        .. deprecated:: 2.1
+            Use :meth:`line_interpolate_point` instead.
         """
+        warn(
+            "The 'interpolate()' method is deprecated and will be "
+            "removed in a future version; use 'line_interpolate_point()' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return shapely.line_interpolate_point(self, distance, normalized=normalized)
 
     def segmentize(self, max_segment_length):

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -438,7 +438,7 @@ class SplitOp:
             return [line]
 
         # point is on line, get the distance from the first point on line
-        distance_on_line = line.project(splitter)
+        distance_on_line = line.line_locate_point(splitter)
         coords = list(line.coords)
         # split the line at the point and create two new lines
         current_position = 0.0
@@ -626,15 +626,15 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
     # Filter out cases in which to return a point
     if start_dist == end_dist:
-        return geom.interpolate(start_dist, normalized=normalized)
+        return geom.line_interpolate_point(start_dist, normalized=normalized)
     elif not normalized and start_dist >= geom.length and end_dist >= geom.length:
-        return geom.interpolate(geom.length, normalized=normalized)
+        return geom.line_interpolate_point(geom.length, normalized=normalized)
     elif not normalized and -start_dist >= geom.length and -end_dist >= geom.length:
-        return geom.interpolate(0, normalized=normalized)
+        return geom.line_interpolate_point(0, normalized=normalized)
     elif normalized and start_dist >= 1 and end_dist >= 1:
-        return geom.interpolate(1, normalized=normalized)
+        return geom.line_interpolate_point(1, normalized=normalized)
     elif normalized and -start_dist >= 1 and -end_dist >= 1:
-        return geom.interpolate(0, normalized=normalized)
+        return geom.line_interpolate_point(0, normalized=normalized)
 
     if normalized:
         start_dist *= geom.length
@@ -642,12 +642,12 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
     # Filter out cases where distances meet at a middle point from opposite ends.
     if start_dist < 0 < end_dist and abs(start_dist) + end_dist == geom.length:
-        return geom.interpolate(end_dist)
+        return geom.line_interpolate_point(end_dist)
     elif end_dist < 0 < start_dist and abs(end_dist) + start_dist == geom.length:
-        return geom.interpolate(start_dist)
+        return geom.line_interpolate_point(start_dist)
 
-    start_point = geom.interpolate(start_dist)
-    end_point = geom.interpolate(end_dist)
+    start_point = geom.line_interpolate_point(start_dist)
+    end_point = geom.line_interpolate_point(end_dist)
 
     if start_dist < 0:
         start_dist = geom.length + start_dist  # Values may still be negative,

--- a/shapely/tests/geometry/test_geometry_base.py
+++ b/shapely/tests/geometry/test_geometry_base.py
@@ -233,12 +233,11 @@ def test_array_argument_float(op):
     assert type(result) is float
 
 
-@pytest.mark.parametrize("op", ["line_interpolate_point", "interpolate"])
-def test_array_argument_linear_point(op):
+def test_array_argument_linear_point():
     line = LineString([(0, 0), (0, 1), (1, 1)])
     distances = np.array([0, 0.5, 1])
 
-    result = getattr(line, op)(distances)
+    result = line.line_interpolate_point(distances)
     assert isinstance(result, np.ndarray)
     expected = np.array(
         [line.line_interpolate_point(d) for d in distances], dtype=object
@@ -246,22 +245,21 @@ def test_array_argument_linear_point(op):
     assert_geometries_equal(result, expected)
 
     # check scalar
-    result = getattr(line, op)(distances[0])
+    result = line.line_interpolate_point(distances[0])
     assert isinstance(result, Point)
 
 
-@pytest.mark.parametrize("op", ["line_locate_point", "project"])
-def test_array_argument_linear_float(op):
+def test_array_argument_linear_float():
     line = LineString([(0, 0), (0, 1), (1, 1)])
     points = shapely.points([(0, 0), (0.5, 0.5), (1, 1)])
 
-    result = getattr(line, op)(points)
+    result = line.line_locate_point(points)
     assert isinstance(result, np.ndarray)
     expected = np.array([line.line_locate_point(p) for p in points], dtype="float64")
     np.testing.assert_array_equal(result, expected)
 
     # check scalar
-    result = getattr(line, op)(points[0])
+    result = line.line_locate_point(points[0])
     assert type(result) is float
 
 
@@ -344,11 +342,9 @@ def test_line_locate_point_deprecate_positional():
         line_string.line_locate_point(Point(1, 1), False)
 
 
-def test_project_deprecate_positional():
+def test_deprecate_project():
     line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
-    with pytest.deprecated_call(
-        match="positional argument `normalized` for `project` is deprecated"
-    ):
+    with pytest.deprecated_call():
         line_string.project(Point(1, 1), False)
 
 
@@ -361,9 +357,7 @@ def test_line_interpolate_point_deprecate_positional():
         line_string.line_interpolate_point(0, False)
 
 
-def test_interpolate_deprecate_positional():
+def test_deprecate_interpolate():
     line_string = LineString([(1.0, 2.0), (3.0, 4.0)])
-    with pytest.deprecated_call(
-        match="positional argument `normalized` for `interpolate` is deprecated"
-    ):
+    with pytest.deprecated_call():
         line_string.interpolate(0, False)

--- a/shapely/tests/legacy/test_linear_referencing.py
+++ b/shapely/tests/legacy/test_linear_referencing.py
@@ -16,36 +16,40 @@ class LinearReferencingTestCase(unittest.TestCase):
         )
 
     def test_line1_project(self):
-        assert self.line1.project(self.point) == 1.0
-        assert self.line1.project(self.point, normalized=True) == 0.5
+        assert self.line1.line_locate_point(self.point) == 1.0
+        assert self.line1.line_locate_point(self.point, normalized=True) == 0.5
 
     def test_alias_project(self):
         assert self.line1.line_locate_point(self.point) == 1.0
         assert self.line1.line_locate_point(self.point, normalized=True) == 0.5
 
     def test_line2_project(self):
-        assert self.line2.project(self.point) == 1.0
-        assert self.line2.project(self.point, normalized=True) == pytest.approx(
-            0.16666666666, 8
-        )
+        assert self.line2.line_locate_point(self.point) == 1.0
+        assert self.line2.line_locate_point(
+            self.point, normalized=True
+        ) == pytest.approx(0.16666666666, 8)
 
     def test_multiline_project(self):
-        assert self.multiline.project(self.point) == 1.0
-        assert self.multiline.project(self.point, normalized=True) == 0.125
+        assert self.multiline.line_locate_point(self.point) == 1.0
+        assert self.multiline.line_locate_point(self.point, normalized=True) == 0.125
 
     def test_not_supported_project(self):
         with pytest.raises(shapely.GEOSException, match="IllegalArgumentException"):
-            self.point.buffer(1.0).project(self.point)
+            self.point.buffer(1.0).line_locate_point(self.point)
 
     def test_not_on_line_project(self):
         # Points that aren't on the line project to 0.
-        assert self.line1.project(Point(-10, -10)) == 0.0
+        assert self.line1.line_locate_point(Point(-10, -10)) == 0.0
 
     def test_line1_interpolate(self):
-        assert self.line1.interpolate(0.5).equals(Point(0.5, 0.0))
-        assert self.line1.interpolate(-0.5).equals(Point(1.5, 0.0))
-        assert self.line1.interpolate(0.5, normalized=True).equals(Point(1, 0))
-        assert self.line1.interpolate(-0.5, normalized=True).equals(Point(1, 0))
+        assert self.line1.line_interpolate_point(0.5).equals(Point(0.5, 0.0))
+        assert self.line1.line_interpolate_point(-0.5).equals(Point(1.5, 0.0))
+        assert self.line1.line_interpolate_point(0.5, normalized=True).equals(
+            Point(1, 0)
+        )
+        assert self.line1.line_interpolate_point(-0.5, normalized=True).equals(
+            Point(1, 0)
+        )
 
     def test_alias_interpolate(self):
         assert self.line1.line_interpolate_point(0.5).equals(Point(0.5, 0.0))
@@ -58,15 +62,19 @@ class LinearReferencingTestCase(unittest.TestCase):
         )
 
     def test_line2_interpolate(self):
-        assert self.line2.interpolate(0.5).equals(Point(3.0, 0.5))
-        assert self.line2.interpolate(0.5, normalized=True).equals(Point(3, 3))
+        assert self.line2.line_interpolate_point(0.5).equals(Point(3.0, 0.5))
+        assert self.line2.line_interpolate_point(0.5, normalized=True).equals(
+            Point(3, 3)
+        )
 
     def test_multiline_interpolate(self):
-        assert self.multiline.interpolate(0.5).equals(Point(0.5, 0))
-        assert self.multiline.interpolate(0.5, normalized=True).equals(Point(3.0, 2.0))
+        assert self.multiline.line_interpolate_point(0.5).equals(Point(0.5, 0))
+        assert self.multiline.line_interpolate_point(0.5, normalized=True).equals(
+            Point(3.0, 2.0)
+        )
 
     def test_line_ends_interpolate(self):
         # Distances greater than length of the line or less than
         # zero yield the line's ends.
-        assert self.line1.interpolate(-1000).equals(Point(0.0, 0.0))
-        assert self.line1.interpolate(1000).equals(Point(2.0, 0.0))
+        assert self.line1.line_interpolate_point(-1000).equals(Point(0.0, 0.0))
+        assert self.line1.line_interpolate_point(1000).equals(Point(2.0, 0.0))

--- a/shapely/tests/legacy/test_operations.py
+++ b/shapely/tests/legacy/test_operations.py
@@ -99,19 +99,19 @@ class OperationsTestCase(unittest.TestCase):
         # successful interpolation
         test_line = LineString([(1, 1), (1, 2)])
         known_point = Point(1, 1.5)
-        interpolated_point = test_line.interpolate(0.5, normalized=True)
+        interpolated_point = test_line.line_interpolate_point(0.5, normalized=True)
         assert interpolated_point == known_point
 
         # Issue #653; should nog segfault for empty geometries
         empty_line = loads("LINESTRING EMPTY")
         assert empty_line.is_empty
-        interpolated_point = empty_line.interpolate(0.5, normalized=True)
+        interpolated_point = empty_line.line_interpolate_point(0.5, normalized=True)
         assert interpolated_point.is_empty
 
         # invalid geometry should raise TypeError on exception
         polygon = loads("POLYGON EMPTY")
         with pytest.raises(TypeError, match="incorrect geometry type"):
-            polygon.interpolate(0.5, normalized=True)
+            polygon.line_interpolate_point(0.5, normalized=True)
 
     def test_normalize(self):
         point = Point(1, 1)


### PR DESCRIPTION
This proposed deprecation is for two linear referencing methods in the BaseGeometry class:

- Deprecate `project()`, use [`line_locate_point()`](https://shapely.readthedocs.io/en/latest/reference/shapely.LineString.html#shapely.LineString.line_locate_point) instead
- Deprecate `interpolate()`, use [`line_interpolate_point()`](https://shapely.readthedocs.io/en/latest/reference/shapely.LineString.html#shapely.LineString.line_interpolate_point) instead

The `project()` and `interpolate()` methods have been around since early shapely releases, whereas `line_locate_point()` and `line_interpolate_point()` were introduced with shapely 2.0 via PyGEOS.

While the new method names are longer, their names are more likely help users describe what they do (without needing to look up the docs). The meanings of "project" and "interpolate" vary in different geospatial contexts, thus they are less clear to users what exactly they do.

What do folks think about this proposal?