### PR TITLE
TST: update rectangle special case tests for GEOS 1.14.1 changes

### DIFF
--- a/shapely/tests/legacy/test_polylabel.py
+++ b/shapely/tests/legacy/test_polylabel.py
@@ -48,7 +48,9 @@ class PolylabelTestCase(unittest.TestCase):
             ]
         )
         label = polylabel(polygon)
-        if shapely.geos_version >= (3, 14, 0):
+        if shapely.geos_version >= (3, 14, 1):
+            assert label.coords[:] == [(32.722025, -117.201875)]
+        elif shapely.geos_version >= (3, 14, 0):
             # https://github.com/libgeos/geos/issues/1265
             assert label.coords[:] == [(32.722025, -117.195155)]
         elif shapely.geos_version >= (3, 12, 0):


### PR DESCRIPTION
With GEOS 1.14.1, the tests are failing with the error:

```
167s =================================== FAILURES ===================================
167s ________________ PolylabelTestCase.test_rectangle_special_case _________________
167s 
167s self = <shapely.tests.legacy.test_polylabel.PolylabelTestCase testMethod=test_rectangle_special_case>
167s 
167s     def test_rectangle_special_case(self):
167s         """
167s         The centroid algorithm used is vulnerable to floating point errors
167s         and can give unexpected results for rectangular polygons. Test
167s         that this special case is handled correctly.
167s         https://github.com/mapbox/polylabel/issues/3
167s         """
167s         polygon = Polygon(
167s             [
167s                 (32.71997, -117.19310),
167s                 (32.71997, -117.21065),
167s                 (32.72408, -117.21065),
167s                 (32.72408, -117.19310),
167s             ]
167s         )
167s         label = polylabel(polygon)
167s         if shapely.geos_version >= (3, 14, 0):
167s             # https://github.com/libgeos/geos/issues/1265
167s             assert label.coords[:] == [(32.722025, -117.195155)]
167s         elif shapely.geos_version >= (3, 12, 0):
167s             # recent GEOS corrects for this
167s >           assert label.coords[:] == [(32.722025, -117.201875)]
167s E           assert [(32.722025, -117.195155)] == [(32.722025, -117.201875)]
167s E             
167s E             At index 0 diff: (32.722025, -117.195155) != (32.722025, -117.201875)
167s E             
167s E             Full diff:
167s E               [
167s E                   (
167s E                       32.722025,
167s E             -         -117.201875,
167s E             ?              -- ^^
167s E             +         -117.195155,
167s E             ?               ^^^^
167s E                   ),
167s E               ]
167s 
167s /usr/lib/python3/dist-packages/shapely/tests/legacy/test_polylabel.py:56: AssertionError
167s ____________________ test_coverage_union_overlapping_inputs ____________________
167s 
167s     def test_coverage_union_overlapping_inputs():
167s         polygon = Polygon([(1, 1), (1, 0), (0, 0), (0, 1), (1, 1)])
167s         other = Polygon([(1, 0), (0.9, 1), (2, 1), (2, 0), (1, 0)])
167s     
167s         if shapely.geos_version >= (3, 14, 0):
167s             # Overlapping polygons raise an error again
167s             with pytest.raises(shapely.GEOSException, match="TopologyException"):
167s                 shapely.coverage_union(polygon, other)
167s         elif shapely.geos_version >= (3, 12, 0):
167s             # Return mostly unchanged output
167s >           result = shapely.coverage_union(polygon, other)
167s                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
167s 
167s /usr/lib/python3/dist-packages/shapely/tests/test_set_operations.py:296: 
167s _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
167s /usr/lib/python3/dist-packages/shapely/decorators.py:88: in wrapped
167s     return func(*args, **kwargs)
167s            ^^^^^^^^^^^^^^^^^^^^^
167s /usr/lib/python3/dist-packages/shapely/set_operations.py:595: in coverage_union
167s     return coverage_union_all([a, b], **kwargs)
167s            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
167s /usr/lib/python3/dist-packages/shapely/decorators.py:173: in wrapper
167s     result = func(*args, **kwargs)
167s              ^^^^^^^^^^^^^^^^^^^^^
167s /usr/lib/python3/dist-packages/shapely/decorators.py:88: in wrapped
167s     return func(*args, **kwargs)
167s            ^^^^^^^^^^^^^^^^^^^^^
167s _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
167s 
167s geometries = array([<POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))>,
167s        <POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))>], dtype=object)
167s axis = None, kwargs = {}
167s collections = <GEOMETRYCOLLECTION (POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1)), POLYGON ((1 0, 0.9...>
167s 
167s     @deprecate_positional(["axis"], category=DeprecationWarning)
167s     @multithreading_enabled
167s     def coverage_union_all(geometries, axis=None, **kwargs):
167s         """Return the union of multiple polygons of a geometry collection.
167s     
167s         This is an optimized version of union which assumes the polygons
167s         to be non-overlapping.
167s     
167s         This function ignores None values when other Geometry elements are present.
167s         If all elements of the given axis are None, an empty GeometryCollection is
167s         returned (before GEOS 3.12 this was an empty MultiPolygon).
167s     
167s         Parameters
167s         ----------
167s         geometries : array_like
167s             Geometries to merge/union.
167s         axis : int, optional
167s             Axis along which the operation is performed. The default (None)
167s             performs the operation over all axes, returning a scalar value.
167s             Axis may be negative, in which case it counts from the last to the
167s             first axis.
167s         **kwargs
167s             See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
167s     
167s         Notes
167s         -----
167s     
167s         .. deprecated:: 2.1.0
167s             A deprecation warning is shown if ``axis`` is specified as a
167s             positional argument. This will need to be specified as a keyword
167s             argument in a future release.
167s     
167s         See Also
167s         --------
167s         coverage_union
167s     
167s         Examples
167s         --------
167s         >>> import shapely
167s         >>> from shapely import Polygon
167s         >>> polygon_1 = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
167s         >>> polygon_2 = Polygon([(1, 0), (1, 1), (2, 1), (2, 0), (1, 0)])
167s         >>> shapely.coverage_union_all([polygon_1, polygon_2]).normalize()
167s         <POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))>
167s         >>> shapely.coverage_union_all([polygon_1, None]).normalize()
167s         <POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
167s         >>> shapely.coverage_union_all([None, None]).normalize()
167s         <GEOMETRYCOLLECTION EMPTY>
167s     
167s         """
167s         # coverage union in GEOS works over GeometryCollections
167s         # first roll the aggregation axis backwards
167s         geometries = np.asarray(geometries)
167s         if axis is None:
167s             geometries = geometries.ravel()
167s         else:
167s             geometries = np.rollaxis(
167s                 np.asarray(geometries), axis=axis, start=geometries.ndim
167s             )
167s         # create_collection acts on the inner axis
167s         collections = lib.create_collection(
167s             geometries, np.intc(GeometryType.GEOMETRYCOLLECTION)
167s         )
167s >       return lib.coverage_union(collections, **kwargs)
167s                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
167s E       shapely.errors.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs
167s 
167s /usr/lib/python3/dist-packages/shapely/set_operations.py:670: GEOSException
167s =========================== short test summary info ============================
167s FAILED tests/legacy/test_polylabel.py::PolylabelTestCase::test_rectangle_special_case - assert [(32.722025, -117.195155)] == [(32.722025, -117.201875)]
167s   
167s   At index 0 diff: (32.722025, -117.195155) != (32.722025, -117.201875)
167s   
167s   Full diff:
167s     [
167s         (
167s             32.722025,
167s   -         -117.201875,
167s   ?              -- ^^
167s   +         -117.195155,
167s   ?               ^^^^
167s         ),
167s     ]
167s FAILED tests/test_set_operations.py::test_coverage_union_overlapping_inputs - shapely.errors.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs
167s ============ 2 failed, 6268 passed, 99 skipped, 3 xfailed in 5.99s =============
```

The test log can be seen at https://autopkgtest.ubuntu.com/results/autopkgtest-resolute/resolute/amd64/p/python-shapely/20251118_131627_759d1@/log.gz