### PR TITLE
MAINT: drop Python 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,11 @@ jobs:
         geos: [3.9.6, 3.10.7, 3.11.5, 3.12.3, 3.13.1, main]
         include:
           # 2020
-          - python: "3.10"
+          - python: "3.11"
             geos: 3.9.6
             numpy: 1.21.6
           # 2021
-          - python: "3.10"
+          - python: "3.11"
             geos: 3.10.7
             numpy: 1.21.6
           # 2022
@@ -55,7 +55,7 @@ jobs:
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
-            python: "3.10"
+            python: "3.11"
             geos: 3.9.6
             numpy: 1.21.6
           - os: windows-2019
@@ -65,7 +65,7 @@ jobs:
             numpy: 1.24.4
           # pypy (use explicit ubuntu version to not overwrite existing ubuntu-latest + geos 3.11.0 build)
           - os: ubuntu-22.04
-            python: "pypy3.10"
+            python: "pypy3.11"
             geos: 3.12.3
             numpy: 1.24.4
 

--- a/README.rst
+++ b/README.rst
@@ -103,9 +103,9 @@ See the documentation for more examples and guidance: https://shapely.readthedoc
 Requirements
 ============
 
-Shapely 2.1 requires
+Shapely 2.2 requires
 
-* Python >=3.10
+* Python >=3.11
 * GEOS >=3.9
 * NumPy >=1.21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,12 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "numpy>=1.21",
 ]
@@ -138,8 +137,6 @@ ignore = [
     "B007",
     # get-attr-with-constant
     "B009",
-    # Only works with python >=3.10
-    "B905",
     # dict literals
     "C408",
     # Too many arguments to function call

--- a/shapely/algorithms/_oriented_envelope.py
+++ b/shapely/algorithms/_oriented_envelope.py
@@ -27,7 +27,7 @@ def _oriented_envelope_min_area(geometry, **kwargs):
     # generate the edge vectors between the convex hull's coords
     edges = (
         (pt2[0] - pt1[0], pt2[1] - pt1[1])
-        for pt1, pt2 in zip(coords, islice(coords, 1, None))
+        for pt1, pt2 in zip(coords, islice(coords, 1, None), strict=False)
     )
 
     def _transformed_rects():

--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -87,7 +87,7 @@ def multithreading_enabled(func):
                 arr.flags.writeable = False
             return func(*args, **kwargs)
         finally:
-            for arr, old_flag in zip(array_args, old_flags):
+            for arr, old_flag in zip(array_args, old_flags, strict=False):
                 arr.flags.writeable = old_flag
 
     return wrapped

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -1051,7 +1051,7 @@ class BaseMultipartGeometry(BaseGeometry):
         return (
             type(other) is type(self)
             and len(self.geoms) == len(other.geoms)
-            and all(a == b for a, b in zip(self.geoms, other.geoms))
+            and all(a == b for a, b in zip(self.geoms, other.geoms, strict=False))
         )
 
     def __hash__(self):

--- a/shapely/tests/geometry/test_decimal.py
+++ b/shapely/tests/geometry/test_decimal.py
@@ -111,7 +111,7 @@ all_geoms = [
 ]
 
 
-@pytest.mark.parametrize("geoms", list(zip(*all_geoms)))
+@pytest.mark.parametrize("geoms", list(zip(*all_geoms, strict=True)))
 def test_decimal(geoms):
     assert geoms[0] == geoms[1] == geoms[2]
     assert geoms[3] == geoms[4] == geoms[5]

--- a/shapely/tests/geometry/test_format.py
+++ b/shapely/tests/geometry/test_format.py
@@ -67,7 +67,7 @@ def test_format_point(format_spec, coords, expt_wkt, same_python_float):
     # check Python's format consistency
     text_coords = expt_wkt[expt_wkt.index("(") + 1 : expt_wkt.index(")")]
     is_same = []
-    for coord, expt_coord in zip(coords, text_coords.split()):
+    for coord, expt_coord in zip(coords, text_coords.split(), strict=True):
         py_fmt_float = format(float(coord), format_spec)
         if same_python_float:
             assert py_fmt_float == expt_coord, format_spec

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -447,14 +447,14 @@ class TestLinearRingGetItem:
             LinearRing([(90.0, 10), (110.0, 10.0), (100.0, 30.0), (90.0, 10.0)]),
         ]
         g = Polygon(shell, holes)
-        t = [a.equals(b) for (a, b) in zip(g.interiors[1:], holes[1:])]
+        t = [a.equals(b) for (a, b) in zip(g.interiors[1:], holes[1:], strict=True)]
         assert all(t)
-        t = [a.equals(b) for (a, b) in zip(g.interiors[:-1], holes[:-1])]
+        t = [a.equals(b) for (a, b) in zip(g.interiors[:-1], holes[:-1], strict=True)]
         assert all(t)
-        t = [a.equals(b) for (a, b) in zip(g.interiors[::-1], holes[::-1])]
+        t = [a.equals(b) for (a, b) in zip(g.interiors[::-1], holes[::-1], strict=True)]
         assert all(t)
