### PR TITLE
Refactor shortest_line into the other YY_Y functions

### DIFF
--- a/shapely/tests/test_linear.py
+++ b/shapely/tests/test_linear.py
@@ -200,25 +200,34 @@ def _prepare_input(geometry, prepare):
 
 
 @pytest.mark.parametrize("prepare", [True, False])
-def test_shortest_line(prepare):
+@pytest.mark.parametrize(
+    "func", [shapely.shortest_line, shapely.lib.shortest_line_scalar]
+)
+def test_shortest_line(prepare, func):
     g1 = shapely.linestrings([(0, 0), (1, 0), (1, 1)])
     g2 = shapely.linestrings([(0, 3), (3, 0)])
-    actual = shapely.shortest_line(_prepare_input(g1, prepare), g2)
+    actual = func(_prepare_input(g1, prepare), g2)
     expected = shapely.linestrings([(1, 1), (1.5, 1.5)])
     assert shapely.equals(actual, expected)
 
 
 @pytest.mark.parametrize("prepare", [True, False])
-def test_shortest_line_none(prepare):
-    assert shapely.shortest_line(_prepare_input(line_string, prepare), None) is None
-    assert shapely.shortest_line(None, line_string) is None
-    assert shapely.shortest_line(None, None) is None
+@pytest.mark.parametrize(
+    "func", [shapely.shortest_line, shapely.lib.shortest_line_scalar]
+)
+def test_shortest_line_none(prepare, func):
+    assert func(_prepare_input(line_string, prepare), None) is None
+    assert func(None, line_string) is None
+    assert func(None, None) is None
 
 
 @pytest.mark.parametrize("prepare", [True, False])
-def test_shortest_line_empty(prepare):
+@pytest.mark.parametrize(
+    "func", [shapely.shortest_line, shapely.lib.shortest_line_scalar]
+)
+def test_shortest_line_empty(prepare, func):
     g1 = _prepare_input(line_string, prepare)
-    assert shapely.shortest_line(g1, empty_line_string) is None
+    assert func(g1, empty_line_string) is None
     g1_empty = _prepare_input(empty_line_string, prepare)
-    assert shapely.shortest_line(g1_empty, line_string) is None
-    assert shapely.shortest_line(g1_empty, empty_line_string) is None
+    assert func(g1_empty, line_string) is None
+    assert func(g1_empty, empty_line_string) is None

--- a/src/geos_funcs_YY_Y.c
+++ b/src/geos_funcs_YY_Y.c
@@ -34,6 +34,34 @@
  */
 typedef GEOSGeometry* FuncGEOS_YY_Y(GEOSContextHandle_t context, const GEOSGeometry* a, const GEOSGeometry* b);
 
+
+/* Wrapper functions to handle special cases */
+static GEOSGeometry* ShapelyShortestLine(GEOSContextHandle_t context, const GEOSGeometry* a, const GEOSPreparedGeometry* prep_a, const GEOSGeometry* b) {
+  GEOSCoordSequence* coord_seq = NULL;
+
+  if (GEOSisEmpty_r(context, a) || GEOSisEmpty_r(context, b)) {
+    // GEOS errors on empty geometries, while we want to return NULL / None
+    return NULL;
+  }
+
+  if (prep_a != NULL) {
+    coord_seq = GEOSPreparedNearestPoints_r(context, prep_a, b);
+  } else {
+    coord_seq = GEOSNearestPoints_r(context, a, b);
+  }
+  if (coord_seq == NULL) {
+    return NULL;
+  }
+  return GEOSGeom_createLineString_r(context, coord_seq);
+}
+
+static GEOSGeometry* ShapelyShortestLineDummy(GEOSContextHandle_t context, const GEOSGeometry* a, const GEOSGeometry* b) {
+  // This function should never be called; it is merely used as a value to FuncGEOS_YY_Y, to signal
+  // core_YY_Y_operation to actually call ShapelyShortestLine.
+  return NULL;
+}
+
+
 /* ========================================================================
  * CORE OPERATION LOGIC
  * ======================================================================== */
