### PR TITLE
DOC: updates CHANGES.txt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,85 +4,17 @@ Changes
 2.1.0 (unreleased)
 ------------------
 
-API changes:
+Shapely 2.1.0 is a feature release with various new functions,
+improvements and bug fixes. Highlights include initial support for geometries
+with M or ZM values, functionality for coverage validation and
+simplification, and a set of new top-level functions.
 
-- Equality of geometries (``geom1 == geom2``) now considers NaN coordinate
-  values in the same location to be equal (#1775). It is recommended however to
-  ensure geometries don't have NaN values in the first place, for which you can
-  now use the ``handle_nan`` parameter in construction functions.
+Shapely supports Python >= 3.10, and binary wheels on PyPI include GEOS 3.13.1
+and are now also provided for musllinux (Alpine) x86_64 platforms.
 
-Bug fixes:
+For a full changelog, see
+https://shapely.readthedocs.io/en/latest/release/2.x.html#version-2-1-0
 
-- Prevent crash when serializing a number > 1e100 to WKT with GEOS < 3.13. (#1907)
-- Ensure ``plot_polygon`` does not color the interiors of polygons (#1933).
-- Fixes GeoJSON serialization of empty points (#2118)
-- Fixes `__geo_interface__` handling of empty points (#2120)
-- Fixes ``GeometryCollection()`` constructor accepting an array of geometries (#2017).
-
-Improvements:
-
-- Add a ``handle_nan`` parameter to ``shapely.points()``,
-  ``shapely.linestrings()`` and ``shapely.linearrings()`` to allow, skip, or
-  error on nonfinite (NaN / Inf) coordinates. The default behaviour (allow) is
-  backwards compatible (#1594, #1811).
-- Add an ``interleaved`` parameter to ``shapely.transform()`` allowing a transposed call
-  signature in the ``transformation`` function.
-- The ``include_z`` in ``shapely.transform()`` now also allows ``None``, which
-  lets it automatically detect the dimensionality of each input geometry.
-- Add an ``include_m`` keyword in ``to_ragged_array`` and ``get_coordinates`` (#2234, #2235)
-- Add parameters ``method`` and ``keep_collapsed`` to ``shapely.make_valid()`` (#1941)
-- The ``voronoi_polygons`` now accepts the ``ordered`` keyword, optionally forcing the
-  order of polygons within the GeometryCollection to follow the order of input
-  coordinates. Requires at least GEOS 3.12. (#1968)
-- Add option on ``invalid="fix"`` to ``from_wkb`` and ``from_wkt`` (#2094)
-- Add a ``normalize`` keyword to ``equals_exact`` (#1231)
-- Handle ``Feature`` type in ``shapely.geometry.shape`` (#1815)
-- Add support to split polygons by multilinestrings (#2206)
-- Add an ``m`` attribute on the Point class and an ``has_m`` attribute on the base Geometry class.
-
-New functions:
-
-- Add ``disjoint_subset_union`` and ``disjoint_subset_union_all`` as an optimized
-  version of union and union_all, assuming inputs can be divided into subsets that do
-  not intersect. Requires at least GEOS 3.12.
-- Add function ``minimum_clearance_line`` (#2106)
-- Add function ``maximum_inscribed_circle`` (#1307)
-- Add function ``orient_polygons`` (#2147)
-- Add function ``constrained_delaunay_triangles`` (#1685)
-- Add function ``coverage_simplify`` to allow topological simplification of polygonal
-  coverages (#1969)
-- Add function ``coverage_is_valid`` and ``coverage_invalid_edges`` to validate
-  an array of geometries as valid topological coverage (#2156)
-- Add function ``equals_identical`` (#1760)
-- Add function ``has_m`` (#2008)
-- Add function ``get_m`` (#2019)
-
-Breaking changes in GEOS 3.12:
-
-- ``oriented_envelope`` / ``minimum_rotated_rectangle`` changed its implementation
-  in GEOS 3.12. Be aware that results will change when updating GEOS. Coincidentally
-  the implementation is similar to the shapely 1.x approach. (#1885)
-- ``get_coordinate_dimension`` / ``has_z`` now considers geometries three dimensional if
-  they have a NaN z coordinate. (#1885)
-- ``voronoi_polygons`` changed its output from a LINESTRING to a MULTILINESTRING in case
-  ``only_edges=True``. (#1885)
-- The WKT representation of a MULTIPOINT changed from for example "MULTIPOINT (0 0, 1 1)"
-  to "MULTIPOINT ((0 0), (1 1))". (#1885)
-
-Deprecations:
-
-- The ``shapely.geos`` module is deprecated. All GEOS-version related attributes are
-  available directly from the top-level ``shapely`` namespace as well (already since
-  shapely 2.0) (#2145).
-- The ``shapely.vectorized`` module is deprecated. The two functions (``contains and
-  ``touches``) can be replaced by the top-level vectorized functions ``contains_xy``
-  and ``intersects_xy`` (#1630).
-
-Packaging:
-
-- Require GEOS >= 3.9, NumPy >= 1.21, and Python >= 3.10 (#1802, #1885, #2124)
-- Binary wheels are now built for musllinux (Alpine) x86_64 platforms (#1996).
-- Upgraded the GEOS version in the binary wheel distributions to 3.13.1.
 
 2.0.7 (2025-01-30)
 ------------------


### PR DESCRIPTION
The content of this file was now out of date compared to the doc page, so similar like we did for the 2.0.0 release, I am just providing some highlights and linking to the full docs.

(this is not ideal, and we should discuss what we do with this duplication, but again going to merge this quickly now for the release. People mostly look at this file on github I think, so we can easily update this again after the release)