### PR TITLE
DOC/TST: remove broken sort, several updates, more doctests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,13 +32,13 @@ jobs:
           - python: "3.12"
             geos: 3.12.3
             numpy: 1.26.4
-            matplotlib: true
-            doctest: true
-            extra_pytest_args: "-W error"  # error on warnings
           # 2024
           - python: "3.13"
             geos: 3.13.1
             numpy: 2.1.3
+            matplotlib: true
+            doctest: true
+            extra_pytest_args: "-W error"  # error on warnings
           # free threaded Python (no numpy version to indicate installing nightly cython and numpy)
           - os: ubuntu-22.04
             python: "3.13t"
@@ -187,10 +187,10 @@ jobs:
           pytest shapely/tests -r a --cov --cov-report term-missing ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
-      - name: Run doctests on manual
+      - name: Run doctests on manual docs
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.doctest }}
         run: |
-          python -m pytest --doctest-modules docs/manual.rst
+          python -m pytest --doctest-modules docs/*.rst
 
       - name: Run doctests on shapely module
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.doctest }}

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -84,7 +84,7 @@ Therefore, geometries are equal if and only if their WKB representations are equ
   >>> point_1 = Point(5.2, 52.1)
   >>> point_2 = Point(1, 1)
   >>> point_3 = Point(5.2, 52.1)
-  >>> {point_1, point_2, point_3}
+  >>> {point_1, point_2, point_3}  # doctest: +SKIP
   {<POINT (1 1)>, <POINT (5.2 52.1)>}
 
 .. warning:: Due to limitations of WKB, linearrings will equal linestrings if they contain the exact same points.
@@ -113,9 +113,9 @@ The most convenient is to use ``.wkb_hex`` and ``.wkt`` properties.
   >>> from shapely import Point, to_wkb, to_wkt, to_geojson
   >>> pt = Point(-169.910918, -18.997564)
   >>> pt.wkb_hex
-  0101000000CF6A813D263D65C0BDAAB35A60FF32C0
+  '0101000000CF6A813D263D65C0BDAAB35A60FF32C0'
   >>> pt.wkt
-  POINT (-169.910918 -18.997564)
+  'POINT (-169.910918 -18.997564)'
 
 More output options can be found using using :func:`~shapely.to_wkb`,
 :func:`~shapely.to_wkt`, and :func:`~shapely.to_geojson` functions.
@@ -123,9 +123,9 @@ More output options can be found using using :func:`~shapely.to_wkb`,
 .. code:: python
 
   >>> to_wkb(pt, hex=True, byte_order=0)
-  0000000001C0653D263D816ACFC032FF605AB3AABD
+  '0000000001C0653D263D816ACFC032FF605AB3AABD'
   >>> to_wkt(pt, rounding_precision=3)
-  POINT (-169.911 -18.998)
+  'POINT (-169.911 -18.998)'
   >>> print(to_geojson(pt, indent=2))
   {
     "type": "Point",
@@ -158,21 +158,35 @@ Semantic for format specification
 
 Format types ``'f'`` and ``'F'`` are to use a fixed-point notation, which is
 activated by setting GEOS' trim option off.
-The upper case variant converts ``nan`` to ``NAN`` and ``inf`` to ``INF``.
 
-Format types ``'g'`` and ``'G'`` are to use a "general format",
+Format types ``'g'`` (default) and ``'G'`` are to use a "general format",
 where unnecessary digits are trimmed. This notation is activated by setting
-GEOS' trim option on. The upper case variant is similar to
-``'F'``, and may also display an upper-case ``"E"`` if scientific notation
-is required. Note that this representation may be different for GEOS 3.10.0
-and later, which does not use scientific notation.
+GEOS' trim option on. This option sometimes enables
+:ref:`scientific-formatting`.
 
-For numeric outputs ``'f'`` and ``'g'``, the precision is optional, and if not
+For numeric outputs ``[fFgG]``, the precision is optional, and if not
 specified, rounding precision will be disabled showing full precision.
 
 Format types ``'x'`` and ``'X'`` show a hex-encoded string representation of
-WKB or Well-Known Binary, with the case of the output matched the
-case of the format type character.
+WKB or Well-Known Binary.
+
+The upper case letter variant converts all non-numeric values to uppercase,
+e.g. ``nan`` to ``NAN``, or ``e`` to ``E``.
+
+.. _scientific-formatting:
+
+Scientific formatting
+---------------------
+
+WKT outputs may sometimes use scientific formatting, depending on the GEOS
+version, coordinate value and WKT writer options. GEOS versions 3.10 to 3.12
+never use scientific formatting (only showing positional), while older and
+newer versions may use scientific formatting for large and small coordinate
+values (e.g. ``POINT (1.234e+18 1.234e-11)``).
+
+Scientific formatting can always be disabled by setting ``trim=False`` for
+:func:`~shapely.to_wkt` or other WKT writer methods,
+which sets the WKT writer to use fixed-precision number formatting.
 
 .. _canonical-form:
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1285,34 +1285,7 @@ and that copies of these are collected into a list
   >>> features = [c, a, d, b, c]
 
 that we'd prefer to have ordered as ``[d, c, c, b, a]`` in reverse containment
-order. As explained in the Python `Sorting HowTo`_, we can define a key
-function that operates on each list element and returns a value for comparison.
-Our key function will be a wrapper class that implements ``__lt__()`` using
-Shapely's binary :meth:`~object.within` predicate.
-
-.. code-block:: python
-
-  >>> class Within:
-  ...     def __init__(self, o):
-  ...         self.o = o
-  ...     def __lt__(self, other):
-  ...         return self.o.within(other.o)
-
-As the howto says, the `less than` comparison is guaranteed to be used in
-sorting. That's what we'll rely on to spatially sort. Trying it out on features
-`d` and `c`, we see that it works.
-
-.. code-block:: pycon
-
-  >>> Within(d) < Within(c)
-  False
-
-It also works on the list of features, producing the order we want.
-
-.. code-block:: pycon
-
-  >>> [d, c, c, b, a] == sorted(features, key=Within, reverse=True)
-  True
+order.
 
 DE-9IM Relationships
 --------------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -5,9 +5,9 @@ Migrating to Shapely 1.8 / 2.0
 ==============================
 
 Shapely 1.8.0 is a transitional version introducing several warnings in
-preparation of the upcoming changes in 2.0.0.
+transition to 2.0.0.
 
-Shapely 2.0.0 will be a major release with a refactor of the internals with
+Shapely 2.0.0 was a major release with a refactor of the internals with
 considerable performance improvements (based on the developments in the
 `PyGEOS <https://github.com/pygeos/pygeos>`__ package), along with several
 breaking changes.
@@ -33,13 +33,13 @@ can change their coordinates in-place. Illustrative code::
     >>> print(line)
     LINESTRING (0 0, 2 2)
 
-    >>> line.coords = [(0, 0), (10, 0), (10, 10)]
-    >>> print(line)
+    >>> line.coords = [(0, 0), (10, 0), (10, 10)]  # doctest: +SKIP
+    >>> print(line)  # doctest: +SKIP
     LINESTRING (0 0, 10 0, 10 10)
 
 In Shapely 1.8, this will start raising a warning::
 
-    >>> line.coords = [(0, 0), (10, 0), (10, 10)]
+    >>> line.coords = [(0, 0), (10, 0), (10, 10)]  # doctest: +SKIP
     ShapelyDeprecationWarning: Setting the 'coords' to mutate a Geometry
     in place is deprecated, and will not be possible any more in Shapely 2.0
 
@@ -56,15 +56,16 @@ Setting custom attributes
 -------------------------
 
 Another consequence of the geometry objects becoming immutable is that
-assigning custom attributes, which currently works, will no longer be possible.
+assigning custom attributes, which previously worked, will no longer be
+possible.
 
-Currently you can do::
+Previously, custom attributes could have ben added::
 
-    >>> line.name = "my_geometry"
-    >>> line.name
+    >>> line.name = "my_geometry"  # doctest: +SKIP
+    >>> line.name  # doctest: +SKIP
     'my_geometry'
 
-In Shapely 1.8, this will start raising a warning, and will raise an
+In Shapely 1.8, this will raise a warning, and will raise an
 AttributeError in Shapely 2.0.
 
 **How do I update my code?** There is no direct alternative for adding custom
@@ -85,18 +86,18 @@ Some examples of this with Shapely 1.x:
 
     >>> from shapely.geometry import Point, MultiPoint
     >>> mp = MultiPoint([(1, 1), (2, 2), (3, 3)])
-    >>> print(mp)
+    >>> print(mp)  # doctest: +SKIP
     MULTIPOINT (1 1, 2 2, 3 3)
-    >>> for part in mp:
-    ...     print(part)
+    >>> for part in mp:  # doctest: +SKIP
+    ...     print(part)  # doctest: +SKIP
     POINT (1 1)
     POINT (2 2)
     POINT (3 3)
-    >>> print(mp[1])
+    >>> print(mp[1])  # doctest: +SKIP
     POINT (2 2)
-    >>> len(mp)
+    >>> len(mp)  # doctest: +SKIP
     3
-    >>> list(mp)
+    >>> list(mp)  # doctest: +SKIP
     [<shapely.geometry.point.Point at 0x7f2e0912bf10>,
      <shapely.geometry.point.Point at 0x7f2e09fed820>,
      <shapely.geometry.point.Point at 0x7f2e09fed4c0>]
@@ -104,8 +105,8 @@ Some examples of this with Shapely 1.x:
 Starting with Shapely 1.8, all the examples above will start raising a
 deprecation warning. For example:
 
-    >>> for part in mp:
-    ...     print(part)
+    >>> for part in mp:  # doctest: +SKIP
+    ...     print(part)  # doctest: +SKIP
     ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated
     and will be removed in Shapely 2.0. Use the `geoms` property to access the
     constituent parts of a multi-part geometry.
@@ -129,7 +130,7 @@ The examples above can be updated to::
     POINT (2 2)
     >>> len(mp.geoms)
     3
-    >>> list(mp.geoms)
+    >>> list(mp.geoms)  # doctest: +SKIP
     [<shapely.geometry.point.Point at 0x7f2e0912bf10>,
      <shapely.geometry.point.Point at 0x7f2e09fed820>,
      <shapely.geometry.point.Point at 0x7f2e09fed4c0>]
@@ -152,7 +153,7 @@ A small example::
 
     >>> line = LineString([(0, 0), (1, 1), (2, 2)])
     >>> import numpy as np
-    >>> np.asarray(line)
+    >>> np.asarray(line)  # doctest: +SKIP
     array([[0., 0.],
            [1., 1.],
            [2., 2.]])
@@ -160,9 +161,9 @@ A small example::
 In addition, there are also the explicit ``array_interface()`` method and
 ``ctypes`` attribute to get access to the coordinates as array data:
 
-    >>> line.ctypes
+    >>> line.ctypes  # doctest: +SKIP
     <shapely.geometry.linestring.c_double_Array_6 at 0x7f75261eb740>
-    >>> line.array_interface()
+    >>> line.array_interface()  # doctest: +SKIP
     {'version': 3,
      'typestr': '<f8',
      'data': <shapely.geometry.linestring.c_double_Array_6 at 0x7f752664ae40>,
@@ -177,7 +178,7 @@ removed from those geometry classes, and limited to the ``coords``.
 Starting with Shapely 1.8, converting a geometry object to a NumPy array
 directly will start raising a warning::
 
-    >>> np.asarray(line)
+    >>> np.asarray(line)  # doctest: +SKIP
     ShapelyDeprecationWarning: The array interface is deprecated and will no longer
     work in Shapely 2.0. Convert the '.coords' to a NumPy array instead.
     array([[0., 0.],
@@ -209,7 +210,7 @@ as follows::
 
     >>> from shapely.geometry import Point
     >>> arr = np.array([Point(0, 0), Point(1, 1), Point(2, 2)])
-    >>> arr
+    >>> arr  # doctest: +SKIP
     array([<shapely.geometry.point.Point object at 0x7fb798407cd0>,
            <shapely.geometry.point.Point object at 0x7fb7982831c0>,
            <shapely.geometry.point.Point object at 0x7fb798283b80>],
@@ -300,7 +301,7 @@ creation methods. A small example for an empty Polygon geometry:
     >>> g1 = Polygon()
     >>> type(g1)
     <class 'shapely.geometry.polygon.Polygon'>
-    >>> g1.wkt
+    >>> g1.wkt  # doctest: +SKIP
     GEOMETRYCOLLECTION EMPTY
 
     # Converting from WKT gives a correct empty polygon
@@ -309,7 +310,7 @@ creation methods. A small example for an empty Polygon geometry:
     >>> type(g2)
     <class 'shapely.geometry.polygon.Polygon'>
     >>> g2.wkt
-    POLYGON EMPTY
+    'POLYGON EMPTY'
 
 Shapely 1.8 does not yet change this inconsistent behaviour, but starting
 with Shapely 2.0, the different methods will always consistently give an

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -56,7 +56,8 @@ def to_wkt(
         The rounding precision when writing the WKT string. Set to a value of
         -1 to indicate the full precision.
     trim : bool, default True
-        If True, trim unnecessary decimals (trailing zeros).
+        If True, trim unnecessary decimals (trailing zeros). If False,
+        use fixed-precision number formatting.
     output_dimension : int, default None
         The output dimension for the WKT string. Supported values are 2, 3 and
         4 for GEOS 3.12+. Default None will automatically choose 3 or 4,


### PR DESCRIPTION
There are multiple objectives of this PR:

- Change CI job to run doctests with Python 3.13, GEOS 3.13.1 and NumPy 2.1.3 (finally makes use of [#2200](https://github.com/shapely/shapely/pull/2200))
- Add CI checks for the other RST docs, which required some minor refactoring to pass
- Remove the advanced sorting example from the manual, since this [only worked "by accident" until Python 3.13](https://github.com/shapely/shapely/issues/2251#issuecomment-2700093910)
- Add a formatting subsection on scientific formatting in WKT, with a bit of re-wording to the "semantic for format specification" section
- Re-word some of the migration guideline, as shapely 2.0 is now a past release (i.e. no longer "upcoming")

Closes #2251
Closes #2275