### PR TITLE
concave hull by length

### DIFF
--- a/shapely/constructive.py
+++ b/shapely/constructive.py
@@ -427,7 +427,7 @@ def clip_by_rect(geometry, xmin, ymin, xmax, ymax, **kwargs):
 
 @requires_geos("3.11.0")
 @multithreading_enabled
-def concave_hull(geometry, ratio=0.0, allow_holes=False, **kwargs):
+def concave_hull(geometry, ratio=0.0, min_length=None, allow_holes=False, **kwargs):
     """Compute a concave geometry that encloses an input geometry.
 
     Parameters
@@ -437,6 +437,9 @@ def concave_hull(geometry, ratio=0.0, allow_holes=False, **kwargs):
     ratio : float, default 0.0
         Number in the range [0, 1]. Higher numbers will include fewer vertices
         in the hull.
+    min_length : float, default None
+        The maximum edge length.
+        Ratio must be set to None when using this criteria.
     allow_holes : bool, default False
         If set to True, the concave hull may have holes.
     **kwargs
@@ -451,16 +454,38 @@ def concave_hull(geometry, ratio=0.0, allow_holes=False, **kwargs):
     <POLYGON ((0 0, 0 3, 1 1, 3 3, 3 0, 0 0))>
     >>> shapely.concave_hull(multi_point, ratio=1.0)
     <POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0))>
+    >>> shapely.concave_hull(multi_point, ratio=None, min_length=2.9)
+    POLYGON ((0 0, 0 3, 1 1, 3 3, 3 0, 0 0))
+    >>> shapely.concave_hull(multi_point, ratio=None, min_length=3.1)
+    <POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0))>
     >>> shapely.concave_hull(Polygon())
     <POLYGON EMPTY>
 
     """
-    if not np.isscalar(ratio):
-        raise TypeError("ratio must be scalar")
+    if ratio is not None:
+        if min_length is not None:
+            raise ValueError("only one of ratio or min_length must be specified")
+        if not np.isscalar(ratio):
+            raise TypeError("ratio must be scalar")
+    if min_length is not None:
+        if lib.geos_version < (3, 12, 0):
+            raise UnsupportedGEOSVersionError(
+                "Concave hull by length requires GEOS >= 3.12.0, "
+                f"found {lib.geos_version_string}"
+            )
+        if not np.isscalar(min_length):
+            raise TypeError("min_length must be scalar")
     if not np.isscalar(allow_holes):
         raise TypeError("allow_holes must be scalar")
-    return lib.concave_hull(geometry, np.double(ratio), np.bool_(allow_holes), **kwargs)
 
+    if ratio is not None:
+        _use_length = False
+        _value = ratio
+    else:
+        _use_length = True
+        _value = min_length
+
+    return lib.concave_hull(geometry, np.double(_value), np.bool_(allow_holes), np.bool_(_use_length), **kwargs)
 
 @multithreading_enabled
 def convex_hull(geometry, **kwargs):

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -1114,6 +1114,33 @@ def test_concave_hull_kwargs():
     result4 = shapely.concave_hull(mp, ratio=1)
     assert shapely.get_num_coordinates(result4) < shapely.get_num_coordinates(result3)
 
+    with pytest.raises(ValueError, match="only one of ratio or min_length must be specified"):
+        shapely.concave_hull(mp, ratio=0.5, min_length=2)
+
+
+@pytest.mark.skipif(shapely.geos_version < (3, 12, 0), reason="GEOS < 3.12")
+def test_concave_hull_by_length_kwargs():
+    triangle = [Point(0,0), Point(0,10), Point(10,0)]
+    pt_inside = Point(3,3)
+
+    triangle_with_pt_inside = MultiPoint([*triangle, pt_inside])
+    triangle_with_hole = MultiPoint(
+        Polygon(triangle).segmentize(1).exterior.coords[:] +
+        pt_inside.buffer(2).exterior.coords[:]
+    )
+
+    result = shapely.concave_hull(triangle_with_hole, ratio=None, min_length=2)
+    assert len(result.interiors) == 0
+    result = shapely.concave_hull(triangle_with_hole, ratio=None, min_length=2, allow_holes=True)
+    assert len(result.interiors) == 1
+
+    # the hypotenuse is sqrt(10**2 + 10**2) ~ 14,1421
+    result = shapely.concave_hull(triangle_with_pt_inside, ratio=None, min_length=14.15)
+    assert len(result.exterior.coords) == 4 ## closed triangle
+
+    result = shapely.concave_hull(triangle_with_pt_inside, ratio=None, min_length=14.14)
+    assert len(result.exterior.coords) == 5 ## closed triangle + point inside
+
 
 @pytest.mark.skipif(shapely.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 class TestConstrainedDelaunayTriangulation:


### PR DESCRIPTION
I'm in need for this functionality in some project and saw that it was on the roadmap of functions to be implemented, seemed like a good fit for a first contribution ! 

because the processing in the concave_hull_func() is the same whether using ratio or length, I just added a flag to know which one to perform. But the function is enclosed by some #if GEOS_SINCE_3_11_0 and the concave hull by length is only available in 3.12... not sure if it's better to create 2 separate functions each enclosed with correct version control ? 