### PR TITLE
DEPR: deprecate symmetric_difference_all

### DIFF
--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -1,5 +1,7 @@
 """Set-theoretic operations on geometry objects."""
 
+import warnings
+
 import numpy as np
 
 from shapely import Geometry, GeometryType, lib
@@ -317,6 +319,12 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     If all elements of the given axis are None an empty GeometryCollection is
     returned.
 
+    .. deprecated:: 2.1.0
+
+        This function behaves incorrectlly and will be removed in a future
+        version. See https://github.com/shapely/shapely/issues/2027 for more
+        details.
+
     Parameters
     ----------
     geometries : array_like
@@ -357,6 +365,13 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     <GEOMETRYCOLLECTION EMPTY>
 
     """
+    warnings.warn(
+        "The symmetric_difference_all function behaves incorrectlly and will be "
+        "removed in a future version. "
+        "See https://github.com/shapely/shapely/issues/2027 for more details.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     geometries = np.asarray(geometries)
     if axis is None:
         geometries = geometries.ravel()

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -321,7 +321,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
 
     .. deprecated:: 2.1.0
 
-        This function behaves incorrectlly and will be removed in a future
+        This function behaves incorrectly and will be removed in a future
         version. See https://github.com/shapely/shapely/issues/2027 for more
         details.
 

--- a/shapely/set_operations.py
+++ b/shapely/set_operations.py
@@ -366,7 +366,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
 
     """
     warnings.warn(
-        "The symmetric_difference_all function behaves incorrectlly and will be "
+        "The symmetric_difference_all function behaves incorrectly and will be "
         "removed in a future version. "
         "See https://github.com/shapely/shapely/issues/2027 for more details.",
         DeprecationWarning,

--- a/shapely/tests/test_set_operations.py
+++ b/shapely/tests/test_set_operations.py
@@ -6,6 +6,10 @@ from shapely import Geometry, GeometryCollection, Polygon
 from shapely.testing import assert_geometries_equal
 from shapely.tests.common import all_types, empty, ignore_invalid, point, polygon
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The symmetric_difference_all function:DeprecationWarning"
+)
+
 # fixed-precision operations raise GEOS exceptions on mixed dimension geometry
 # collections
 all_single_types = np.array(all_types)[


### PR DESCRIPTION
See https://github.com/shapely/shapely/issues/2027 for more context: the `symmetric_difference_all` has wrong behaviour which is not easy to fix, so rather deprecate and remove this function for now.