### PR TITLE
DEPR: remove deprecated cascaded_union() method

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -1,11 +1,9 @@
 """Support for various GEOS geometry operations."""
 
-from warnings import warn
-
 import shapely
 from shapely import lib
 from shapely.algorithms.polylabel import polylabel  # noqa
-from shapely.errors import GeometryTypeError, ShapelyDeprecationWarning
+from shapely.errors import GeometryTypeError
 from shapely.geometry import (
     GeometryCollection,
     LineString,
@@ -20,7 +18,6 @@ from shapely.geometry.polygon import orient as orient_
 from shapely.prepared import prep
 
 __all__ = [
-    "cascaded_union",
     "clip_by_rect",
     "linemerge",
     "nearest_points",
@@ -113,20 +110,6 @@ class CollectionOperator:
             raise ValueError(f"Cannot linemerge {lines}")
         return shapely.line_merge(source, directed=directed)
 
-    def cascaded_union(self, geoms):
-        """Return the union of a sequence of geometries.
-
-        .. deprecated:: 1.8
-            This function was superseded by :meth:`unary_union`.
-        """
-        warn(
-            "The 'cascaded_union()' function is deprecated. "
-            "Use 'unary_union()' instead.",
-            ShapelyDeprecationWarning,
-            stacklevel=2,
-        )
-        return shapely.union_all(geoms, axis=None)
-
     def unary_union(self, geoms):
         """Return the union of a sequence of geometries.
 
@@ -140,7 +123,6 @@ operator = CollectionOperator()
 polygonize = operator.polygonize
 polygonize_full = operator.polygonize_full
 linemerge = operator.linemerge
-cascaded_union = operator.cascaded_union
 unary_union = operator.unary_union
 
 

--- a/shapely/tests/legacy/test_union.py
+++ b/shapely/tests/legacy/test_union.py
@@ -5,9 +5,8 @@ from itertools import islice
 
 import pytest
 
-from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import MultiPolygon, Point
-from shapely.ops import cascaded_union, unary_union
+from shapely.ops import unary_union
 
 
 def halton(base):
@@ -30,9 +29,7 @@ def halton(base):
 
 
 class UnionTestCase(unittest.TestCase):
-    def test_cascaded_union(self):
-        # cascaded_union is deprecated, as it was superseded by unary_union
-
+    def test_unary_union_partial(self):
         # Use a partial function to make 100 points uniformly distributed
         # in a 40x40 box centered on 0,0.
 
@@ -44,8 +41,7 @@ class UnionTestCase(unittest.TestCase):
 
         # Perform a cascaded union of the polygon spots, dissolving them
         # into a collection of polygon patches
-        with pytest.warns(ShapelyDeprecationWarning, match="is deprecated"):
-            u = cascaded_union(spots)
+        u = unary_union(spots)
         assert u.geom_type in ("Polygon", "MultiPolygon")
 
     def setUp(self):


### PR DESCRIPTION
This removes `cascaded_union()`, which has been deprecated since shapely 1.8

Related xrefs:

- #715
- #1025