### PR TITLE
CI: replace macos-13 with macos-latest; use macos-15-intel for x86_64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,10 @@ jobs:
             python: "pypy3.11"
             geos: 3.12.3  # keep distinct from free threaded geos version
             numpy: 2.3.2
-
+        exclude:
+          # skip floating-point exceptions from GEOS that are now resolved
+          - os: macos-latest
+            geos: 3.13.1
     env:
       GEOS_VERSION: ${{ matrix.geos }}
       GEOS_VERSION_SPEC: ${{ matrix.geos }}


### PR DESCRIPTION
Recently [`macos-13` images were shut down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), so this update prefers `macos-latest`, which are currently an alias for `macos-15` which is arm64-based. I've added `macos-15-intel` for x86_64 testing.

I've also changed `windows-2022` to `windows-latest`, which is currently an alias for `windows-2025`.

See also https://github.com/actions/runner-images