### PR TITLE
ENH: improve performance of deprecate_positional

### DIFF
--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -142,7 +142,7 @@ def deprecate_positional(
             return func
 
         # earliest position where a warning could occur
-        warn_from = min(idx for idx, _ in deprecate_positions)
+        warn_from = min(deprecate_positions)[0]
 
         @lru_cache(10)
         def make_msg(n_args: int):

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -145,10 +145,8 @@ def deprecate_positional(
         warn_from = min(idx for idx, _ in deprecate_positions)
 
         @lru_cache(10)
-        def make_msg(n_args: int) -> str | None:
+        def make_msg(n_args: int):
             used = [name for idx, name in deprecate_positions if idx < n_args]
-            if not used:
-                return None
 
             if len(used) == 1:
                 args_txt = f"`{used[0]}`"
@@ -174,9 +172,7 @@ def deprecate_positional(
 
             n = len(args)
             if n > warn_from:
-                msg = make_msg(n)
-                if msg is not None:
-                    warnings.warn(msg, category=category, stacklevel=2)
+                warnings.warn(make_msg(n), category=category, stacklevel=2)
 
             return result
 

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -4,6 +4,7 @@ import os
 import warnings
 from collections.abc import Callable, Iterable
 from functools import lru_cache, wraps
+from inspect import unwrap
 
 import numpy as np
 
@@ -124,7 +125,7 @@ def deprecate_positional(
     """
 
     def decorator(func: Callable):
-        code = func.__code__
+        code = unwrap(func).__code__
 
         # positional parameters are the first co_argcount names
         pos_names = code.co_varnames[: code.co_argcount]

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -1,9 +1,9 @@
 """Decorators for Shapely functions."""
 
-import inspect
 import os
 import warnings
-from functools import wraps
+from collections.abc import Callable, Iterable
+from functools import lru_cache, wraps
 
 import numpy as np
 
@@ -92,41 +92,93 @@ def multithreading_enabled(func):
     return wrapped
 
 
-def deprecate_positional(should_be_kwargs, category=DeprecationWarning):
-    """Show warning if positional arguments are used that should be keyword."""
+def deprecate_positional(
+    should_be_kwargs: Iterable[str],
+    category: type[Warning] = DeprecationWarning,
+):
+    """Show warning if positional arguments are used that should be keyword.
 
-    def decorator(func):
+    Parameters
+    ----------
+    should_be_kwargs : Iterable[str]
+        Names of parameters that should be passed as keyword arguments.
+    category : type[Warning], optional (default: DeprecationWarning)
+        Warning category to use for deprecation warnings.
+
+    Returns
+    -------
+    callable
+        Decorator function that adds positional argument deprecation warnings.
+
+    Examples
+    --------
+    >>> @deprecate_positional(['b', 'c'])
+    ... def example(a, b, c=None):
+    ...     return a, b, c
+    ...
+    >>> example(1, 2)  # Warning for b
+    DeprecationWarning: Positional argument `b` for `example` is deprecated. ...
+    (1, 2, None)
+    >>> example(1, b=2)  # No warnings
+    (1, 2, None)
+    """
+
+    def decorator(func: Callable):
+        code = func.__code__
+
+        # positional parameters are the first co_argcount names
+        pos_names = code.co_varnames[: code.co_argcount]
+        # build a name -> index map
+        name_to_idx = {name: idx for idx, name in enumerate(pos_names)}
+        # pick out only those names we care about
+        deprecate_positions = [
+            (name_to_idx[name], name)
+            for name in should_be_kwargs
+            if name in name_to_idx
+        ]
+
+        # early exit if there are no deprecated positional args
+        if not deprecate_positions:
+            return func
+
+        # earliest position where a warning could occur
+        warn_from = min(idx for idx, _ in deprecate_positions)
+
+        @lru_cache(10)
+        def make_msg(n_args: int) -> str | None:
+            used = [name for idx, name in deprecate_positions if idx < n_args]
+            if not used:
+                return None
+
+            if len(used) == 1:
+                args_txt = f"`{used[0]}`"
+                plr = ""
+                isare = "is"
+            else:
+                plr = "s"
+                isare = "are"
+                if len(used) == 2:
+                    args_txt = " and ".join(f"`{u}`" for u in used)
+                else:
+                    args_txt = ", ".join(f"`{u}`" for u in used[:-1])
+                    args_txt += f", and `{used[-1]}`"
+
+            return (
+                f"Positional argument{plr} {args_txt} for `{func.__name__}` "
+                f"{isare} deprecated. Please use keyword argument{plr} instead."
+            )
+
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # call the function first, to make sure the signature matches
-            ret_value = func(*args, **kwargs)
+            result = func(*args, **kwargs)
 
-            # check signature to see which positional args were used
-            sig = inspect.signature(func)
-            args_bind = sig.bind_partial(*args)
-            warn_args = [
-                f"`{arg}`"
-                for arg in args_bind.arguments.keys()
-                if arg in should_be_kwargs
-            ]
-            if warn_args:
-                if len(warn_args) == 1:
-                    plr = ""
-                    isare = "is"
-                    args = warn_args[0]
-                else:
-                    plr = "s"
-                    isare = "are"
-                    if len(warn_args) < 3:
-                        args = " and ".join(warn_args)
-                    else:
-                        args = ", ".join(warn_args[:-1]) + ", and " + warn_args[-1]
-                msg = (
-                    f"positional argument{plr} {args} for `{func.__name__}` "
-                    f"{isare} deprecated.  Please use keyword argument{plr} instead."
-                )
-                warnings.warn(msg, category=category, stacklevel=2)
-            return ret_value
+            n = len(args)
+            if n > warn_from:
+                msg = make_msg(n)
+                if msg is not None:
+                    warnings.warn(msg, category=category, stacklevel=2)
+
+            return result
 
         return wrapper
 

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -117,7 +117,7 @@ def deprecate_positional(
     ...     return a, b, c
     ...
     >>> example(1, 2)  # Warning for b
-    DeprecationWarning: Positional argument `b` for `example` is deprecated. ...
+    DeprecationWarning: positional argument `b` for `example` is deprecated. ...
     (1, 2, None)
     >>> example(1, b=2)  # No warnings
     (1, 2, None)
@@ -162,7 +162,7 @@ def deprecate_positional(
                     args_txt += f", and `{used[-1]}`"
 
             return (
-                f"Positional argument{plr} {args_txt} for `{func.__name__}` "
+                f"positional argument{plr} {args_txt} for `{func.__name__}` "
                 f"{isare} deprecated. Please use keyword argument{plr} instead."
             )
 

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -113,11 +113,12 @@ def deprecate_positional(
 
     Examples
     --------
+    >>> from shapely.decorators import deprecate_positional
     >>> @deprecate_positional(['b', 'c'])
     ... def example(a, b, c=None):
     ...     return a, b, c
     ...
-    >>> example(1, 2)  # Warning for b
+    >>> example(1, 2)  # doctest: +SKIP
     DeprecationWarning: positional argument `b` for `example` is deprecated. ...
     (1, 2, None)
     >>> example(1, b=2)  # No warnings

--- a/shapely/tests/test_decorators.py
+++ b/shapely/tests/test_decorators.py
@@ -36,12 +36,12 @@ def func_no_deprecations(a, b=1):
 
 def test_all_kwargs_no_warning(recwarn: WarningsRecorder) -> None:
     assert func_two(a=10, b=20, c=30) == (10, 20, 30)
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_only_required_arg_no_warning(recwarn: WarningsRecorder) -> None:
     assert func_two(1) == (1, 2, 3)
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_single_positional_warning() -> None:
@@ -100,19 +100,19 @@ def test_custom_warning_category() -> None:
 def test_func_no_deprecations_never_warns(recwarn: WarningsRecorder) -> None:
     out = func_no_deprecations(7, 8)
     assert out == (7, 8)
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_missing_required_arg_no_warning(recwarn: WarningsRecorder) -> None:
     with pytest.raises(TypeError):
         func_two()  # missing required 'a'  # type: ignore
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_unknown_keyword_no_warning(recwarn: WarningsRecorder) -> None:
     with pytest.raises(TypeError):
         func_two(1, 4, d=5)  # unknown keyword 'd'  # type: ignore
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_varargs_behavior_and_deprecation() -> None:
@@ -127,7 +127,7 @@ def test_varargs_behavior_and_deprecation() -> None:
 def test_varargs_no_warning(recwarn: WarningsRecorder) -> None:
     out = func_varargs(1)
     assert out == (1, 1, ())
-    assert not list(recwarn)
+    assert not recwarn.list
 
 
 def test_repeated_warnings() -> None:

--- a/shapely/tests/test_decorators.py
+++ b/shapely/tests/test_decorators.py
@@ -1,6 +1,5 @@
-import warnings
-
 import pytest
+from pytest import WarningsRecorder
 
 from shapely.decorators import deprecate_positional
 
@@ -35,115 +34,105 @@ def func_no_deprecations(a, b=1):
     return a, b
 
 
-def test_all_kwargs_no_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        assert func_two(a=10, b=20, c=30) == (10, 20, 30)
-        assert not caught
+def test_all_kwargs_no_warning(recwarn: WarningsRecorder) -> None:
+    assert func_two(a=10, b=20, c=30) == (10, 20, 30)
+    assert not list(recwarn)
 
 
-def test_only_required_arg_no_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        assert func_two(1) == (1, 2, 3)
-        assert not caught
+def test_only_required_arg_no_warning(recwarn: WarningsRecorder) -> None:
+    assert func_two(1) == (1, 2, 3)
+    assert not list(recwarn)
 
 
-def test_single_positional_warning():
-    with warnings.catch_warnings(record=True) as caught:
+def test_single_positional_warning() -> None:
+    with pytest.warns(
+        DeprecationWarning, match="positional argument `b` for `func_two` is deprecated"
+    ):
         out = func_two(1, 4)
         assert out == (1, 4, 3)
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert "positional argument `b` for `func_two` is deprecated." in msg
 
 
-def test_multiple_positional_warning():
-    with warnings.catch_warnings(record=True) as caught:
+def test_multiple_positional_warning() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="positional arguments `b` and `c` for `func_two` are deprecated",
+    ):
         out = func_two(1, 4, 5)
         assert out == (1, 4, 5)
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert "positional arguments `b` and `c` for `func_two` are deprecated." in msg
 
 
-def test_three_positional_warning_oxford_comma():
-    with warnings.catch_warnings(record=True) as caught:
+def test_three_positional_warning_oxford_comma() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="positional arguments `b`, `c`, and `d` for `func_three` are deprecated",
+    ):
         out = func_three(1, 2, 3, 4)
         assert out == (1, 2, 3, 4)
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert (
-            "positional arguments `b`, `c`, and `d` for `func_three` are deprecated."
-            in msg
-        )
 
 
-def test_noncontiguous_partial_warning():
-    with warnings.catch_warnings(record=True) as caught:
+def test_noncontiguous_partial_warning() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="positional argument `b` for `func_noncontig` is deprecated",
+    ):
         out = func_noncontig(1, 2, 3)
         assert out == (1, 2, 3, 3)
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert "positional argument `b` for `func_noncontig` is deprecated." in msg
 
 
-def test_noncontiguous_full_warning():
-    with warnings.catch_warnings(record=True) as caught:
+def test_noncontiguous_full_warning() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="positional arguments `b` and `d` for `func_noncontig` are deprecated",
+    ):
         out = func_noncontig(1, 2, 3, 4)
         assert out == (1, 2, 3, 4)
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert (
-            "positional arguments `b` and `d` for `func_noncontig` are deprecated."
-            in msg
-        )
 
 
-def test_custom_warning_category():
-    with warnings.catch_warnings(record=True) as caught:
+def test_custom_warning_category() -> None:
+    with pytest.warns(
+        UserWarning,
+        match="positional argument `b` for `func_custom_category` is deprecated",
+    ):
         out = func_custom_category(1, 2)
         assert out == (1, 2)
-        assert len(caught) == 1
-        assert issubclass(caught[0].category, UserWarning)
 
 
-def test_func_no_deprecations_never_warns():
-    with warnings.catch_warnings(record=True) as caught:
-        out = func_no_deprecations(7, 8)
-        assert out == (7, 8)
-        assert not caught
+def test_func_no_deprecations_never_warns(recwarn: WarningsRecorder) -> None:
+    out = func_no_deprecations(7, 8)
+    assert out == (7, 8)
+    assert not list(recwarn)
 
 
-def test_missing_required_arg_no_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        with pytest.raises(TypeError):
-            func_two()  # missing required 'a'
-        assert not caught
+def test_missing_required_arg_no_warning(recwarn: WarningsRecorder) -> None:
+    with pytest.raises(TypeError):
+        func_two()  # missing required 'a'  # type: ignore
+    assert not list(recwarn)
 
 
-def test_unknown_keyword_no_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        with pytest.raises(TypeError):
-            func_two(1, 4, d=5)  # unknown keyword 'd'
-        assert not caught
+def test_unknown_keyword_no_warning(recwarn: WarningsRecorder) -> None:
+    with pytest.raises(TypeError):
+        func_two(1, 4, d=5)  # unknown keyword 'd'  # type: ignore
+    assert not list(recwarn)
 
 
-def test_varargs_behavior_and_deprecation():
-    with warnings.catch_warnings(record=True) as caught:
+def test_varargs_behavior_and_deprecation() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="positional argument `b` for `func_varargs` is deprecated",
+    ):
         out = func_varargs(1, 2, 3, 4)
         assert out == (1, 2, (3, 4))
-        assert len(caught) == 1
-        msg = str(caught[0].message)
-        assert "positional argument `b` for `func_varargs` is deprecated." in msg
-
-    with warnings.catch_warnings(record=True) as caught:
-        out = func_varargs(1)
-        assert out == (1, 1, ())
-        assert not caught
 
 
-def test_repeated_warnings():
-    with warnings.catch_warnings(record=True) as caught:
+def test_varargs_no_warning(recwarn: WarningsRecorder) -> None:
+    out = func_varargs(1)
+    assert out == (1, 1, ())
+    assert not list(recwarn)
+
+
+def test_repeated_warnings() -> None:
+    with pytest.warns(DeprecationWarning) as record:
         func_two(1, 4, 5)
         func_two(1, 4, 5)
-        assert len(caught) == 2
-        assert str(caught[0].message) == str(caught[1].message)
+        assert len(record) == 2
+        assert str(record[0].message) == str(record[1].message)

--- a/shapely/tests/test_decorators.py
+++ b/shapely/tests/test_decorators.py
@@ -53,7 +53,7 @@ def test_single_positional_warning():
         assert out == (1, 4, 3)
         assert len(caught) == 1
         msg = str(caught[0].message)
-        assert "Positional argument `b` for `func_two` is deprecated." in msg
+        assert "positional argument `b` for `func_two` is deprecated." in msg
 
 
 def test_multiple_positional_warning():
@@ -62,7 +62,7 @@ def test_multiple_positional_warning():
         assert out == (1, 4, 5)
         assert len(caught) == 1
         msg = str(caught[0].message)
-        assert "Positional arguments `b` and `c` for `func_two` are deprecated." in msg
+        assert "positional arguments `b` and `c` for `func_two` are deprecated." in msg
 
 
 def test_three_positional_warning_oxford_comma():
@@ -72,7 +72,7 @@ def test_three_positional_warning_oxford_comma():
         assert len(caught) == 1
         msg = str(caught[0].message)
         assert (
-            "Positional arguments `b`, `c`, and `d` for `func_three` are deprecated."
+            "positional arguments `b`, `c`, and `d` for `func_three` are deprecated."
             in msg
         )
 
@@ -83,7 +83,7 @@ def test_noncontiguous_partial_warning():
         assert out == (1, 2, 3, 3)
         assert len(caught) == 1
         msg = str(caught[0].message)
-        assert "Positional argument `b` for `func_noncontig` is deprecated." in msg
+        assert "positional argument `b` for `func_noncontig` is deprecated." in msg
 
 
 def test_noncontiguous_full_warning():
@@ -93,14 +93,13 @@ def test_noncontiguous_full_warning():
         assert len(caught) == 1
         msg = str(caught[0].message)
         assert (
-            "Positional arguments `b` and `d` for `func_noncontig` are deprecated."
+            "positional arguments `b` and `d` for `func_noncontig` are deprecated."
             in msg
         )
 
 
 def test_custom_warning_category():
     with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", UserWarning)
         out = func_custom_category(1, 2)
         assert out == (1, 2)
         assert len(caught) == 1
@@ -116,7 +115,6 @@ def test_func_no_deprecations_never_warns():
 
 def test_missing_required_arg_no_warning():
     with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", DeprecationWarning)
         with pytest.raises(TypeError):
             func_two()  # missing required 'a'
         assert not caught
@@ -124,7 +122,6 @@ def test_missing_required_arg_no_warning():
 
 def test_unknown_keyword_no_warning():
     with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", DeprecationWarning)
         with pytest.raises(TypeError):
             func_two(1, 4, d=5)  # unknown keyword 'd'
         assert not caught
@@ -136,7 +133,7 @@ def test_varargs_behavior_and_deprecation():
         assert out == (1, 2, (3, 4))
         assert len(caught) == 1
         msg = str(caught[0].message)
-        assert "Positional argument `b` for `func_varargs` is deprecated." in msg
+        assert "positional argument `b` for `func_varargs` is deprecated." in msg
 
     with warnings.catch_warnings(record=True) as caught:
         out = func_varargs(1)

--- a/shapely/tests/test_decorators.py
+++ b/shapely/tests/test_decorators.py
@@ -1,0 +1,152 @@
+import warnings
+
+import pytest
+
+from shapely.decorators import deprecate_positional
+
+
+@deprecate_positional(["b", "c"])
+def func_two(a, b=2, c=3):
+    return a, b, c
+
+
+@deprecate_positional(["b", "c", "d"])
+def func_three(a, b=1, c=2, d=3):
+    return a, b, c, d
+
+
+@deprecate_positional(["b", "d"])
+def func_noncontig(a, b=1, c=2, d=3):
+    return a, b, c, d
+
+
+@deprecate_positional(["b"], category=UserWarning)
+def func_custom_category(a, b=1):
+    return a, b
+
+
+@deprecate_positional(["b"])
+def func_varargs(a, b=1, *args):
+    return a, b, args
+
+
+@deprecate_positional([])
+def func_no_deprecations(a, b=1):
+    return a, b
+
+
+def test_all_kwargs_no_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        assert func_two(a=10, b=20, c=30) == (10, 20, 30)
+        assert not caught
+
+
+def test_only_required_arg_no_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        assert func_two(1) == (1, 2, 3)
+        assert not caught
+
+
+def test_single_positional_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_two(1, 4)
+        assert out == (1, 4, 3)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert "Positional argument `b` for `func_two` is deprecated." in msg
+
+
+def test_multiple_positional_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_two(1, 4, 5)
+        assert out == (1, 4, 5)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert "Positional arguments `b` and `c` for `func_two` are deprecated." in msg
+
+
+def test_three_positional_warning_oxford_comma():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_three(1, 2, 3, 4)
+        assert out == (1, 2, 3, 4)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert (
+            "Positional arguments `b`, `c`, and `d` for `func_three` are deprecated."
+            in msg
+        )
+
+
+def test_noncontiguous_partial_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_noncontig(1, 2, 3)
+        assert out == (1, 2, 3, 3)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert "Positional argument `b` for `func_noncontig` is deprecated." in msg
+
+
+def test_noncontiguous_full_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_noncontig(1, 2, 3, 4)
+        assert out == (1, 2, 3, 4)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert (
+            "Positional arguments `b` and `d` for `func_noncontig` are deprecated."
+            in msg
+        )
+
+
+def test_custom_warning_category():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        out = func_custom_category(1, 2)
+        assert out == (1, 2)
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, UserWarning)
+
+
+def test_func_no_deprecations_never_warns():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_no_deprecations(7, 8)
+        assert out == (7, 8)
+        assert not caught
+
+
+def test_missing_required_arg_no_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with pytest.raises(TypeError):
+            func_two()  # missing required 'a'
+        assert not caught
+
+
+def test_unknown_keyword_no_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with pytest.raises(TypeError):
+            func_two(1, 4, d=5)  # unknown keyword 'd'
+        assert not caught
+
+
+def test_varargs_behavior_and_deprecation():
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_varargs(1, 2, 3, 4)
+        assert out == (1, 2, (3, 4))
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert "Positional argument `b` for `func_varargs` is deprecated." in msg
+
+    with warnings.catch_warnings(record=True) as caught:
+        out = func_varargs(1)
+        assert out == (1, 1, ())
+        assert not caught
+
+
+def test_repeated_warnings():
+    with warnings.catch_warnings(record=True) as caught:
+        func_two(1, 4, 5)
+        func_two(1, 4, 5)
+        assert len(caught) == 2
+        assert str(caught[0].message) == str(caught[1].message)


### PR DESCRIPTION
Closes https://github.com/shapely/shapely/issues/2282
Closes https://github.com/shapely/shapely/issues/2280

It's my first time contributing here.

- I'm aware that shapely is generally untyped.
- Types used here are very similar to shapely/strtree.py, and because of that I decided to include them.
- **Allow edits by maintainers** is checked so feel free to push commits for minor issues

Potentially useful info for reviewers:

`__code__` docs reference (from Python 3.9): https://docs.python.org/3.9/library/inspect.html
	
- co_argcount: number of arguments (not including keyword only arguments, * or ** args)
- co_varnames: tuple of names of arguments and local variables

This lets us skip the heavy inspect logic.

Another big optimization is the `n > warn_from` check and LRU cache of the messages, so people who don't resolve the deprecation warning aren't affected too much performance-wise.