### PR TITLE
doc: add 'See Also' sections to geometry class docstrings

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -24,6 +24,11 @@ class LineString(BaseGeometry):
         an array-like with shape (N, 2) or (N, 3).
         Also can be a sequence of Point objects, or combination of both.
 
+    See Also
+    --------
+    shapely.linestrings :
+        Create multiple line strings efficiently from coordinate arrays.
+
     Examples
     --------
     Create a LineString with two segments
@@ -32,11 +37,6 @@ class LineString(BaseGeometry):
     >>> a = LineString([[0, 0], [1, 0], [1, 1]])
     >>> a.length
     2.0
-
-    See Also
-    --------
-    shapely.linestrings : Create multiple line strings efficiently from coordinate
-                          arrays.
 
     """
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -24,17 +24,17 @@ class MultiLineString(BaseMultipartGeometry):
     geoms : sequence
         A sequence of LineStrings
 
+    See Also
+    --------
+    shapely.multilinestrings : Create MultiLineString geometries from arrays.
+    LineString : Single line string geometry.
+
     Examples
     --------
     Construct a MultiLineString containing two LineStrings.
 
     >>> from shapely import MultiLineString
     >>> lines = MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]])
-
-    See Also
-    --------
-    shapely.multilinestrings : Create MultiLineString geometries from arrays.
-    LineString : Single line string geometry.
 
     """
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -26,6 +26,11 @@ class MultiPoint(BaseMultipartGeometry):
     geoms : sequence
         A sequence of Points
 
+    See Also
+    --------
+    shapely.multipoints : Create MultiPoint geometries from arrays of points.
+    Point : Single point geometry.
+
     Examples
     --------
     Construct a MultiPoint containing two Points
@@ -36,11 +41,6 @@ class MultiPoint(BaseMultipartGeometry):
     2
     >>> type(ob.geoms[0]) == Point
     True
-
-    See Also
-    --------
-    shapely.multipoints : Create MultiPoint geometries from arrays of points.
-    Point : Single point geometry.
 
     """
 

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -25,6 +25,11 @@ class MultiPolygon(BaseMultipartGeometry):
     geoms : sequence
         A sequence of `Polygon` instances
 
+    See Also
+    --------
+    shapely.multipolygons : Create MultiPolygon geometries from arrays.
+    Polygon : Single polygon geometry.
+
     Examples
     --------
     Construct a MultiPolygon from a sequence of coordinate tuples
@@ -40,11 +45,6 @@ class MultiPolygon(BaseMultipartGeometry):
     1
     >>> type(ob.geoms[0]) == Polygon
     True
-
-    See Also
-    --------
-    shapely.multipolygons : Create MultiPolygon geometries from arrays.
-    Polygon : Single polygon geometry.
 
     """
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -30,6 +30,10 @@ class Point(BaseGeometry):
     x, y, z, m : float
         Coordinate values
 
+    See Also
+    --------
+    shapely.points : Create multiple points efficiently from coordinate arrays.
+
     Examples
     --------
     Constructing the Point using separate parameters for x and y:
@@ -46,10 +50,6 @@ class Point(BaseGeometry):
     -1.0
     >>> p.x
     1.0
-
-    See Also
-    --------
-    shapely.points : Create multiple points efficiently from coordinate arrays.
 
     """
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -41,6 +41,10 @@ class LinearRing(LineString):
     Rings are automatically closed. There is no need to specify a final
     coordinate pair identical to the first.
 
+    See Also
+    --------
+    shapely.linearrings : Create multiple linear rings efficiently from arrays.
+
     Examples
     --------
     Construct a square ring.
@@ -53,10 +57,6 @@ class LinearRing(LineString):
     [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]
     >>> ring.length
     4.0
-
-    See Also
-    --------
-    shapely.linearrings : Create multiple linear rings efficiently from arrays.
 
     """
 
@@ -214,6 +214,11 @@ class Polygon(BaseGeometry):
     interiors : sequence
         A sequence of rings which bound all existing holes.
 
+    See Also
+    --------
+    shapely.polygons : Create multiple polygons efficiently from coordinate arrays.
+    shapely.box : Create rectangular polygons from bounding coordinates.
+
     Examples
     --------
     Create a square polygon with no holes
@@ -223,11 +228,6 @@ class Polygon(BaseGeometry):
     >>> polygon = Polygon(coords)
     >>> polygon.area
     1.0
-
-    See Also
-    --------
-    shapely.polygons : Create multiple polygons efficiently from coordinate arrays.
-    shapely.box : Create rectangular polygons from bounding coordinates.
 
     """
 


### PR DESCRIPTION
## Summary

This PR adds "See Also" sections to geometry class docstrings, linking each geometry class to its corresponding vectorized function.

Closes #1925

## Changes

| Class | Links to |
|-------|----------|
| `Point` | `shapely.points` |
| `LineString` | `shapely.linestrings` |
| `Polygon` | `shapely.polygons`, `shapely.box` |
| `LinearRing` | `shapely.linearrings` |
| `MultiPoint` | `shapely.multipoints`, `Point` |
| `MultiLineString` | `shapely.multilinestrings`, `LineString` |
| `MultiPolygon` | `shapely.multipolygons`, `Polygon` |

## Motivation

As mentioned in #1925, users often miss the existence of vectorized functions like `shapely.polygons` because the `Polygon` class documentation doesn't reference them. This leads to inefficient code where users write for-loops instead of using the faster vectorized alternatives.

By adding "See Also" sections following NumPy docstring conventions, we help users discover these efficient functions directly from the class documentation.