### PR TITLE
DOC/RLS: update changelog notes for 2.1.0 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,8 +51,8 @@ New functions:
 - Add function ``constrained_delaunay_triangles`` (#1685)
 - Add function ``coverage_simplify`` to allow topological simplification of polygonal
   coverages (#1969)
-- Add function ``coverage_is_valid`` to validate an array of geometries as valid
-  topological coverage (#2156)
+- Add function ``coverage_is_valid`` and ``coverage_invalid_edges`` to validate
+  an array of geometries as valid topological coverage (#2156)
 - Add function ``equals_identical`` (#1760)
 - Add function ``has_m`` (#2008)
 - Add function ``get_m`` (#2019)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -48,6 +48,7 @@ New functions:
 - Add function ``minimum_clearance_line`` (#2106)
 - Add function ``maximum_inscribed_circle`` (#1307)
 - Add function ``orient_polygons`` (#2147)
+- Add function ``constrained_delaunay_triangles`` (#1685)
 - Add function ``coverage_simplify`` to allow topological simplification of polygonal
   coverages (#1969)
 - Add function ``coverage_is_valid`` to validate an array of geometries as valid

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,13 @@ Changes
 2.1.0 (unreleased)
 ------------------
 
+API changes:
+
+- Equality of geometries (``geom1 == geom2``) now considers NaN coordinate
+  values in the same location to be equal (#1775). It is recommended however to
+  ensure geometries don't have NaN values in the first place, for which you can
+  now use the ``handle_nan`` parameter in construction functions.
+
 Bug fixes:
 
 - Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13. (#1907)
@@ -14,32 +21,40 @@ Bug fixes:
 
 Improvements:
 
-- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
-- Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
-- Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and ``shapely.linearrings()``
-  to allow, skip, or error on nonfinite (NaN / Inf) coordinates. The default
-  behaviour (allow) is backwards compatible (#1594).
+- Add a ``handle_nan`` parameter to ``shapely.points()``,
+  ``shapely.linestrings()`` and ``shapely.linearrings()`` to allow, skip, or
+  error on nonfinite (NaN / Inf) coordinates. The default behaviour (allow) is
+  backwards compatible (#1594, #1811).
 - Add an ``interleaved`` parameter to ``shapely.transform()`` allowing a transposed call
   signature in the ``transformation`` function.
 - The ``include_z`` in ``shapely.transform()`` now also allows ``None``, which
   lets it automatically detect the dimensionality of each input geometry.
+- Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates`` (#2234, #2235)
 - Add parameters ``method`` and ``keep_collapsed`` to ``shapely.make_valid()`` (#1941)
-- Upgraded the GEOS version in the binary wheel distributions to 3.12.1.
-- Add ``disjoint_subset_union`` and ``disjoint_subset_union_all`` as an optimized
-  version of union and union_all, assuming inputs can be divided into subsets that do
-  not intersect. Requires at least GEOS 3.12.
 - The ``voronoi_polygons`` now accepts the ``ordered`` keyword, optionally forcing the
   order of polygons within the GeometryCollection to follow the order of input
   coordinates. Requires at least GEOS 3.12. (#1968)
 - Add option on ``invalid="fix"`` to ``from_wkb`` and ``from_wkt`` (#2094)
+- Add a ``normalize`` keyword to ``equals_exact`` (#1231)
+- Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
+- Add support to split polygons by multilinestrings (#2206)
+- Add an ``m`` attribute on the Point class and an ``has_m`` attribute on the base Geometry class.
+
+New functions:
+
+- Add ``disjoint_subset_union`` and ``disjoint_subset_union_all`` as an optimized
+  version of union and union_all, assuming inputs can be divided into subsets that do
+  not intersect. Requires at least GEOS 3.12.
 - Add function ``minimum_clearance_line`` (#2106)
 - Add function ``maximum_inscribed_circle`` (#1307)
-- Add support to split polygons by multilinestrings (#2206)
 - Add function ``orient_polygons`` (#2147)
 - Add function ``coverage_simplify`` to allow topological simplification of polygonal
   coverages (#1969)
 - Add function ``coverage_is_valid`` to validate an array of geometries as valid
   topological coverage (#2156)
+- Add function ``equals_identical`` (#1760)
+- Add function ``has_m`` (#2008)
+- Add function ``get_m`` (#2019)
 
 Breaking changes in GEOS 3.12:
 
@@ -64,7 +79,9 @@ Deprecations:
 
 Packaging:
 
+- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
 - Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
+- Upgraded the GEOS version in the binary wheel distributions to 3.13.1.
 
 2.0.7 (2025-01-30)
 ------------------

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -43,8 +43,9 @@ vectorized functions:
   can be divided into subsets that do not intersect. (requires GEOS >= 3.12)
 - :func:`.coverage_simplify` to allow topological simplification of polygonal
   coverages (#1969) (requires GEOS >= 3.12)
-- :func:`.coverage_is_valid` to validate an array of geometries as valid
-  topological coverage (#2156) (requires GEOS >= 3.12)
+- :func:`.coverage_is_valid` and :func:`.coverage_invalid_edges` to validate an
+  array of geometries as valid topological coverage (#2156) (requires
+  GEOS >= 3.12)
 - :func:`.has_m` (#2008) (requires GEOS >= 3.12)
 - :func:`.get_m` (#2019) (requires GEOS >= 3.12)
 

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -122,6 +122,9 @@ Deprecations:
   keyword in geometry constructor functions, etc) (#2237)
 - The ``resolution`` keyword in ``Geometry.buffer()`` is deprecated, use
   ``quad_segs`` instead (alraedy available since shapely 2.0) (#2243)
+- The ``symmetric_difference_all`` function behaves incorrectly and will be
+  removed in a future version. See
+  https://github.com/shapely/shapely/issues/2027 for more details.
 
 Removals from previous deprecations:
 

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -17,17 +17,18 @@ New functions:
 
 - :func:`.disjoint_subset_union` and :func:`.disjoint_subset_union_all` as an
   optimized version of :func:`.union` and :func:`.union_all`, assuming inputs
-  can be divided into subsets that do not intersect. (requires GEOS > 3.12)
+  can be divided into subsets that do not intersect. (requires GEOS >= 3.12)
 - :func:`.minimum_clearance_line` (#2106)
-- :func:`.maximum_inscribed_circle` (#1307)
+- :func:`.maximum_inscribed_circle` (polylabel) (#1307)
 - :func:`.orient_polygons` (#2147)
+- :func:`.constrained_delaunay_triangles` (#1685) (requires GEOS >= 3.10)
 - :func:`.coverage_simplify` to allow topological simplification of polygonal
-  coverages (#1969) (requires GEOS > 3.12)
+  coverages (#1969) (requires GEOS >= 3.12)
 - :func:`.coverage_is_valid` to validate an array of geometries as valid
-  topological coverage (#2156) (requires GEOS > 3.12)
-- :func:`.equals_identical`` (#1760)
-- :func:`.has_m`` (#2008) (requires GEOS > 3.12)
-- :func:`.get_m`` (#2019) (requires GEOS > 3.12)
+  topological coverage (#2156) (requires GEOS >= 3.12)
+- :func:`.equals_identical` (#1760)
+- :func:`.has_m` (#2008) (requires GEOS >= 3.12)
+- :func:`.get_m` (#2019) (requires GEOS >= 3.12)
 
 Improvements:
 
@@ -36,9 +37,10 @@ Improvements:
   error on nonfinite (NaN / Inf) coordinates. The default behaviour (allow) is
   backwards compatible (#1594, #1811).
 - Add an ``interleaved`` parameter to ``shapely.transform()`` allowing a
-  transposed call signature in the ``transformation`` function.
+  transposed call signature in the ``transformation`` function (#1849).
 - The ``include_z`` in ``shapely.transform()`` now also allows ``None``, which
-  lets it automatically detect the dimensionality of each input geometry.
+  lets it automatically detect the dimensionality of each input geometry
+  (#1849).
 - Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates``
   (#2234, #2235)
 - Add parameters ``method`` and ``keep_collapsed`` to ``shapely.make_valid()``
@@ -46,12 +48,22 @@ Improvements:
 - The ``voronoi_polygons`` now accepts the ``ordered`` keyword, optionally
   forcing the order of polygons within the GeometryCollection to follow the
   order of input coordinates. Requires at least GEOS 3.12. (#1968)
-- Add option on ``invalid="fix"`` to ``from_wkb`` and ``from_wkt`` (#2094)
-- Add a ``normalize`` keyword to ``equals_exact`` (#1231)
+- Add option ``on_invalid="fix"`` to ``from_wkb`` and ``from_wkt`` (#2094)
+- Add a ``normalize`` keyword to ``equals_exact`` to normalize the input
+  geometries (#1231)
 - Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
 - Add support to split polygons by multilinestrings (#2206)
 - Add an ``m`` attribute on the Point class and an ``has_m`` attribute on the
   base Geometry class.
+
+Performance improvements:
+
+- Single geometry input to ``contains_xy`` and ``intersects_xy`` now gets
+  prepared automatically, providing a considerable speedup (#2146).
+- Improved ``from_ragged_array`` performance (#2142, #2225).
+- Improved ``MultiPoint(..)`` constructor from a numpy array of coordinates
+  (#1961).
+
 
 Bug fixes:
 
@@ -62,6 +74,11 @@ Bug fixes:
 - Fixes `__geo_interface__` handling of empty points (#2120)
 - Fixes ``GeometryCollection()`` constructor accepting an array of geometries
   (#2017).
+- Fixes the ``MultiPolygon()`` constructor from a numpy array of Polygons
+  (#1880).
+- Raise proper error message when trying to construct a MultiPolygon from a
+  sequence of MultiPolygons (#1786).
+- Fixes ``shapely.ops.orient()`` for empty polygons (#2214).
 
 Breaking changes in GEOS 3.12:
 
@@ -84,6 +101,20 @@ Deprecations:
 - The ``shapely.vectorized`` module is deprecated. The two functions
   (``contains`` and ``touches``) can be replaced by the top-level vectorized
   functions ``contains_xy`` and ``intersects_xy`` (#1630).
+- Various parameters will be required to be passed as a keyword argument in the
+  future, and specifying it as a positional argument is deprecated and raises a
+  warning (for example, the ``grid_size`` keyword in set operations, boolean
+  flags such as the ``normalized`` or ``include_z`` keywords, the ``indices``
+  keyword in geometry constructor functions, etc) (#2237)
+- The ``resolution`` keyword in ``Geometry.buffer()`` is deprecated, use
+  ``quad_segs`` instead (alraedy available since shapely 2.0) (#2243)
+
+Removals from previous deprecations:
+
+- The ``almost_equals`` method on the Geometry class. Use :func:`.equals_exact`
+  instead (#2244)
+- The ``shapely.ops.cascaded_union()`` function has been removed. Use
+  :func:`.unary_union` instead (#2246).
 
 Packaging:
 

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -14,6 +14,7 @@ Initial support for geometries with M or ZM values
 
 Shapely geometries can now represent coordinates with M values (measure) in
 addition to X, Y, and Z (requires GEOS >= 3.12).
+The initial support includes:
 
 - Creating geometries from WKT or WKB with M values will now preserve the M
   values.
@@ -152,6 +153,9 @@ Packaging
   #1885, #2124)
 - Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
 - Upgraded the GEOS version in the binary wheel distributions to 3.13.1.
+- Initial support for free-threaded Python builds, with the extension module
+  declaring free-threaded support and wheels for Python 3.13t being built
+  (#2138).
 
 Acknowledgments
 ^^^^^^^^^^^^^^^

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -6,31 +6,49 @@ Version 2.x
 Version 2.1.0 (unreleased)
 --------------------------
 
-API changes:
+New features
+^^^^^^^^^^^^
 
-- Equality of geometries (``geom1 == geom2``) now considers NaN coordinate
-  values in the same location to be equal (#1775). It is recommended however to
-  ensure geometries don't have NaN values in the first place, for which you can
-  now use the ``handle_nan`` parameter in construction functions.
+Initial support for geometries with M or ZM values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-New functions:
+Shapely geometries can now represent coordinates with M values (measure) in
+addition to X, Y, and Z (requires GEOS >= 3.12).
 
-- :func:`.disjoint_subset_union` and :func:`.disjoint_subset_union_all` as an
-  optimized version of :func:`.union` and :func:`.union_all`, assuming inputs
-  can be divided into subsets that do not intersect. (requires GEOS >= 3.12)
+- Creating geometries from WKT or WKB with M values will now preserve the M
+  values.
+- Exporting geometries to WKT and WKB will include the M values by default, if
+  present (#1808).
+- The ``Geometry`` class now has a ``.has_m`` attribute to check if the
+  geometry has M values (#2008). The Point subclass has a ``.m`` attribute to
+  access the M value (#2019). The ``.coords`` attribute will include
+  the M value, if present (#2238).
+- Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates``
+  (#2234, #2235).
+
+New functions
+~~~~~~~~~~~~~
+
+Several (new) functions from GEOS are now exposed in Shapely as top-level
+vectorized functions:
+
 - :func:`.minimum_clearance_line` (#2106)
 - :func:`.maximum_inscribed_circle` (polylabel) (#1307)
 - :func:`.orient_polygons` (#2147)
 - :func:`.constrained_delaunay_triangles` (#1685) (requires GEOS >= 3.10)
+- :func:`.equals_identical` (#1760)
+- :func:`.disjoint_subset_union` and :func:`.disjoint_subset_union_all` as an
+  optimized version of :func:`.union` and :func:`.union_all`, assuming inputs
+  can be divided into subsets that do not intersect. (requires GEOS >= 3.12)
 - :func:`.coverage_simplify` to allow topological simplification of polygonal
   coverages (#1969) (requires GEOS >= 3.12)
 - :func:`.coverage_is_valid` to validate an array of geometries as valid
   topological coverage (#2156) (requires GEOS >= 3.12)
-- :func:`.equals_identical` (#1760)
 - :func:`.has_m` (#2008) (requires GEOS >= 3.12)
 - :func:`.get_m` (#2019) (requires GEOS >= 3.12)
 
-Improvements:
+Other improvements
+~~~~~~~~~~~~~~~~~~
 
 - Add a ``handle_nan`` parameter to ``shapely.points()``,
   ``shapely.linestrings()`` and ``shapely.linearrings()`` to allow, skip, or
@@ -41,8 +59,6 @@ Improvements:
 - The ``include_z`` in ``shapely.transform()`` now also allows ``None``, which
   lets it automatically detect the dimensionality of each input geometry
   (#1849).
-- Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates``
-  (#2234, #2235)
 - Add parameters ``method`` and ``keep_collapsed`` to ``shapely.make_valid()``
   (#1941)
 - The ``voronoi_polygons`` now accepts the ``ordered`` keyword, optionally
@@ -53,8 +69,10 @@ Improvements:
   geometries (#1231)
 - Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
 - Add support to split polygons by multilinestrings (#2206)
-- Add an ``m`` attribute on the Point class and an ``has_m`` attribute on the
-  base Geometry class.
+- The ``to_ragged_array()`` function will now use int32 offsets instead of
+  int64, when possible, reducing memory usage and improving compatibility with
+  the Arrow ecosystem (#2223).
+- Support sliced offsets in ``from_ragged_array()`` (#2255).
 
 Performance improvements:
 
@@ -64,21 +82,15 @@ Performance improvements:
 - Improved ``MultiPoint(..)`` constructor from a numpy array of coordinates
   (#1961).
 
+API changes
+^^^^^^^^^^^
 
-Bug fixes:
+Breaking change:
 
-- Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13.
-  (#1907)
-- Ensure ``plot_polygon`` does not color the interiors of polygons (#1933).
-- Fixes GeoJSON serialization of empty points (#2118)
-- Fixes `__geo_interface__` handling of empty points (#2120)
-- Fixes ``GeometryCollection()`` constructor accepting an array of geometries
-  (#2017).
-- Fixes the ``MultiPolygon()`` constructor from a numpy array of Polygons
-  (#1880).
-- Raise proper error message when trying to construct a MultiPolygon from a
-  sequence of MultiPolygons (#1786).
-- Fixes ``shapely.ops.orient()`` for empty polygons (#2214).
+- Equality of geometries (``geom1 == geom2``) now considers NaN coordinate
+  values in the same location to be equal (#1775). It is recommended however to
+  ensure geometries don't have NaN values in the first place, for which you can
+  now use the ``handle_nan`` parameter in construction functions.
 
 Breaking changes in GEOS 3.12:
 
@@ -116,11 +128,38 @@ Removals from previous deprecations:
 - The ``shapely.ops.cascaded_union()`` function has been removed. Use
   :func:`.unary_union` instead (#2246).
 
-Packaging:
+Bug fixes
+^^^^^^^^^
 
-- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
+- Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13.
+  (#1907)
+- Ensure ``plot_polygon`` does not color the interiors of polygons (#1933).
+- Fixes GeoJSON serialization of empty points (#2118)
+- Fixes `__geo_interface__` handling of empty points (#2120)
+- Fixes ``GeometryCollection()`` constructor accepting an array of geometries
+  (#2017).
+- Fixes the ``MultiPolygon()`` constructor from a numpy array of Polygons
+  (#1880).
+- Raise proper error message when trying to construct a MultiPolygon from a
+  sequence of MultiPolygons (#1786).
+- Fixes ``shapely.ops.orient()`` for empty polygons (#2214).
+- Fixes ``to_geojson()`` with empty points (#2118).
+
+Packaging
+^^^^^^^^^
+
+- Shapely 2.1.0 requires GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802,
+  #1885, #2124)
 - Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
 - Upgraded the GEOS version in the binary wheel distributions to 3.13.1.
+
+Acknowledgments
+^^^^^^^^^^^^^^^
+
+Thanks to everyone who contributed to this release!
+People with a "+" by their names contributed a patch for the first time.
+
+
 
 .. _version-2-0-7:
 

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -159,7 +159,48 @@ Acknowledgments
 Thanks to everyone who contributed to this release!
 People with a "+" by their names contributed a patch for the first time.
 
-
+* Adam J. Stewart
+* Ali Hamdan +
+* Andrea Giudiceandrea +
+* Antoni Gołoś +
+* Ben Beasley
+* Bill Mill +
+* Brendan Ward
+* Casper van der Wel
+* David Hoese +
+* Erik Pettersson +
+* Frédéric Junod
+* Gabriel Homsi +
+* Gareth Simons +
+* Greg Lucas +
+* Hood Chatham +
+* Ian Williamson +
+* Idan Miara +
+* Joris Van den Bossche
+* JuriaanSioux +
+* Kyle Barron
+* Luke Lashley +
+* Lyle Cheatham +
+* Marek Czaplicki +
+* Martin Fleischmann
+* Mathew Topper +
+* Mathias Hauser +
+* Michał Górny +
+* Mike Taves
+* Nicolas Hammje +
+* Oreille +
+* Paul Jurczak +
+* Pieter Roggemans +
+* Raja Gangopadhya
+* Sean Gillies
+* Sebastian Castro +
+* Tetsuo Koyama +
+* Tom Augspurger +
+* Wentao Li +
+* nobkd +
+* quassy +
+* tfardet +
+* void-rooster +
 
 .. _version-2-0-7:
 

--- a/docs/release/2.x.rst
+++ b/docs/release/2.x.rst
@@ -13,12 +13,83 @@ API changes:
   ensure geometries don't have NaN values in the first place, for which you can
   now use the ``handle_nan`` parameter in construction functions.
 
+New functions:
+
+- :func:`.disjoint_subset_union` and :func:`.disjoint_subset_union_all` as an
+  optimized version of :func:`.union` and :func:`.union_all`, assuming inputs
+  can be divided into subsets that do not intersect. (requires GEOS > 3.12)
+- :func:`.minimum_clearance_line` (#2106)
+- :func:`.maximum_inscribed_circle` (#1307)
+- :func:`.orient_polygons` (#2147)
+- :func:`.coverage_simplify` to allow topological simplification of polygonal
+  coverages (#1969) (requires GEOS > 3.12)
+- :func:`.coverage_is_valid` to validate an array of geometries as valid
+  topological coverage (#2156) (requires GEOS > 3.12)
+- :func:`.equals_identical`` (#1760)
+- :func:`.has_m`` (#2008) (requires GEOS > 3.12)
+- :func:`.get_m`` (#2019) (requires GEOS > 3.12)
+
 Improvements:
 
+- Add a ``handle_nan`` parameter to ``shapely.points()``,
+  ``shapely.linestrings()`` and ``shapely.linearrings()`` to allow, skip, or
+  error on nonfinite (NaN / Inf) coordinates. The default behaviour (allow) is
+  backwards compatible (#1594, #1811).
+- Add an ``interleaved`` parameter to ``shapely.transform()`` allowing a
+  transposed call signature in the ``transformation`` function.
+- The ``include_z`` in ``shapely.transform()`` now also allows ``None``, which
+  lets it automatically detect the dimensionality of each input geometry.
+- Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates``
+  (#2234, #2235)
+- Add parameters ``method`` and ``keep_collapsed`` to ``shapely.make_valid()``
+  (#1941)
+- The ``voronoi_polygons`` now accepts the ``ordered`` keyword, optionally
+  forcing the order of polygons within the GeometryCollection to follow the
+  order of input coordinates. Requires at least GEOS 3.12. (#1968)
+- Add option on ``invalid="fix"`` to ``from_wkb`` and ``from_wkt`` (#2094)
+- Add a ``normalize`` keyword to ``equals_exact`` (#1231)
+- Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
+- Add support to split polygons by multilinestrings (#2206)
+- Add an ``m`` attribute on the Point class and an ``has_m`` attribute on the
+  base Geometry class.
+
+Bug fixes:
+
+- Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13.
+  (#1907)
+- Ensure ``plot_polygon`` does not color the interiors of polygons (#1933).
+- Fixes GeoJSON serialization of empty points (#2118)
+- Fixes `__geo_interface__` handling of empty points (#2120)
+- Fixes ``GeometryCollection()`` constructor accepting an array of geometries
+  (#2017).
+
+Breaking changes in GEOS 3.12:
+
+- ``oriented_envelope`` / ``minimum_rotated_rectangle`` changed its
+  implementation in GEOS 3.12. Be aware that results will change when updating
+  GEOS. Coincidentally the implementation is similar to the shapely 1.x
+  approach. (#1885)
+- ``get_coordinate_dimension`` / ``has_z`` now considers geometries three
+  dimensional if they have a NaN z coordinate. (#1885)
+- ``voronoi_polygons`` changed its output from a LINESTRING to a
+  MULTILINESTRING in case ``only_edges=True``. (#1885)
+- The WKT representation of a MULTIPOINT changed from for example
+  "MULTIPOINT (0 0, 1 1)" to "MULTIPOINT ((0 0), (1 1))". (#1885)
+
+Deprecations:
+
+- The ``shapely.geos`` module is deprecated. All GEOS-version related
+  attributes are available directly from the top-level ``shapely`` namespace
+  as well (already since shapely 2.0) (#2145).
+- The ``shapely.vectorized`` module is deprecated. The two functions
+  (``contains`` and ``touches``) can be replaced by the top-level vectorized
+  functions ``contains_xy`` and ``intersects_xy`` (#1630).
+
+Packaging:
+
 - Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
-- Add a ``handle_nan`` parameter to ``shapely.linestrings()`` and
-  ``shapely.linearrings()`` to allow, skip, or error on nonfinite (NaN / Inf)
-  coordinates. The default behaviour (allow) is backwards compatible (#1594).
+- Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
+- Upgraded the GEOS version in the binary wheel distributions to 3.13.1.
 
 .. _version-2-0-7:
 

--- a/shapely/_coverage.py
+++ b/shapely/_coverage.py
@@ -16,6 +16,8 @@ def coverage_is_valid(geometry, **kwargs):
 
     Geometries that are not Polygon or MultiPolygon are ignored.
 
+    .. versionadded:: 2.1.0
+
     Parameters
     ----------
     geometry : array_like
@@ -57,6 +59,8 @@ def coverage_simplify(geometry, tolerance, *, simplify_boundary=True):
 
     If the geometry is polygonal but does not form a valid coverage due to overlaps,
     it will be simplified but it may result in invalid topology.
+
+    .. versionadded:: 2.1.0
 
     Parameters
     ----------

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -285,6 +285,7 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
           unclosed rings). If this is not possible, they are returned as
           ``None`` without a warning. Requires GEOS >= 3.11.
 
+          .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 
@@ -328,6 +329,7 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
           unclosed rings). If this is not possible, they are returned as
           ``None`` without a warning. Requires GEOS >= 3.11.
 
+          .. versionadded:: 2.1.0
     **kwargs
         See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
 

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -1121,7 +1121,7 @@ def equals_identical(a, b, **kwargs):
     This function is the vectorized equivalent of scalar equality of
     geometry objects (``a == b``, i.e. ``__eq__``).
 
-    .. versionadded:: 2.1
+    .. versionadded:: 2.1.0
 
     Parameters
     ----------


### PR DESCRIPTION
Starting to update the release notes for 2.1.0. For now adding some missing things and aligning CHANGES.txt and 
docs/release/2.x.rst (some things were only added in one of both). 

If we follow the same approach as for 2.0.0, we could further expand the doc page a bit more (e.g. add an explicit section about M support or about coverage support), and at the same time reduce the content in CHANGES.txt. But also happy to keep both in sync (although it is not great to have to keep both)