### PR TITLE
CI: update retired macos-13 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         architecture: [x64]
         geos: [3.10.7, 3.11.5, 3.12.3, 3.13.1, 3.14.0, main]
         include:
@@ -43,8 +43,8 @@ jobs:
           - os: ubuntu-22.04
             python: "3.13t"
             geos: 3.13.1
-          # apple silicon
-          - os: macos-14
+          # apple intel
+          - os: macos-15-intel
             python: "3.12"
             geos: 3.12.3
             numpy: 2.0.2


### PR DESCRIPTION
For https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/