### PR TITLE
CI: address warnings from cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,10 @@ include = ["shapely", "shapely.*"]
 "shapely" = ["*.pxd"]
 
 [tool.cibuildwheel]
-skip = ["pp*", "*_i686", "*_ppc64le", "*_s390x"]
+skip = ["*_i686", "*_ppc64le", "*_s390x"]
 build-verbosity = 1
 test-requires = "pytest"
 test-command = "pytest --pyargs shapely.tests"
-enable = ["cpython-freethreading"]
 
 [tool.coverage.run]
 source = ["shapely"]


### PR DESCRIPTION
Small follow-up on https://github.com/shapely/shapely/pull/2431, addressing part of the warnings that can be seen at https://github.com/shapely/shapely/actions/runs/24053890587.  
There is another node warning coming from `ilammy/msvc-dev-cmd@v1` (but that first needs a new release in that action), and about the macosx deployment target (but cibuildwheel is bumping that correctly anyway, and to different values depending on the build)