### PR TITLE
Better input validation in from_ragged_array

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -470,7 +470,7 @@ def _from_ragged_array_multi_linear(
     if offsets2[n_geoms] > n_rings:
         raise ValueError(
             f"Number of rings indicated by the geometry offsets ({offsets2[n_geoms]}) "
-            f"larger than indicated by the shape of linear offsets ({n_rings})"
+            f"larger than indicated by the shape of the linear offsets array ({n_rings})"
         )
 
     if offsets1[n_rings] > n_total_coords:
@@ -584,7 +584,7 @@ def _from_ragged_array_multipolygon(
     Create MultiPolygons from coordinate and offset arrays.
     """
     cdef:
-        Py_ssize_t n_geoms
+        Py_ssize_t n_total_coords, n_rings, n_parts, n_geoms
         Py_ssize_t i, j, k
         Py_ssize_t i1, i2, j1, j2, k1, k2
         Py_ssize_t n_coords, rings_idx, parts_idx
@@ -594,7 +594,28 @@ def _from_ragged_array_multipolygon(
         GEOSGeometry *part = NULL
         GEOSGeometry *geom = NULL
 
+    n_total_coords = coordinates.shape[0]
+    n_rings = offsets1.shape[0] - 1
+    n_parts = offsets2.shape[0] - 1
     n_geoms = offsets3.shape[0] - 1
+
+    if offsets3[n_geoms] > n_parts:
+        raise ValueError(
+            f"Number of geometry parts indicated by the geometry offsets ({offsets3[n_geoms]}) "
+            f"larger than indicated by the shape of the part offsets array ({n_parts})"
+        )
+
+    if offsets2[n_parts] > n_rings:
+        raise ValueError(
+            f"Number of rings indicated by the part offsets ({offsets2[n_parts]}) "
+            f"larger than indicated by the shape of the linear offsets array ({n_rings})"
+        )
+
+    if offsets1[n_rings] > n_total_coords:
+        raise ValueError(
+            f"Number of coordinates indicated by the linear offsets ({offsets1[n_rings]}) "
+            f"larger than the shape of the coordinates array ({n_total_coords})"
+        )
 
     # A temporary array for the geometries that will be given to CreatePolygon
     # and CreateCollection. For simplicity, we use n_geoms instead of calculating

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -454,7 +454,7 @@ def _from_ragged_array_multi_linear(
     MultiLineString (geometry_type 5): linear_type is a LineString (1)
     """
     cdef:
-        Py_ssize_t n_geoms
+        Py_ssize_t n_total_coords, n_rings, n_geoms
         Py_ssize_t i, k
         Py_ssize_t i1, i2, k1, k2
         Py_ssize_t n_coords, linear_idx
@@ -463,7 +463,21 @@ def _from_ragged_array_multi_linear(
         GEOSGeometry *linear = NULL
         GEOSGeometry *geom = NULL
 
+    n_total_coords = coordinates.shape[0]
+    n_rings = offsets1.shape[0] - 1
     n_geoms = offsets2.shape[0] - 1
+
+    if offsets2[n_geoms] > n_rings:
+        raise ValueError(
+            f"Number of rings indicated by the geometry offsets ({offsets2[n_geoms]}) "
+            f"larger than indicated by the shape of linear offsets ({n_rings})"
+        )
+
+    if offsets1[n_rings] > n_total_coords:
+        raise ValueError(
+            f"Number of coordinates indicated by the linear offsets ({offsets1[n_rings]}) "
+            f"larger than the shape of the coordinates array ({n_total_coords})"
+        )
 
     # A temporary array for the geometries that will be given to CreatePolygon/Collection.
     # For simplicity, we use n_geoms instead of calculating

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -586,3 +586,31 @@ def test_from_ragged_wrong_offsets():
             np.array([[0, 0], [0, 1]]),
             offsets=(np.array([0, 1]),),
         )
+
+
+def test_from_ragged_wrong_offsets_values():
+    # caused segfault in shapely 2.1.0
+
+    # outer offsets indicats more rings than the shape of the ring offsets
+    coords = np.random.randn(35, 2)
+    offsets1 = np.array([0, 10, 20], dtype=np.uint32)
+    offsets2 = np.array([0, 1, 5], dtype=np.uint32)
+
+    with pytest.raises(
+        ValueError, match="Number of rings indicated by the geometry offsets"
+    ):
+        shapely.from_ragged_array(
+            shapely.GeometryType.POLYGON, coords, (offsets1, offsets2)
+        )
+
+    # inner offsets indicating more coordinats that the shape of the coordinates
+    coords = np.random.randn(35, 2)
+    offsets1 = np.array([0, 10, 40], dtype=np.uint32)
+    offsets2 = np.array([0, 1, 2], dtype=np.uint32)
+
+    with pytest.raises(
+        ValueError, match="Number of coordinates indicated by the linear offsets"
+    ):
+        shapely.from_ragged_array(
+            shapely.GeometryType.POLYGON, coords, (offsets1, offsets2)
+        )

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -591,16 +591,24 @@ def test_from_ragged_wrong_offsets():
 def test_from_ragged_wrong_offsets_values():
     # caused segfault in shapely 2.1.0
 
-    # outer offsets indicats more rings than the shape of the ring offsets
+    # outer offsets indicates more rings than the shape of the ring offsets
     coords = np.random.randn(35, 2)
     offsets1 = np.array([0, 10, 20], dtype=np.uint32)
     offsets2 = np.array([0, 1, 5], dtype=np.uint32)
+    offsets3 = np.array([0, 2])
 
     with pytest.raises(
         ValueError, match="Number of rings indicated by the geometry offsets"
     ):
         shapely.from_ragged_array(
             shapely.GeometryType.POLYGON, coords, (offsets1, offsets2)
+        )
+
+    with pytest.raises(
+        ValueError, match="Number of rings indicated by the part offsets"
+    ):
+        shapely.from_ragged_array(
+            shapely.GeometryType.MULTIPOLYGON, coords, (offsets1, offsets2, offsets3)
         )
 
     # inner offsets indicating more coordinats that the shape of the coordinates
@@ -613,4 +621,20 @@ def test_from_ragged_wrong_offsets_values():
     ):
         shapely.from_ragged_array(
             shapely.GeometryType.POLYGON, coords, (offsets1, offsets2)
+        )
+
+    with pytest.raises(
+        ValueError, match="Number of coordinates indicated by the linear offsets"
+    ):
+        shapely.from_ragged_array(
+            shapely.GeometryType.MULTIPOLYGON, coords, (offsets1, offsets2, offsets3)
+        )
+
+    # outer multipolygon offsets indicating too many parts
+    offsets3 = np.array([0, 3])
+    with pytest.raises(
+        ValueError, match="Number of geometry parts indicated by the geometry offsets"
+    ):
+        shapely.from_ragged_array(
+            shapely.GeometryType.MULTIPOLYGON, coords, (offsets1, offsets2, offsets3)
         )


### PR DESCRIPTION
Noticed some other issues while investigating https://github.com/shapely/shapely/discussions/2284, it was easy to pass invalid offset data. While we can do some cheap checks to avoid wrong data or crashes later down the line if a user is passing wrong data.