### PR TITLE
REF: postpone shapely <2 geometry pickle doomsday

### DIFF
--- a/shapely/tests/legacy/test_pickle.py
+++ b/shapely/tests/legacy/test_pickle.py
@@ -62,7 +62,7 @@ def test_unpickle_pre_20(fname):
     expected = TEST_DATA[geom_type]
 
     with open(fname, "rb") as f:
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="may be removed in a future version"):
             result = pickle.load(f)
 
     assert_geometries_equal(result, expected)

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -308,8 +308,9 @@ static PyObject* GeometryObject_SetState(PyObject* self, PyObject* value) {
   GEOSWKBReader* reader = NULL;
 
   PyErr_WarnFormat(PyExc_UserWarning, 0,
-                   "Unpickling a shapely <2.0 geometry object. Please save the pickle "
-                   "again; shapely 2.1 will not have this compatibility.");
+                   "Unpickling a shapely <2.0 geometry object. "
+                   "Please save the pickle again as this compatibility may be "
+                   "removed in a future version of shapely.");
 
   /* Cast the PyObject bytes to char */
   if (!PyBytes_Check(value)) {


### PR DESCRIPTION
This refactor postpones shapely <2 geometry pickle doomsday for a future shapely release. There's no rush to remove this support, as it works and is used "out in the wild".

Closes #2242