### PR TITLE
TST: change test_remove_repeated_points_invalid_result for GEOS 3.15

### DIFF
--- a/shapely/tests/test_constructive.py
+++ b/shapely/tests/test_constructive.py
@@ -450,8 +450,12 @@ def test_remove_repeated_points(geom, expected):
 def test_remove_repeated_points_invalid_result(geom, tolerance):
     # Requiring GEOS 3.12 instead of 3.11
     # (GEOS 3.11 had a bug causing this to intermittently not fail)
-    with pytest.raises(shapely.GEOSException, match="Invalid number of points"):
-        shapely.remove_repeated_points(geom, tolerance)
+    if shapely.geos_version >= (3, 15, 0):
+        result = shapely.remove_repeated_points(geom, tolerance)
+        assert result.wkt == "POLYGON EMPTY"
+    else:
+        with pytest.raises(shapely.GEOSException, match="Invalid number of points"):
+            shapely.remove_repeated_points(geom, tolerance)
 
 
 @pytest.mark.skipif(shapely.geos_version < (3, 11, 0), reason="GEOS < 3.11")


### PR DESCRIPTION
This fixes a recent regression of tests with GEOS main for `remove_repeated_points` with this new behaviour:

```pycon
>>> import shapely
>>> shapely.geos_version_string
'3.15.0dev'
>>> geom = shapely.from_wkt("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))")
>>> shapely.remove_repeated_points(geom, 0)
<POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))>
>>> shapely.remove_repeated_points(geom, 1)
<POLYGON ((0 0, 1 1, 0 0))>
>>> shapely.remove_repeated_points(geom, 2)
<POLYGON EMPTY>
```

Xref #2344