@@ -54,13 +82,14 @@ typedef GEOSGeometry* FuncGEOS_YY_Y(GEOSContextHandle_t context, const GEOSGeome
  *   Error state code (PGERR_SUCCESS, PGERR_NOT_A_GEOMETRY, etc.)
  */
 static char core_YY_Y_operation(GEOSContextHandle_t context, FuncGEOS_YY_Y* func,
-                                PyObject* geom_obj_a, PyObject* geom_obj_b,
+                                PyObject* geom_obj_a, PyObject* geom_obj_b, char* last_error,
                                 GEOSGeometry** result) {
   const GEOSGeometry* geom_a;
   const GEOSGeometry* geom_b;
+  const GEOSPreparedGeometry* prep_a = NULL;
 
   // Extract the underlying GEOS geometries from the Python geometry objects
-  if (!ShapelyGetGeometry(geom_obj_a, &geom_a)) {
+  if (!ShapelyGetGeometryWithPrepared(geom_obj_a, &geom_a, &prep_a)) {
     return PGERR_NOT_A_GEOMETRY;
   }
   if (geom_a == NULL) {
@@ -77,10 +106,18 @@ static char core_YY_Y_operation(GEOSContextHandle_t context, FuncGEOS_YY_Y* func
     return PGERR_SUCCESS;
   }
 
-  // Call the specific GEOS function (e.g., GEOSIntersection_r, GEOSUnion_r, etc.)
-  *result = func(context, geom_a, geom_b);
+  if (func == ShapelyShortestLineDummy) {
+    // Special case for nearest_point, which has an optimized version that uses prepared geometries
+    *result = ShapelyShortestLine(context, geom_a, prep_a, geom_b);
+  } else {
+    // Call the specific GEOS function (e.g., GEOSIntersection_r, GEOSUnion_r, etc.)
+    *result = func(context, geom_a, geom_b);
+  }
 
-  if (*result == NULL) {
+  // NULL can mean either error or a valid "missing value" for some functions
+  // (ShapelyShortestLine) so check the last_error before
+  // setting error state
+  if ((*result == NULL) && (last_error[0] != 0)) {
     return PGERR_GEOS_EXCEPTION;
   }
 
@@ -118,7 +155,7 @@ static PyObject* Py_YY_Y_Scalar(PyObject* self, PyObject* const* args, Py_ssize_
 
   GEOS_INIT;
 
-  errstate = core_YY_Y_operation(ctx, func, args[0], args[1], &ret_ptr);
+  errstate = core_YY_Y_operation(ctx, func, args[0], args[1], last_error, &ret_ptr);
 
   GEOS_FINISH;
 
@@ -170,7 +207,7 @@ static void YY_Y_func(char** args, const npy_intp* dimensions, const npy_intp* s
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
     }
-    errstate = core_YY_Y_operation(ctx, func, *(PyObject**)ip1, *(PyObject**)ip2, &geom_arr[i]);
+    errstate = core_YY_Y_operation(ctx, func, *(PyObject**)ip1, *(PyObject**)ip2, last_error, &geom_arr[i]);
     if (errstate != PGERR_SUCCESS) {
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
@@ -230,6 +267,7 @@ DEFINE_YY_Y(GEOSDifference_r);
 DEFINE_YY_Y(GEOSSymDifference_r);
 DEFINE_YY_Y(GEOSUnion_r);
 DEFINE_YY_Y(GEOSSharedPaths_r);
+DEFINE_YY_Y(ShapelyShortestLineDummy);
 
 
 /* ========================================================================
@@ -283,6 +321,7 @@ int init_geos_funcs_YY_Y(PyObject* m, PyObject* d) {
   INIT_YY_Y(GEOSSymDifference_r, symmetric_difference);
   INIT_YY_Y(GEOSUnion_r, union);
   INIT_YY_Y(GEOSSharedPaths_r, shared_paths);
+  INIT_YY_Y(ShapelyShortestLineDummy, shortest_line);
 
   return 0;
 }

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1426,79 +1426,6 @@ static PyUFuncGenericFunction coverage_simplify_funcs[1] = {&coverage_simplify_f
 
 #endif  // GEOS_SINCE_3_12_0
 
-static char shortest_line_dtypes[3] = {NPY_OBJECT, NPY_OBJECT, NPY_OBJECT};
-static void shortest_line_func(char** args, const npy_intp* dimensions, const npy_intp* steps,
-                               void* data) {
-  GEOSGeometry* in1 = NULL;
-  GEOSGeometry* in2 = NULL;
-  GEOSPreparedGeometry* in1_prepared = NULL;
-  GEOSGeometry** geom_arr;
-  GEOSCoordSequence* coord_seq = NULL;
-
-  CHECK_NO_INPLACE_OUTPUT(2);
-
-  // allocate a temporary array to store output GEOSGeometry objects
-  geom_arr = malloc(sizeof(void*) * dimensions[0]);
-  CHECK_ALLOC(geom_arr);
-
-  GEOS_INIT_THREADS;
-
-  BINARY_LOOP {
-    CHECK_SIGNALS_THREADS(i);
-    if (errstate == PGERR_PYSIGNAL) {
-      destroy_geom_arr(ctx, geom_arr, i - 1);
-      break;
-    }
-    /* get the geometries: return on error */
-    if (!get_geom_with_prepared(*(GeometryObject**)ip1, &in1, &in1_prepared)) {
-      errstate = PGERR_NOT_A_GEOMETRY;
-      destroy_geom_arr(ctx, geom_arr, i - 1);
-      break;
-    }
-    if (!get_geom(*(GeometryObject**)ip2, &in2)) {
-      errstate = PGERR_NOT_A_GEOMETRY;
-      destroy_geom_arr(ctx, geom_arr, i - 1);
-      break;
-    }
-
-    if ((in1 == NULL) || (in2 == NULL) || GEOSisEmpty_r(ctx, in1) ||
-        GEOSisEmpty_r(ctx, in2)) {
-      // in case of a missing value or empty geometry: return NULL (None)
-      // GEOSNearestPoints_r returns NULL for empty geometries
-      // but this is not distinguishable from an actual error, so we handle this ourselves
-      geom_arr[i] = NULL;
-      continue;
-    }
-    if (in1_prepared != NULL) {
-      coord_seq = GEOSPreparedNearestPoints_r(ctx, in1_prepared, in2);
-    } else {
-      coord_seq = GEOSNearestPoints_r(ctx, in1, in2);
-    }
-    if (coord_seq == NULL) {
-      errstate = PGERR_GEOS_EXCEPTION;
-      destroy_geom_arr(ctx, geom_arr, i - 1);
-      break;
-    }
-    geom_arr[i] = GEOSGeom_createLineString_r(ctx, coord_seq);
-    // Note: coordinate sequence is owned by linestring; if linestring fails to
-    // construct, it will automatically clean up the coordinate sequence
-    if (geom_arr[i] == NULL) {
-      errstate = PGERR_GEOS_EXCEPTION;
-      destroy_geom_arr(ctx, geom_arr, i - 1);
-      break;
-    }
-  }
-
-  GEOS_FINISH_THREADS;
-
-  // fill the numpy array with PyObjects while holding the GIL
-  if (errstate == PGERR_SUCCESS) {
-    geom_arr_to_npy(geom_arr, args[2], steps[2], dimensions[0]);
-  }
-  free(geom_arr);
-}
-static PyUFuncGenericFunction shortest_line_funcs[1] = {&shortest_line_func};
-
 static char set_precision_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_INT, NPY_OBJECT};
 static void set_precision_func(char** args, const npy_intp* dimensions, const npy_intp* steps,
                                void* data) {
@@ -2637,7 +2564,6 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_CUSTOM(relate_pattern, 3);
   DEFINE_GENERALIZED(polygonize, 1, "(d)->()");
   DEFINE_GENERALIZED_NOUT4(polygonize_full, 1, "(d)->(),(),(),()");
-  DEFINE_CUSTOM(shortest_line, 2);
 
   DEFINE_GENERALIZED(points, 2, "(d),()->()");
   DEFINE_GENERALIZED(linestrings, 2, "(i, d),()->()");


### PR DESCRIPTION
This merges the implementation of the "custom ufunc" `shortest_line` into the other ufuncs with the same call signature (YY->Y, for example `intersection`).

I added three extra conditionals in the main path of the other YY-Y function. Theoretically, these should be very fast (order nanoseconds), but I did benchmark the difference. I didn't measure anything larger than the benchmark noise. So I think we're good here.