### PR TITLE
maint: Replace unittest.SkipTest with pytest.skip

### DIFF
--- a/shapely/tests/legacy/test_locale.py
+++ b/shapely/tests/legacy/test_locale.py
@@ -4,6 +4,8 @@ import locale
 import sys
 import unittest
 
+import pytest
+
 from shapely.wkt import dumps, loads
 
 # Set locale to one that uses a comma as decimal separator
@@ -30,7 +32,7 @@ def setUpModule():
         except Exception:
             pass
     if not do_test_locale:
-        raise unittest.SkipTest("test locale not found")
+        pytest.skip("test locale not found")
 
 
 def tearDownModule():


### PR DESCRIPTION
This fixes test failures with pytest 9 on main.