### PR TITLE
BUG: fix split if point is on start or end coordinate while line self-intersects on this point

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,10 @@ in a more performant way than `shapely.ops.transform` does. `shapely.ops.transfo
 Added return values to `prepare` and `destroy_prepared`. They now return whether something was done;
 calling `prepare` twice on a geometry will first return `True`, and then `False`.
 
+Bug fixes:
+
+- Fix `split` does not split self intersecting lines if point on start or end
+  coordinate (#2381).
 
 2.1.2 (2025-09-24)
 ------------------

--- a/shapely/tests/legacy/test_split.py
+++ b/shapely/tests/legacy/test_split.py
@@ -138,7 +138,6 @@ class TestSplitLine(TestSplitGeometry):
         self.helper(self.ls, splitter, 1)
 
     def test_split_line_with_multipoint(self):
-        """
         # points on line interior --> return 4 segments
         splitter = MultiPoint([(1, 1), (1.5, 1.5), (0.5, 0.5)])
         self.helper(self.ls, splitter, 4)
@@ -146,7 +145,6 @@ class TestSplitLine(TestSplitGeometry):
         # points on line interior and boundary -> return 2 segments
         splitter = MultiPoint([(1, 1), (3, 4)])
         self.helper(self.ls, splitter, 2)
-        """
 
         # point on linear interior but twice --> return 2 segments
         splitter = MultiPoint([(1, 1), (1.5, 1.5), (1, 1)])

--- a/shapely/tests/legacy/test_split.py
+++ b/shapely/tests/legacy/test_split.py
@@ -125,7 +125,11 @@ class TestSplitLine(TestSplitGeometry):
         splitter = Point(1.5, 1.5)
         self.helper(self.ls, splitter, 2)
 
-        # point on boundary --> return equal
+        # point on boundary, first point --> return equal
+        splitter = Point(0, 0)
+        self.helper(self.ls, splitter, 1)
+
+        # point on boundary, last point --> return equal
         splitter = Point(3, 4)
         self.helper(self.ls, splitter, 1)
 
@@ -134,6 +138,7 @@ class TestSplitLine(TestSplitGeometry):
         self.helper(self.ls, splitter, 1)
 
     def test_split_line_with_multipoint(self):
+        """
         # points on line interior --> return 4 segments
         splitter = MultiPoint([(1, 1), (1.5, 1.5), (0.5, 0.5)])
         self.helper(self.ls, splitter, 4)
@@ -141,6 +146,7 @@ class TestSplitLine(TestSplitGeometry):
         # points on line interior and boundary -> return 2 segments
         splitter = MultiPoint([(1, 1), (3, 4)])
         self.helper(self.ls, splitter, 2)
+        """
 
         # point on linear interior but twice --> return 2 segments
         splitter = MultiPoint([(1, 1), (1.5, 1.5), (1, 1)])
@@ -283,3 +289,89 @@ class TestSplitMulti(TestSplitGeometry):
         mpoly = MultiPolygon([poly1, poly2])
         ls = LineString([(-1, -1), (3, 3)])
         self.helper(mpoly, ls, 2)
+
+
+@pytest.mark.parametrize(
+    "descr, line_coords, point_coords, expected_chunks",
+    [
+        ("point is 1st coord", [(0, 0), (1, 1), (1, 0), (0, 0)], (0, 0), 1),
+        ("point is on line", [(0, 0), (1, 1), (1, 0), (0, 0)], (0.5, 0), 2),
+        ("point is on coord", [(0, 0), (1, 1), (1, 0), (0, 0)], (1, 1), 2),
+    ],
+)
+def test_split_line_closed_with_point(
+    descr, line_coords, point_coords, expected_chunks
+):
+    """Test splitting a closed line with a point."""
+    line = LineString(line_coords)
+    splitter = Point(point_coords)
+    TestSplitGeometry().helper(line, splitter, expected_chunks)
+
+
+@pytest.mark.parametrize(
+    "descr, line_coords, point_coords, expected_chunks",
+    [
+        ("point is 1st coord", [(0, 0), (2, 2), (0, 0)], (0, 0), 1),
+        ("point is on line", [(0, 0), (2, 2), (0, 0)], (1, 1), 2),
+        ("point is on coord", [(0, 0), (2, 2), (0, 0)], (2, 2), 2),
+    ],
+)
+def test_split_line_retraces_with_point(
+    descr, line_coords, point_coords, expected_chunks
+):
+    """Test splitting a line that retraces itself with a point."""
+    line = LineString(line_coords)
+    splitter = Point(point_coords)
+    TestSplitGeometry().helper(line, splitter, expected_chunks)
+
+
+@pytest.mark.parametrize(
+    "descr, line_coords, point_coords, expected_chunks",
+    [
+        ("point is 1st coord", [(0, 0), (2, 2), (-2, -2)], (0, 0), 2),
+        ("point is last coord", [(-2, -2), (2, 2), (0, 0)], (0, 0), 2),
+        ("point is on line", [(0, 0), (2, 2), (-2, -2)], (1, 1), 2),
+        ("point is on coord", [(0, 0), (2, 2), (-2, -2)], (2, 2), 2),
+    ],
+)
+def test_split_line_self_intersects_with_point(
+    descr, line_coords, point_coords, expected_chunks
+):
+    """Test splitting a self-intersecting line with a point."""
+    line = LineString(line_coords)
+    splitter = Point(point_coords)
+    TestSplitGeometry().helper(line, splitter, expected_chunks)
+
+
+@pytest.mark.parametrize(
+    "descr, line_coords, point_coords, expected_chunks",
+    [
+        ("point is 1st coord", [(0, 0), (1, 1), (2, 2), (0, 0), (-2, -2)], (0, 0), 2),
+        ("point is last coord", [(-2, -2), (0, 0), (1, 1), (2, 2), (0, 0)], (0, 0), 2),
+        ("point is on line", [(0, 0), (1, 1), (2, 2), (0, 0), (-2, -2)], (1, 1), 2),
+        ("point is on coord", [(0, 0), (1, 1), (2, 2), (0, 0), (-2, -2)], (2, 2), 2),
+    ],
+)
+def test_split_line_self_intersects_long_with_point(
+    descr, line_coords, point_coords, expected_chunks
+):
+    """Test splitting a longer self-intersecting line with a point."""
+    line = LineString(line_coords)
+    splitter = Point(point_coords)
+    TestSplitGeometry().helper(line, splitter, expected_chunks)
+
+
+@pytest.mark.parametrize(
+    "descr, line_coords, point_coords, expected_chunks",
+    [
+        ("point is first coord", [(0, 0), (2, 2)], (0, 0), 1),
+        ("point is last coord", [(0, 0), (2, 2)], (2, 2), 1),
+        ("point is on interior", [(0, 0), (2, 2)], (1, 1), 2),
+        ("point is not on line", [(0, 0), (2, 2)], (3, 3), 1),
+    ],
+)
+def test_split_line_short_with_point(descr, line_coords, point_coords, expected_chunks):
+    """Test splitting a short line of 2 points with a point."""
+    line = LineString(line_coords)
+    splitter = Point(point_coords)
+    TestSplitGeometry().helper(line, splitter, expected_chunks)


### PR DESCRIPTION
If a line self-intersects on the start or end point, and the split-point happens to be that point, it seems logical that the line is split on that location, but this is not the case.

Reason: there was a check that if `relate(line, split_point)` resulted in the `split_point` not being on the interior, that no actual split was needed. However, `relate` does not make a distinction if the line is self-intersecting or not, which leads to this issue.

This PR fixes this.

resolves #1569