### PR TITLE
MNT: rename first arg for __new__ staticmethods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.11.11
     hooks:
       # Run the linter
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ select = [
     # implicit string concatenation
     "ISC",
     # type-checking imports
-    "TCH",
+    "TC",
     # comprehensions
     "C4",
     # Ruff-specific rules
@@ -148,16 +148,8 @@ ignore = [
     "PLR0911",
     # Too many branches
     "PLR0912",
-    # Too many statements
-    "PLR0915",
     # Magic number
     "PLR2004",
-    # Redefined loop name
-    "PLW2901",
-    # Global statements are discouraged
-    "PLW0603",
-    # compare-to-empty-string
-    "PLC1901",
     # requiring | in isinstance
     "UP038",
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -99,7 +99,7 @@ class BaseGeometry(shapely.Geometry):
 
     __slots__ = []
 
-    def __new__(self):
+    def __new__(cls):
         """Directly calling the base class 'BaseGeometry()' is deprecated.
 
         This will raise an error in the future. To create an empty geometry,
@@ -1126,7 +1126,7 @@ class GeometrySequence:
 class EmptyGeometry(BaseGeometry):
     """An empty geometry."""
 
-    def __new__(self):
+    def __new__(cls):
         """Create an empty geometry."""
         warn(
             "The 'EmptyGeometry()' constructor to create an empty geometry is "

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -31,7 +31,7 @@ class GeometryCollection(BaseMultipartGeometry):
 
     __slots__ = []
 
-    def __new__(self, geoms=None):
+    def __new__(cls, geoms=None):
         """Create a new GeometryCollection."""
         if isinstance(geoms, BaseGeometry):
             # TODO(shapely-2.0) do we actually want to split Multi-part geometries?

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -37,7 +37,7 @@ class LineString(BaseGeometry):
 
     __slots__ = []
 
-    def __new__(self, coordinates=None):
+    def __new__(cls, coordinates=None):
         """Create a new LineString geometry."""
         if coordinates is None:
             # empty geometry

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -35,7 +35,7 @@ class MultiLineString(BaseMultipartGeometry):
 
     __slots__ = []
 
-    def __new__(self, lines=None):
+    def __new__(cls, lines=None):
         """Create a new MultiLineString geometry."""
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -41,7 +41,7 @@ class MultiPoint(BaseMultipartGeometry):
 
     __slots__ = []
 
-    def __new__(self, points=None):
+    def __new__(cls, points=None):
         """Create a new MultiPoint geometry."""
         if points is None:
             # allow creation of empty multipoints, to support unpickling

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -45,7 +45,7 @@ class MultiPolygon(BaseMultipartGeometry):
 
     __slots__ = []
 
-    def __new__(self, polygons=None):
+    def __new__(cls, polygons=None):
         """Create a new MultiPolygon geometry."""
         if polygons is None:
             # allow creation of empty multipolygons, to support unpickling

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -51,7 +51,7 @@ class Point(BaseGeometry):
 
     __slots__ = []
 
-    def __new__(self, *args):
+    def __new__(cls, *args):
         """Create a new Point geometry."""
         if len(args) == 0:
             # empty geometry

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -58,7 +58,7 @@ class LinearRing(LineString):
 
     __slots__ = []
 
-    def __new__(self, coordinates=None):
+    def __new__(cls, coordinates=None):
         """Create a new LinearRing geometry."""
         if coordinates is None:
             # empty geometry
@@ -224,7 +224,7 @@ class Polygon(BaseGeometry):
 
     __slots__ = []
 
-    def __new__(self, shell=None, holes=None):
+    def __new__(cls, shell=None, holes=None):
         """Create a new Polygon geometry."""
         if shell is None:
             # empty geometry

--- a/shapely/tests/legacy/test_locale.py
+++ b/shapely/tests/legacy/test_locale.py
@@ -20,7 +20,7 @@ do_test_locale = False
 
 
 def setUpModule():
-    global do_test_locale
+    global do_test_locale  # noqa: PLW0603
     for name in test_locales:
         try:
             test_locale = test_locales[name]


### PR DESCRIPTION
This PR started with `pre-commit autoupdate` which updated the ruff version and check rules. Thus the primary change here is to fix [bad-staticmethod-argument (PLW0211)](https://docs.astral.sh/ruff/rules/bad-staticmethod-argument/#bad-staticmethod-argument-plw0211), where I've renamed the first argument of the implicitly static methods `__new__(self...` to `__new__(cls...`.

Other changes:

- Rename `TCH` to `TC` for type-checking imports, as it seems that this rule has been renamed at some version.
- Remove a few unused ignores related to PLW/PLC; move one as an inline ignore.

Also, should this change be part of the yet-to-be created `maint-2.1` or just for `main` branch development for the next version? My instinct is for the later choice, thus I'd create a maintenance branch before merging.