### PR TITLE
TST: rename tests that use `handle_nan` option

### DIFF
--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -139,7 +139,7 @@ def test_points_handle_nan(coords, handle_nan, expected_wkt):
         [0, -np.inf],
     ],
 )
-def test_points_nan_handle_nan_err(coords):
+def test_points_handle_nan_error(coords):
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.points(coords, handle_nan="error")
 
@@ -250,7 +250,7 @@ def test_linestrings_invalid_ndim():
         [[float("nan"), float("nan")], [float("nan"), float("nan")]],
     ],
 )
-def test_linestrings_allow_nan(coords):
+def test_linestrings_handle_nan_allow(coords):
     with ignore_invalid():
         actual = shapely.linestrings(coords, handle_nan="allow")
     actual = shapely.get_coordinates(actual, include_z=len(coords[0]) == 3)
@@ -266,23 +266,23 @@ def test_linestrings_allow_nan(coords):
         [[0, 1], [2, 3], [2, float("nan")]],
     ],
 )
-def test_linestrings_skip_nan(coords):
+def test_linestrings_handle_nan_skip(coords):
     actual = shapely.linestrings(coords, handle_nan="skip")
     assert_geometries_equal(actual, LineString([(0, 1), (2, 3)]))
 
 
-def test_linestrings_skip_nan_invalid():
+def test_linestrings_handle_nan_skip_invalid():
     with pytest.raises(shapely.GEOSException):
         shapely.linestrings([[0, 1], [2, float("nan")]], handle_nan="skip")
 
 
-def test_linestrings_skip_nan_only_nan():
+def test_linestrings_handle_nan_skip_only_nan():
     # all-nan becomes an empty linestring
     actual = shapely.linestrings(np.full((3, 2), fill_value=np.nan), handle_nan="skip")
     assert actual.is_empty
 
 
-def test_linestrings_error_nan():
+def test_linestrings_handle_nan_error():
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.linestrings([[0, 1], [2, float("nan")], [2, 3]], handle_nan="error")
 
@@ -357,7 +357,7 @@ def test_linearrings_invalid_ndim():
     # too few ordinates
     coords3 = np.random.randn(10, 3, 1)
     with pytest.raises(ValueError, match=msg.format(1)):
-        shapely.linestrings(coords3)
+        shapely.linearrings(coords3)
 
 
 def test_linearrings_all_nan():
@@ -394,7 +394,7 @@ def test_linearrings_buffer(dim, order):
         [[0, 2, 5], [1, 2, float("nan")], [1, 3, 5], [0, 2, 5]],
     ],
 )
-def test_linearrings_allow_nan(coords):
+def test_linearrings_handle_nan_allow(coords):
     with ignore_invalid():
         actual = shapely.linearrings(coords, handle_nan="allow")
     actual = shapely.get_coordinates(actual, include_z=len(coords[0]) == 3)
@@ -411,22 +411,22 @@ def test_linearrings_allow_nan(coords):
         ([float("nan"), 0, 1, 2, 0], [3, 3, 4, 5, 3]),
     ],
 )
-def test_linearrings_skip_nan(x, y):
+def test_linearrings_handle_nan_skip(x, y):
     actual = shapely.linearrings(x, y, handle_nan="skip")
     assert_geometries_equal(actual, LinearRing([(0, 3), (1, 4), (2, 5), (0, 3)]))
 
 
-def test_linearrings_skip_nan_invalid():
+def test_linearrings_handle_nan_skip_invalid():
     with pytest.raises(ValueError):
         shapely.linearrings([0, float("nan"), 0], [3, 4, 3], handle_nan="skip")
 
 
-def test_linearrings_skip_nan_only_nan():
+def test_linearrings_handle_nan_skip_only_nan():
     actual = shapely.linearrings(np.full((5, 2), fill_value=np.nan), handle_nan="skip")
     assert actual.is_empty
 
 
-def test_linearrings_error_nan():
+def test_linearrings_handle_nan_error():
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.linearrings(
             [0, 1, float("nan"), 2, 0], [3, 4, 5, 5, 3], handle_nan="error"

--- a/shapely/tests/test_creation_indices.py
+++ b/shapely/tests/test_creation_indices.py
@@ -195,7 +195,7 @@ def test_linestrings_allow_nan(coordinates):
         ([[1, 1], [1, float("nan")], [2, 2]], [0, 0, 0], [lstrs([[1, 1], [2, 2]])]),
     ],
 )
-def test_linestrings_skip_nan(coordinates, indices, expected):
+def test_linestrings_handle_nan_skip(coordinates, indices, expected):
     actual = shapely.linestrings(
         np.array(coordinates, dtype=float),
         indices=np.array(indices, dtype=np.intp),
@@ -204,7 +204,7 @@ def test_linestrings_skip_nan(coordinates, indices, expected):
     assert_geometries_equal(actual, expected)
 
 
-def test_linestrings_skip_nan_invalid():
+def test_linestrings_handle_nan_skip_invalid():
     # the NaN makes the linestring too short
     with pytest.raises(shapely.GEOSException):
         shapely.linestrings(
@@ -212,14 +212,14 @@ def test_linestrings_skip_nan_invalid():
         )
 
 
-def test_linestrings_skip_nan_only_nan():
+def test_linestrings_handle_nan_skip_only_nan():
     actual = shapely.linestrings(
         np.full((3, 2), fill_value=np.nan), indices=[0, 0, 0], handle_nan="skip"
     )
     assert actual[0].is_empty
 
 
-def test_linestrings_error_nan():
+def test_linestrings_handle_nan_error():
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.linestrings(
             [[0, 0], [float("nan"), 0], [1, 1]], indices=[0, 0, 0], handle_nan="error"
@@ -315,7 +315,7 @@ def test_linearrings_allow_nan(coordinates):
         [[2, float("nan")], [1, 1], [2, 1], [2, 2]],
     ],
 )
-def test_linearrings_skip_nan(coordinates):
+def test_linearrings_handle_nan_skip(coordinates):
     actual = shapely.linearrings(
         np.array(coordinates, dtype=np.float64),
         indices=np.zeros(len(coordinates), dtype=np.intp),
@@ -324,7 +324,7 @@ def test_linearrings_skip_nan(coordinates):
     assert_geometries_equal(actual, shapely.linearrings(coordinates, handle_nan="skip"))
 
 
-def test_linearrings_skip_nan_invalid():
+def test_linearrings_handle_nan_skip_invalid():
     # the NaN makes the linearring too short
     with pytest.raises(ValueError):
         shapely.linearrings(
@@ -332,7 +332,7 @@ def test_linearrings_skip_nan_invalid():
         )
 
 
-def test_linearrings_skip_nan_only_nan():
+def test_linearrings_handle_nan_skip_only_nan():
     actual = shapely.linearrings(
         np.full((5, 2), fill_value=np.nan), indices=[0] * 5, handle_nan="skip"
     )
@@ -340,7 +340,7 @@ def test_linearrings_skip_nan_only_nan():
     assert actual[0].is_empty
 
 
-def test_linearrings_error_nan():
+def test_linearrings_handle_nan_error():
     with pytest.raises(ValueError, match=".*NaN.*"):
         shapely.linearrings(
             [[1, 1], [2, 1], [2, 2], [2, float("nan")], [1, 1]],


### PR DESCRIPTION
This is a relatively minor renaming of tests for the `handle_nan` option, which makes them more consistent, something along the lines of:

    def test_<geomtype>_handle_nan_<option>[_<behaviour]([args]):

There is also a minor fix for a geometry type in `test_linearrings_invalid_ndim` which I've stumbled on while developing M support for linestrings (for 2.2).