-        t = [a.equals(b) for (a, b) in zip(g.interiors[::2], holes[::2])]
+        t = [a.equals(b) for (a, b) in zip(g.interiors[::2], holes[::2], strict=True)]
         assert all(t)
-        t = [a.equals(b) for (a, b) in zip(g.interiors[:3], holes[:3])]
+        t = [a.equals(b) for (a, b) in zip(g.interiors[:3], holes[:3], strict=True)]
         assert all(t)
         assert g.interiors[3:] == holes[3:] == []

--- a/shapely/tests/legacy/test_affinity.py
+++ b/shapely/tests/legacy/test_affinity.py
@@ -122,11 +122,11 @@ class AffineTestCase(unittest.TestCase):
         assert a22.equals_exact(expected2d, 1e-6)
         assert a23.equals_exact(expected2d, 1e-6)
         # Do explicit 3D check of coordinate values
-        for a, e in zip(a32.coords, expected32.coords):
-            for ap, ep in zip(a, e):
+        for a, e in zip(a32.coords, expected32.coords, strict=True):
+            for ap, ep in zip(a, e, strict=True):
                 self.assertAlmostEqual(ap, ep)
-        for a, e in zip(a33.coords, expected3d.coords):
-            for ap, ep in zip(a, e):
+        for a, e in zip(a33.coords, expected3d.coords, strict=True):
+            for ap, ep in zip(a, e, strict=True):
                 self.assertAlmostEqual(ap, ep)
 
 
@@ -187,8 +187,8 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt("LINESTRING(210 500 5, 210 200 15, 330 200 10)")
         assert sls.equals(els)
         # Do explicit 3D check of coordinate values
-        for a, b in zip(sls.coords, els.coords):
-            for ap, bp in zip(a, b):
+        for a, b in zip(sls.coords, els.coords, strict=True):
+            for ap, bp in zip(a, b, strict=True):
                 self.assertEqual(ap, bp)
         # retest with named parameters for the same result
         sls = affinity.scale(geom=ls, xfact=2, yfact=3, zfact=0.5, origin="center")
@@ -207,8 +207,8 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt("LINESTRING(380 800 505, 380 500 515, 500 500 510)")
         assert sls.equals(els)
         # Do explicit 3D check of coordinate values
-        for a, b in zip(sls.coords, els.coords):
-            for ap, bp in zip(a, b):
+        for a, b in zip(sls.coords, els.coords, strict=True):
+            for ap, bp in zip(a, b, strict=True):
                 assert ap == bp
 
     def test_scale_empty(self):
@@ -294,8 +294,8 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt("LINESTRING(340 800 0, 340 700 20, 400 700 10)")
         assert tls.equals(els)
         # Do explicit 3D check of coordinate values
-        for a, b in zip(tls.coords, els.coords):
-            for ap, bp in zip(a, b):
+        for a, b in zip(tls.coords, els.coords, strict=True):
+            for ap, bp in zip(a, b, strict=True):
                 assert ap == bp
         # retest with named parameters for the same result
         tls = affinity.translate(geom=ls, xoff=100, yoff=400, zoff=-10)

--- a/shapely/tests/legacy/test_locale.py
+++ b/shapely/tests/legacy/test_locale.py
@@ -34,11 +34,7 @@ def setUpModule():
 
 
 def tearDownModule():
-    if sys.platform == "win32" or sys.version_info[0:2] >= (3, 11):
-        locale.setlocale(locale.LC_ALL, "")
-    else:
-        # Deprecated since version 3.11, will be removed in version 3.13
-        locale.resetlocale()
+    locale.setlocale(locale.LC_ALL, "")
 
 
 class LocaleTestCase(unittest.TestCase):

--- a/shapely/tests/legacy/test_pickle.py
+++ b/shapely/tests/legacy/test_pickle.py
@@ -37,7 +37,7 @@ TEST_DATA = {
     "emptypoint": wkt.loads("POINT EMPTY"),
     "emptypolygon": wkt.loads("POLYGON EMPTY"),
 }
-TEST_NAMES, TEST_GEOMS = zip(*TEST_DATA.items())
+TEST_NAMES, TEST_GEOMS = zip(*TEST_DATA.items(), strict=True)
 
 
 @pytest.mark.parametrize("geom1", TEST_GEOMS, ids=TEST_NAMES)

--- a/shapely/tests/legacy/test_union.py
+++ b/shapely/tests/legacy/test_union.py
@@ -50,6 +50,7 @@ class UnionTestCase(unittest.TestCase):
         self.coords = zip(
             list(islice(halton(5), 20, 120)),
             list(islice(halton(7), 20, 120)),
+            strict=True,
         )
 
     def test_unary_union(self):


### PR DESCRIPTION
This drops Python 3.10 support for the next phase of development for shapely 2.2.

A few suggestions from ruff check are evaluated and applied, based on python 3.11+ support. Most of this is based on [zip-without-explicit-strict (B905)](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905).