### PR TITLE
CI: update windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Add MSVC LICENSE
         run: cp ci/wheelbuilder/LICENSE_win32 .
         shell: bash
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: Activate MSVC
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-2019]
+        os: [ubuntu-latest, macos-13, windows-2022]
         architecture: [x64]
         geos: [3.10.7, 3.11.5, 3.12.3, 3.13.1, main]
         include:
@@ -49,12 +49,12 @@ jobs:
             geos: main
             extra_pytest_args: "-W error"  # error on warnings
           # enable two 32-bit windows builds:
-          - os: windows-2019
+          - os: windows-2022
             architecture: x86
             python: "3.10"
             geos: 3.10.7
             numpy: 1.21.6
-          - os: windows-2019
+          - os: windows-2022
             architecture: x86
             python: "3.11"
             geos: 3.12.3
@@ -76,7 +76,7 @@ jobs:
         run: |
           echo 'GEOS_INSTALL=${{ github.workspace }}\geosinstall\geos-${{ matrix.geos }}' >> $GITHUB_ENV
           echo 'GEOS_BUILD=${{ github.workspace }}\geosbuild' >> $GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: Checkout Shapely
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.architecture }}
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: Install GEOS
         run: |


### PR DESCRIPTION
The windows-2019 image was deprecated and now the builds were no longer running
