### PR TITLE
BUILD/CI: Add win_arm64 wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,19 +145,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2022
+          - os: windows-2025
             arch: x86
             msvc_arch: x86
-          - os: windows-2022
+          - os: windows-2025
             arch: AMD64
             msvc_arch: x64
           - os: windows-11-arm
             arch: ARM64
             msvc_arch: ARM64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
             cmake_osx_architectures: x86_64
-          - os: macos-14
+          - os: macos-15
             arch: arm64
             cmake_osx_architectures: arm64
 
@@ -218,7 +218,6 @@ jobs:
             pip install numpy setuptools wheel &&
             pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} {wheel}
-          CIBW_SKIP: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && '*pp3* *cp310*' || '*pp3*' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- windows x86-64 image bumped to 2022 (due the 2019 deprecation)
- added windows-11-arm platform

Huge kudos to @w8sl for hints

Closes: https://github.com/shapely/shapely/issues/2296