### PR TITLE
BUG: avoid memory segfault in from_ragged_array

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -468,7 +468,7 @@ def _from_ragged_array_multi_linear(
 
     # A temporary array for the geometries that will be given to CreatePolygon/Collection.
     # For simplicity, we use n_rings instead of calculating the max needed size
-    # as max(diff(offsets1)) (trading performance for a bit more memory usage)
+    # as max(diff(offsets2)) (trading performance for a bit more memory usage)
     temp_linear = np.empty(shape=(n_rings, ), dtype=np.intp)
     cdef np.intp_t[:] temp_linear_view = temp_linear
     # A temporary array for resulting geometries

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -454,7 +454,7 @@ def _from_ragged_array_multi_linear(
     MultiLineString (geometry_type 5): linear_type is a LineString (1)
     """
     cdef:
-        Py_ssize_t n_geoms
+        Py_ssize_t n_rings, n_geoms
         Py_ssize_t i, k
         Py_ssize_t i1, i2, k1, k2
         Py_ssize_t n_coords, linear_idx
@@ -463,12 +463,13 @@ def _from_ragged_array_multi_linear(
         GEOSGeometry *linear = NULL
         GEOSGeometry *geom = NULL
 
+    n_rings = offsets1.shape[0] - 1
     n_geoms = offsets2.shape[0] - 1
 
     # A temporary array for the geometries that will be given to CreatePolygon/Collection.
-    # For simplicity, we use n_geoms instead of calculating
-    # the max needed size (trading performance for a bit more memory usage)
-    temp_linear = np.empty(shape=(n_geoms, ), dtype=np.intp)
+    # For simplicity, we use n_rings instead of calculating the max needed size
+    # as max(offsets1) (trading performance for a bit more memory usage)
+    temp_linear = np.empty(shape=(n_rings, ), dtype=np.intp)
     cdef np.intp_t[:] temp_linear_view = temp_linear
     # A temporary array for resulting geometries
     temp_geoms = np.empty(shape=(n_geoms, ), dtype=np.intp)

--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -468,7 +468,7 @@ def _from_ragged_array_multi_linear(
 
     # A temporary array for the geometries that will be given to CreatePolygon/Collection.
     # For simplicity, we use n_rings instead of calculating the max needed size
-    # as max(offsets1) (trading performance for a bit more memory usage)
+    # as max(diff(offsets1)) (trading performance for a bit more memory usage)
     temp_linear = np.empty(shape=(n_rings, ), dtype=np.intp)
     cdef np.intp_t[:] temp_linear_view = temp_linear
     # A temporary array for resulting geometries
@@ -571,7 +571,7 @@ def _from_ragged_array_multipolygon(
     Create MultiPolygons from coordinate and offset arrays.
     """
     cdef:
-        Py_ssize_t n_geoms
+        Py_ssize_t n_rings, n_parts, n_geoms
         Py_ssize_t i, j, k
         Py_ssize_t i1, i2, j1, j2, k1, k2
         Py_ssize_t n_coords, rings_idx, parts_idx
@@ -581,14 +581,16 @@ def _from_ragged_array_multipolygon(
         GEOSGeometry *part = NULL
         GEOSGeometry *geom = NULL
 
+    n_rings = offsets1.shape[0] - 1
+    n_parts = offsets2.shape[0] - 1
     n_geoms = offsets3.shape[0] - 1
 
     # A temporary array for the geometries that will be given to CreatePolygon
-    # and CreateCollection. For simplicity, we use n_geoms instead of calculating
-    # the max needed size (trading performance for a bit more memory usage)
-    temp_rings = np.empty(shape=(n_geoms, ), dtype=np.intp)
+    # and CreateCollection. For simplicity, we use n_rings/n_parts instead of
+    # calculating the max needed size (trading performance for a bit more memory usage)
+    temp_rings = np.empty(shape=(n_rings, ), dtype=np.intp)
     cdef np.intp_t[:] temp_rings_view = temp_rings
-    temp_parts = np.empty(shape=(n_geoms, ), dtype=np.intp)
+    temp_parts = np.empty(shape=(n_parts, ), dtype=np.intp)
     cdef np.intp_t[:] temp_parts_view = temp_parts
     # A temporary array for resulting geometries
     temp_geoms = np.empty(shape=(n_geoms, ), dtype=np.intp)

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -586,3 +586,20 @@ def test_from_ragged_wrong_offsets():
             np.array([[0, 0], [0, 1]]),
             offsets=(np.array([0, 1]),),
         )
+
+
+def test_from_ragged_crash_2284():
+    # caused segfault in shapely 2.1.0
+    # https://github.com/shapely/shapely/discussions/2284
+
+    # one of the geometries has more rings than the total number of geometries
+    coords = np.random.randn(60, 2)
+    offsets1 = np.array([0, 10, 20, 30, 40, 50, 60], dtype=np.uint32)
+    offsets2 = np.array([0, 1, 5, 6], dtype=np.uint32)
+
+    for _ in range(10):
+        polygons = shapely.from_ragged_array(
+            shapely.GeometryType.POLYGON, coords, (offsets1, offsets2)
+        )
+        # just ensure it didn't crash
+        assert len(polygons) == 3

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -594,8 +594,8 @@ def test_from_ragged_crash_2284():
 
     # one of the geometries has more rings than the total number of geometries
     coords = np.random.randn(60, 2)
-    offsets1 = np.array([0, 10, 20, 30, 40, 50, 60], dtype=np.uint32)
-    offsets2 = np.array([0, 1, 5, 6], dtype=np.uint32)
+    offsets1 = np.array([0, 10, 20, 30, 40, 50, 60])
+    offsets2 = np.array([0, 1, 5, 6])
 
     for _ in range(10):
         polygons = shapely.from_ragged_array(
@@ -603,3 +603,11 @@ def test_from_ragged_crash_2284():
         )
         # just ensure it didn't crash
         assert len(polygons) == 3
+
+    offsets3 = np.array([0, 3])
+    for _ in range(10):
+        polygons = shapely.from_ragged_array(
+            shapely.GeometryType.MULTIPOLYGON, coords, (offsets1, offsets2, offsets3)
+        )
+        # just ensure it didn't crash
+        assert len(polygons) == 1

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -593,7 +593,7 @@ def test_from_ragged_crash_2284():
     # https://github.com/shapely/shapely/discussions/2284
 
     # one of the geometries has more rings than the total number of geometries
-    coords = np.random.randn(60, 2)
+    coords = np.random.default_rng().random(120).reshape((60, 2))
     offsets1 = np.array([0, 10, 20, 30, 40, 50, 60])
     offsets2 = np.array([0, 1, 5, 6])
 
@@ -617,7 +617,7 @@ def test_from_ragged_wrong_offsets_values():
     # caused segfault in shapely 2.1.0
 
     # outer offsets indicates more rings than the shape of the ring offsets
-    coords = np.random.randn(35, 2)
+    coords = np.random.default_rng().random(70).reshape((35, 2))
     offsets1 = np.array([0, 10, 20], dtype=np.uint32)
     offsets2 = np.array([0, 1, 5], dtype=np.uint32)
     offsets3 = np.array([0, 2])
@@ -637,7 +637,7 @@ def test_from_ragged_wrong_offsets_values():
         )
 
     # inner offsets indicating more coordinats that the shape of the coordinates
-    coords = np.random.randn(35, 2)
+    coords = np.random.default_rng().random(70).reshape((35, 2))
     offsets1 = np.array([0, 10, 40], dtype=np.uint32)
     offsets2 = np.array([0, 1, 2], dtype=np.uint32)
 


### PR DESCRIPTION
Fixes the issue reported in https://github.com/shapely/shapely/discussions/2284

We were allocating a too small temporary array for storing the intermediate rings. 
