### PR TITLE
TST: support sliced offsets in from_ragged_array

### DIFF
--- a/shapely/_ragged_array.py
+++ b/shapely/_ragged_array.py
@@ -347,6 +347,8 @@ def _point_from_flatcoords(coords):
 
 def _multipoint_from_flatcoords(coords, offsets):
     # recreate points
+    if len(offsets):
+        coords = coords[offsets[0] :]
     points = creation.points(coords)
 
     # recreate multipoints
@@ -364,6 +366,8 @@ def _multipoint_from_flatcoords(coords, offsets):
 
 def _linestring_from_flatcoords(coords, offsets):
     # recreate linestrings
+    if len(offsets):
+        coords = coords[offsets[0] :]
     linestring_n = np.diff(offsets)
     linestring_indices = np.repeat(np.arange(len(linestring_n)), linestring_n)
 

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -246,10 +246,14 @@ def test_linestrings():
     arr[-2] = shapely.from_wkt("LINESTRING EMPTY")
     assert_geometries_equal(result, arr)
 
-    # # sliced
-    # offsets_sliced = (offsets[0][1:],)
-    # result = shapely.from_ragged_array(typ, coords, offsets_sliced)
-    # assert_geometries_equal(result, arr[1:])
+    # sliced
+    offsets_sliced = (offsets[0][1:],)
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[1:])
+
+    offsets_sliced = (offsets[0][:-1],)
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[:-1])
 
 
 def test_polygons():
@@ -311,6 +315,10 @@ def test_polygons():
     result = shapely.from_ragged_array(typ, coords, offsets_sliced)
     assert_geometries_equal(result, arr[1:])
 
+    offsets_sliced = (offsets[0], offsets[1][:-1])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[:-1])
+
 
 def test_multipoints():
     arr = shapely.from_wkt(
@@ -350,10 +358,14 @@ def test_multipoints():
     arr[-2] = shapely.from_wkt("MULTIPOINT EMPTY")
     assert_geometries_equal(result, arr)
 
-    # # sliced:
-    # offsets_sliced = (offsets[0][1:],)
-    # result = shapely.from_ragged_array(typ, coords, offsets_sliced)
-    # assert_geometries_equal(result, arr[1:])
+    # sliced:
+    offsets_sliced = (offsets[0][1:],)
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[1:])
+
+    offsets_sliced = (offsets[0][:-1],)
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[:-1])
 
 
 def test_multilinestrings():
@@ -412,6 +424,10 @@ def test_multilinestrings():
     offsets_sliced = (offsets[0], offsets[1][1:])
     result = shapely.from_ragged_array(typ, coords, offsets_sliced)
     assert_geometries_equal(result, arr[1:])
+
+    offsets_sliced = (offsets[0], offsets[1][:-1])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[:-1])
 
 
 def test_multipolygons():
@@ -481,6 +497,11 @@ def test_multipolygons():
     offsets_sliced = (offsets[0], offsets[1], offsets[2][1:])
     result = shapely.from_ragged_array(typ, coords, offsets_sliced)
     assert_geometries_equal(result, arr[1:])
+
+    offsets_sliced = (offsets[0], offsets[1], offsets[2][:-3])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[:-3])
+    print(result)
 
 
 def test_mixture_point_multipoint():

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -246,6 +246,11 @@ def test_linestrings():
     arr[-2] = shapely.from_wkt("LINESTRING EMPTY")
     assert_geometries_equal(result, arr)
 
+    # # sliced
+    # offsets_sliced = (offsets[0][1:],)
+    # result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    # assert_geometries_equal(result, arr[1:])
+
 
 def test_polygons():
     arr = shapely.from_wkt(
@@ -299,6 +304,13 @@ def test_polygons():
     arr[-2] = shapely.from_wkt("POLYGON EMPTY")
     assert_geometries_equal(result, arr)
 
+    # sliced:
+    # - indices into the coordinate array for the whole buffer
+    # - indices into the ring array for *just* the sliced part
+    offsets_sliced = (offsets[0], offsets[1][1:])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[1:])
+
 
 def test_multipoints():
     arr = shapely.from_wkt(
@@ -337,6 +349,11 @@ def test_multipoints():
     # in a roundtrip, missing geometries come back as empty
     arr[-2] = shapely.from_wkt("MULTIPOINT EMPTY")
     assert_geometries_equal(result, arr)
+
+    # # sliced:
+    # offsets_sliced = (offsets[0][1:],)
+    # result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    # assert_geometries_equal(result, arr[1:])
 
 
 def test_multilinestrings():
@@ -388,6 +405,13 @@ def test_multilinestrings():
     # in a roundtrip, missing geometries come back as empty
     arr[-2] = shapely.from_wkt("MULTILINESTRING EMPTY")
     assert_geometries_equal(result, arr)
+
+    # sliced:
+    # - indices into the coordinate array for the whole buffer
+    # - indices into the line parts for *just* the sliced part
+    offsets_sliced = (offsets[0], offsets[1][1:])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[1:])
 
 
 def test_multipolygons():
@@ -452,6 +476,11 @@ def test_multipolygons():
     # in a roundtrip, missing geometries come back as empty
     arr[-2] = shapely.from_wkt("MULTIPOLYGON EMPTY")
     assert_geometries_equal(result, arr)
+
+    # sliced:
+    offsets_sliced = (offsets[0], offsets[1], offsets[2][1:])
+    result = shapely.from_ragged_array(typ, coords, offsets_sliced)
+    assert_geometries_equal(result, arr[1:])
 
 
 def test_mixture_point_multipoint():


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/1745

It appears that we now already support this (because of the new cython implementation, https://github.com/shapely/shapely/pull/2142 and https://github.com/shapely/shapely/pull/2225), so just adding tests.