### PR TITLE
MNT: implement PEP 639 for improved license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
     # define).
     "numpy>=1.25,<3",
-    "setuptools>=61.0.0",
+    "setuptools>=77.0.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -21,12 +21,11 @@ maintainers = [
 description = "Manipulation and analysis of geometric objects"
 readme = "README.rst"
 keywords = ["geometry", "topology", "gis"]
-license = {text = "BSD 3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
This implements [PEP 639](https://peps.python.org/pep-0639/) licence metadata changes and silences package build warnings with recent setuptools versions.