### PR TITLE
TST: update maximum_inscribed_circle tests for latest GEOS changes

### DIFF
--- a/shapely/tests/legacy/test_polylabel.py
+++ b/shapely/tests/legacy/test_polylabel.py
@@ -48,6 +48,9 @@ class PolylabelTestCase(unittest.TestCase):
             ]
         )
         label = polylabel(polygon)
+        if shapely.geos_version >= (3, 14, 0):
+            # TODO verify if this is a bug in GEOS?
+            assert label.coords[:] == [(32.722025, -117.195155)]
         if shapely.geos_version >= (3, 12, 0):
             # recent GEOS corrects for this
             assert label.coords[:] == [(32.722025, -117.201875)]

--- a/shapely/tests/legacy/test_polylabel.py
+++ b/shapely/tests/legacy/test_polylabel.py
@@ -49,7 +49,7 @@ class PolylabelTestCase(unittest.TestCase):
         )
         label = polylabel(polygon)
         if shapely.geos_version >= (3, 14, 0):
-            # TODO verify if this is a bug in GEOS?
+            # https://github.com/libgeos/geos/issues/1265
             assert label.coords[:] == [(32.722025, -117.195155)]
         elif shapely.geos_version >= (3, 12, 0):
             # recent GEOS corrects for this

--- a/shapely/tests/legacy/test_polylabel.py
+++ b/shapely/tests/legacy/test_polylabel.py
@@ -51,7 +51,7 @@ class PolylabelTestCase(unittest.TestCase):
         if shapely.geos_version >= (3, 14, 0):
             # TODO verify if this is a bug in GEOS?
             assert label.coords[:] == [(32.722025, -117.195155)]
-        if shapely.geos_version >= (3, 12, 0):
+        elif shapely.geos_version >= (3, 12, 0):
             # recent GEOS corrects for this
             assert label.coords[:] == [(32.722025, -117.201875)]
         else:

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -1193,7 +1193,7 @@ def test_maximum_inscribed_circle_all_types(geometry):
 
     if geometry.is_empty:
         with pytest.raises(
-            GEOSException, match="Empty input geometry is not supported"
+            GEOSException, match="Empty input(?: geometry)? is not supported"
         ):
             shapely.maximum_inscribed_circle(geometry)
         return
@@ -1227,7 +1227,7 @@ def test_maximum_inscribed_circle_empty():
         GEOSException,
         match=(
             "Argument must be Polygonal or LinearRing|"  # GEOS < 3.10.4
-            "Input geometry must be a Polygon or MultiPolygon"
+            "must be a Polygon or MultiPolygon"
         ),
     ):
         shapely.maximum_inscribed_circle(geometry)

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -1233,7 +1233,9 @@ def test_maximum_inscribed_circle_empty():
         shapely.maximum_inscribed_circle(geometry)
 
     geometry = shapely.from_wkt("POLYGON EMPTY")
-    with pytest.raises(GEOSException, match="Empty input geometry is not supported"):
+    with pytest.raises(
+        GEOSException, match="Empty input(?: geometry)? is not supported"
+    ):
         shapely.maximum_inscribed_circle(geometry)
 
 

--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -1184,7 +1184,7 @@ def test_maximum_inscribed_circle_all_types(geometry):
             GEOSException,
             match=(
                 "Argument must be Polygonal or LinearRing|"  # GEOS < 3.10.4
-                "Input geometry must be a Polygon or MultiPolygon|"
+                "must be a Polygon or MultiPolygon|"
                 "Operation not supported by GeometryCollection"
             ),
         ):


### PR DESCRIPTION
Some tests are failing on the GEOS main builds (eg https://github.com/shapely/shapely/actions/runs/14814815121/job/41593981112), related to some recent commits in GEOS (https://github.com/libgeos/geos/compare/4ae3f0536735923dc93d6ea8a1e0dadafc791af1...6f4a7396481ab28dd240cc7b1511949f1892ac2a)