### PR TITLE
BUG: fix to_ragged_array to work with read-only ndarray input

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -214,7 +214,7 @@ cdef const GEOSGeometry* GetRingN(GEOSContextHandle_t handle, GEOSGeometry* poly
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_parts(object[:] array, bint extract_rings=0):
+def get_parts(np.ndarray[object] array, bint extract_rings=0):
     cdef Py_ssize_t geom_idx = 0
     cdef Py_ssize_t part_idx = 0
     cdef Py_ssize_t idx = 0

--- a/shapely/tests/test_ragged_array.py
+++ b/shapely/tests/test_ragged_array.py
@@ -158,12 +158,14 @@ def test_include_m_default():
 @pytest.mark.parametrize("geom", all_types)
 def test_read_only_arrays(geom):
     # https://github.com/shapely/shapely/pull/1744
-    typ, coords, offsets = shapely.to_ragged_array([geom, geom])
+    arr = np.array([geom, geom])
+    arr.flags.writeable = False
+    typ, coords, offsets = shapely.to_ragged_array(arr)
     coords.flags.writeable = False
-    for arr in offsets:
-        arr.flags.writeable = False
+    for a in offsets:
+        a.flags.writeable = False
     result = shapely.from_ragged_array(typ, coords, offsets)
-    assert_geometries_equal(result, [geom, geom])
+    assert_geometries_equal(result, arr)
 
 
 @pytest.mark.parametrize("geom", all_types_not_supported)


### PR DESCRIPTION
xref https://github.com/geopandas/geopandas/issues/3697

Similar as https://github.com/shapely/shapely/pull/1744,  but then for the geometry input