### PR TITLE
DOC: add coverage_union to coverage API page

### DIFF
--- a/docs/coverage.rst
+++ b/docs/coverage.rst
@@ -9,3 +9,5 @@ Coverage operations
 {% for function in get_module_functions("_coverage") %}
    {{ function }}
 {% endfor %}
+   coverage_union
+   coverage_union_all


### PR DESCRIPTION
Exposing these on coverage-dedicated API reference page to keep all relevant functions visible from a single place. Keeping it also in set operations page as it belongs to both and will have better discoverabilty that way.