### PR TITLE
TST: update frechet_distance densify test for latest GEOS main (densify>0.001)``

### DIFF
--- a/shapely/tests/test_measurement.py
+++ b/shapely/tests/test_measurement.py
@@ -247,7 +247,7 @@ def test_frechet_distance(geom1, geom2, expected):
         (
             shapely.linestrings([[0, 0], [100, 0]]),
             shapely.linestrings([[0, 0], [50, 50], [100, 0]]),
-            0.001,
+            0.002,
             50,
         )
     ],


### PR DESCRIPTION
This test is currently failing on the builds against GEOS main:

```
 >       return lib.frechet_distance_densify(a, b, densify, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       shapely.errors.GEOSException: IllegalArgumentException: Fraction is not in range (0.001 - 1.0]
```

We were testing with exactly a densify fraction of 0.001, but a recent change in GEOS (https://github.com/libgeos/geos/commit/ae1f72600b5939169d57c1ae76cd9dec7fba847e#diff-a81958906dd1e0b8d7226c676d64f313b6c5ee44ea817a98731f0646b64153daL62-R97) changed the lower bound from 0 to 0.001.