### PR TITLE
DEPR: bump some DeprecationWarnings from shapely 2.0 to more visible FutureWarning

### DIFF
--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -71,7 +71,7 @@ def __getattr__(name):
             f"{name} is deprecated and will be removed in a future version. "
             "Use ShapelyError instead (functions previously raising {name} "
             "will now raise a ShapelyError instead).",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         return ShapelyError

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -46,7 +46,7 @@ def geom_factory(g, parent=None):
     warn(
         "The 'geom_factory' function is deprecated in Shapely 2.0, and will be "
         "removed in a future version",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return _geom_factory(g)

--- a/shapely/speedups.py
+++ b/shapely/speedups.py
@@ -27,7 +27,7 @@ def enable():
     Previously, this function enabled cython-based speedups. Starting with
     Shapely 2.0, equivalent speedups are available in every installation.
     """
-    warnings.warn(_MSG, DeprecationWarning, stacklevel=2)
+    warnings.warn(_MSG, FutureWarning, stacklevel=2)
 
 
 def disable():
@@ -36,4 +36,4 @@ def disable():
     Previously, this function enabled cython-based speedups. Starting with
     Shapely 2.0, equivalent speedups are available in every installation.
     """
-    warnings.warn(_MSG, DeprecationWarning, stacklevel=2)
+    warnings.warn(_MSG, FutureWarning, stacklevel=2)


### PR DESCRIPTION
Those are deprecations that were already introduced in shapely 2.0. I think we can move those to a more visible FutureWarning now before actually removing them later.