### PR TITLE
perf: Improve performance of scalar Ydd->b functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,7 @@ else:
                 "src/geos_funcs_YYd_Y.c",
                 "src/geos_funcs_YYd_d.c",
                 "src/geos_funcs_O_b.c",
+                "src/geos_funcs_Ydd_b.c",
                 "src/vector.c",
             ],
             **ext_options,

--- a/shapely/tests/test_predicates.py
+++ b/shapely/tests/test_predicates.py
@@ -65,6 +65,11 @@ XY_PREDICATES = (
     (shapely.intersects_xy, shapely.intersects),
 )
 
+XY_PREDICATES_SCALAR = (
+    (shapely.lib.contains_xy_scalar, shapely.contains),
+    (shapely.lib.intersects_xy_scalar, shapely.intersects),
+)
+
 
 @pytest.mark.parametrize("geometry", all_types + all_types_z)
 @pytest.mark.parametrize("func", UNARY_PREDICATES)
@@ -181,6 +186,22 @@ def test_xy_missing(func):
         np.array([point.y, point.y, np.nan, point.y]),
     )
     np.testing.assert_allclose(actual, [True, False, False, False])
+
+
+@pytest.mark.parametrize("func, func_bin", XY_PREDICATES_SCALAR)
+@pytest.mark.parametrize("prepare", [False, True])
+def test_xy_scalar(func, func_bin, prepare):
+    x = _prepare_with_copy(polygon) if prepare else polygon
+    actual = func(x, 2, 3)
+    expected = func_bin(x, Point(2, 3))
+    assert actual == expected
+
+
+@pytest.mark.parametrize("func, func_bin", XY_PREDICATES_SCALAR)
+def test_xy_scalar_missing(func, func_bin):
+    assert func(None, 2, 3) is False
+    assert func(polygon, np.nan, 3) is False
+    assert func(polygon, 2, np.nan) is False
 
 
 def test_equals_exact_tolerance():

--- a/src/geos_funcs_Ydd_b.c
+++ b/src/geos_funcs_Ydd_b.c
@@ -1,0 +1,291 @@
+#define PY_SSIZE_T_CLEAN
+
+#include <Python.h>
+#include <math.h>
+
+#define NO_IMPORT_ARRAY
+#define NO_IMPORT_UFUNC
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL shapely_UFUNC_API
+#include <numpy/ndarraytypes.h>
+#include <numpy/npy_3kcompat.h>
+#include <numpy/ufuncobject.h>
+
+#include "fast_loop_macros.h"
+#include "geos.h"
+#include "pygeos.h"
+#include "pygeom.h"
+#include "signal_checks.h"
+
+/* ========================================================================
+ * GEOS WRAPPER FUNCTIONS
+ * ========================================================================
+ *
+ * Function signatures for GEOS operations that take a geometry and two doubles,
+ * and return a bool: Ydd->b.
+ *
+ * On GEOS >= 3.12, dedicated XY variants take a prepared geometry and (x, y).
+ * On older GEOS, we fall back to constructing a point and calling the regular
+ * prepared predicate.
+ *
+ * Parameters:
+ *   context: GEOS context handle for thread safety
+ *   pg:      Prepared geometry (first argument)
+ *   x, y:    Coordinate values
+ *
+ * Returns:
+ *   0 for false, 1 for true, 2 on error (following GEOS convention)
+ */
+#if GEOS_SINCE_3_12_0
+typedef char FuncGEOS_Ydd_b(GEOSContextHandle_t context, const GEOSPreparedGeometry* pg,
+                             double x, double y);
+#else
+typedef char FuncGEOS_Ydd_b(GEOSContextHandle_t context, const GEOSPreparedGeometry* pg,
+                             const GEOSGeometry* point);
+#endif
+
+/* ========================================================================
+ * CORE OPERATION LOGIC
+ * ======================================================================== */
+
+/*
+ * Core function that performs the actual GEOS operation on a geometry and an (x, y) point.
+ * This is shared between both ufunc and scalar implementations to avoid code duplication.
+ *
+ * The first input geometry is always prepared on-the-fly when it hasn't already been
+ * prepared by the user.
+ *
+ * Parameters:
+ *   context: GEOS context handle for thread-safe operations
+ *   func:    Function pointer to the specific GEOS prepared operation
+ *   geom_obj: Shapely geometry object (Python wrapper around GEOSGeometry)
+ *   x, y:    Coordinate values of the point to test against
+ *   result:  Pointer where the computed boolean result will be stored
+ *
+ * Returns:
+ *   Error state code (PGERR_SUCCESS, PGERR_NOT_A_GEOMETRY, etc.)
+ */
+static char core_Ydd_b_operation(GEOSContextHandle_t context, FuncGEOS_Ydd_b* func,
+                                  PyObject* geom_obj, double x, double y, char* result) {
+  const GEOSGeometry* geom;
+  const GEOSPreparedGeometry* geom_prepared;
+
+  if (!ShapelyGetGeometryWithPrepared(geom_obj, &geom, &geom_prepared)) {
+    return PGERR_NOT_A_GEOMETRY;
+  }
+
+  /* NULL geometry or NaN coordinate -> return False */
+  if ((geom == NULL) || npy_isnan(x) || npy_isnan(y)) {
+    *result = 0;
+    return PGERR_SUCCESS;
+  }
+
+  /* Prepare on-the-fly if the geometry was not already prepared */
+  char destroy_prepared = 0;
+  if (geom_prepared == NULL) {
+    geom_prepared = GEOSPrepare_r(context, geom);
+    if (geom_prepared == NULL) {
+      return PGERR_GEOS_EXCEPTION;
+    }
+    destroy_prepared = 1;
+  }
+
+#if GEOS_SINCE_3_12_0
+  *result = func(context, geom_prepared, x, y);
+#else
+  GEOSGeometry* point = NULL;
+  if (create_point(context, x, y, NULL, SHAPELY_HANDLE_NAN_ALLOW, &point) == PGERR_SUCCESS) {
+    *result = func(context, geom_prepared, point);
+    GEOSGeom_destroy_r(context, point);
+  } else {
+    *result = 2;  // GEOS convention for error
+  }
+#endif
+
+  if (destroy_prepared) {
+    GEOSPreparedGeom_destroy_r(context, geom_prepared);
+  }
+
+  if (*result == 2) {
+    return PGERR_GEOS_EXCEPTION;
+  }
+
+  return PGERR_SUCCESS;
+}
+
+/* ========================================================================
+ * SCALAR PYTHON FUNCTION
+ * ======================================================================== */
+
+/*
+ * Generic scalar Python function implementation for Ydd->b operations.
+ * This handles a single (geometry, x, y) call and returns a Python bool.
+ * It should be registered as a METH_FASTCALL method.
+ *
+ * Parameters:
+ *   self:  Module object (unused, required by Python C API)
+ *   args:  Array of arguments [geom, x, y]
+ *   nargs: Number of arguments (must be 3)
+ *   func:  Function pointer to the specific GEOS prepared operation
+ *
+ * Returns:
+ *   PyBool object containing the result, or NULL on error
+ */
+static PyObject* Py_Ydd_b_Scalar(PyObject* self, PyObject* const* args, Py_ssize_t nargs,
+                                   FuncGEOS_Ydd_b* func) {
+  if (nargs != 3) {
+    PyErr_Format(PyExc_TypeError, "Expected 3 arguments, got %zd", nargs);
+    return NULL;
+  }
+
+  double x = PyFloat_AsDouble(args[1]);
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+  double y = PyFloat_AsDouble(args[2]);
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+
+  char result = 0;
+
+  GEOS_INIT;
+
+  errstate = core_Ydd_b_operation(ctx, func, args[0], x, y, &result);
+
+  GEOS_FINISH;
+
+  if (errstate != PGERR_SUCCESS) {
+    return NULL;
+  }
+
+  return PyBool_FromLong(result);
+}
+
+/* ========================================================================
+ * NUMPY UFUNC
+ * ======================================================================== */
+
+/*
+ * NumPy universal function implementation for Ydd->b operations.
+ * This handles arrays of (geometry, double, double) efficiently by iterating
+ * through them, using the prepared geometry path for best performance.
+ *
+ * Parameters:
+ *   args, dimensions, steps: Standard ufunc loop parameters (see NumPy docs)
+ *   data: User data passed from ufunc creation (contains function pointer)
+ */
+static void Ydd_b_func(char** args, const npy_intp* dimensions, const npy_intp* steps,
+                        void* data) {
+  // Extract the specific GEOS function from the user data
+  FuncGEOS_Ydd_b* func = (FuncGEOS_Ydd_b*)data;
+
+  // Initialize GEOS context with thread support (releases Python GIL)
+  GEOS_INIT_THREADS;
+
+  // The TERNARY_LOOP macro unpacks args, dimensions, and steps and iterates through input/output arrays
+  // ip1 points to first input (geometry), ip2 points to second input (x coordinate),
+  // ip3 points to third input (y coordinate), op1 points to output (boolean)
+  TERNARY_LOOP {
+    CHECK_SIGNALS_THREADS(i);
+    if (errstate == PGERR_PYSIGNAL) {
+      goto finish;
+    }
+    errstate = core_Ydd_b_operation(ctx, func, *(PyObject**)ip1, *(double*)ip2, *(double*)ip3, (char*)op1);
+    if (errstate != PGERR_SUCCESS) {
+      goto finish;
+    }
+  }
+
+finish:
+  // Clean up GEOS context and handle any errors (reacquires Python GIL)
+  GEOS_FINISH_THREADS;
+}
+
+/*
+ * Function pointer array for NumPy ufunc creation.
+ * NumPy requires this format to register different implementations
+ * for different type combinations.
+ */
+static PyUFuncGenericFunction Ydd_b_funcs[1] = {&Ydd_b_func};
+
+/*
+ * Type signature for the ufunc: takes NPY_OBJECT (geometry), NPY_DOUBLE x 2, returns NPY_BOOL.
+ * This tells NumPy what input and output types this ufunc supports.
+ */
+static char Ydd_b_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_DOUBLE, NPY_BOOL};
+
+
+/* ========================================================================
+ * PYTHON FUNCTION DEFINITIONS
+ * ========================================================================
+ *
+ * We use a macro to define a scalar Python function for each Ydd->b GEOS operation.
+ *
+ * This creates a function that can be called from Python.
+ *
+ * Example: DEFINE_Ydd_b(GEOSPreparedContainsXY_r) creates:
+ *   static PyObject* PyGEOSPreparedContainsXY_r_Scalar(...)
+ *
+ * Parameters:
+ *   func: Name of the C functtion that performs the GEOS operation
+ */
+#define DEFINE_Ydd_b(func) \
+  static PyObject* Py##func##_Scalar(PyObject* self, PyObject* const* args, Py_ssize_t nargs) { \
+    return Py_Ydd_b_Scalar(self, args, nargs, (FuncGEOS_Ydd_b*)func); \
+  }
+
+#if GEOS_SINCE_3_12_0
+DEFINE_Ydd_b(GEOSPreparedContainsXY_r);
+DEFINE_Ydd_b(GEOSPreparedIntersectsXY_r);
+#else
+DEFINE_Ydd_b(GEOSPreparedContains_r);
+DEFINE_Ydd_b(GEOSPreparedIntersects_r);
+#endif
+
+
+/* ========================================================================
+ * MODULE INITIALIZATION
+ * ======================================================================== */
+
+/*
+ * Macro to register both the ufunc and the scalar Python function for a Ydd->b operation.
+ *
+ * This creates two Python-callable objects in the module dictionary:
+ *   1. A NumPy ufunc (e.g. "contains_xy") for array operations
+ *   2. A scalar function (e.g. "contains_xy_scalar") for single-element operations
+ *
+ * Parameters:
+ *   py_name:  Python name (e.g. contains_xy)
+ *   func:     GEOS function pointer (version-dependent)
+ */
+#define INIT_Ydd_b(py_name, func) do { \
+    static void* func##_FuncData[1] = {(void*)(FuncGEOS_Ydd_b*)func}; \
+    \
+    ufunc = PyUFunc_FromFuncAndData(Ydd_b_funcs, func##_FuncData, Ydd_b_dtypes, 1, 3, 1, \
+                                    PyUFunc_None, #py_name, "", 0); \
+    PyDict_SetItemString(d, #py_name, ufunc); \
+    \
+    static PyMethodDef Py##func##_Scalar_Def = { \
+        #py_name "_scalar",                   \
+        (PyCFunction)Py##func##_Scalar,       \
+        METH_FASTCALL,                        \
+        #py_name " scalar implementation"     \
+    }; \
+    PyObject* Py##func##_Scalar_Func = PyCFunction_NewEx(&Py##func##_Scalar_Def, NULL, NULL); \
+    PyDict_SetItemString(d, #py_name "_scalar", Py##func##_Scalar_Func); \
+} while(0)
+
+int init_geos_funcs_Ydd_b(PyObject* m, PyObject* d) {
+  PyObject* ufunc;
+
+#if GEOS_SINCE_3_12_0
+  INIT_Ydd_b(contains_xy, GEOSPreparedContainsXY_r);
+  INIT_Ydd_b(intersects_xy, GEOSPreparedIntersectsXY_r);
+#else
+  INIT_Ydd_b(contains_xy, GEOSPreparedContains_r);
+  INIT_Ydd_b(intersects_xy, GEOSPreparedIntersects_r);
+#endif
+
+  return 0;
+}

--- a/src/geos_funcs_Ydd_b.h
+++ b/src/geos_funcs_Ydd_b.h
@@ -1,0 +1,8 @@
+#ifndef _GEOS_FUNCS_YDD_B_H
+#define _GEOS_FUNCS_YDD_B_H
+
+#include <Python.h>
+
+extern int init_geos_funcs_Ydd_b(PyObject* m, PyObject* d);
+
+#endif

--- a/src/lib.c
+++ b/src/lib.c
@@ -28,6 +28,7 @@
 #include "geos_funcs_YY_d.h"
 #include "geos_funcs_YYd_Y.h"
 #include "geos_funcs_O_b.h"
+#include "geos_funcs_Ydd_b.h"
 
 /* This tells Python what methods this module has. */
 static PyMethodDef GeosModule[] = {
@@ -149,6 +150,10 @@ PyMODINIT_FUNC PyInit_lib(void) {
   };
 
   if (init_geos_funcs_O_b(m, d) < 0) {
+    return NULL;
+  };
+
+  if (init_geos_funcs_Ydd_b(m, d) < 0) {
     return NULL;
   };
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -59,92 +59,6 @@
     };                                              \
   }
 
-/* Define the geom, X, Y -> bool functions (Ydd_b) prepared */
-#if GEOS_SINCE_3_12_0
-static void* contains_xy_data[1] = {GEOSPreparedContainsXY_r};
-static void* intersects_xy_data[1] = {GEOSPreparedIntersectsXY_r};
-#else
-static void* contains_xy_data[1] = {GEOSPreparedContains_r};
-static void* intersects_xy_data[1] = {GEOSPreparedIntersects_r};
-#endif
-typedef char FuncGEOS_YY_b(void* context, void* a, void* b);
-typedef char FuncGEOS_Ydd_b(void* context, const void* pg, double x, double y);
-static char Ydd_b_p_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_DOUBLE, NPY_BOOL};
-static void Ydd_b_p_func(char** args, const npy_intp* dimensions, const npy_intp* steps, void* data) {
-#if GEOS_SINCE_3_12_0
-  FuncGEOS_Ydd_b* func = (FuncGEOS_Ydd_b*)data;
-#else
-  FuncGEOS_YY_b* func = (FuncGEOS_YY_b*)data;
-#endif
-  GEOSGeometry* in1 = NULL;
-  GEOSPreparedGeometry* in1_prepared = NULL;
-  const GEOSPreparedGeometry* prepared_geom_tmp = NULL;
-  char ret;
-
-  GEOS_INIT_THREADS;
-
-  TERNARY_LOOP {
-    CHECK_SIGNALS_THREADS(i);
-    if (errstate == PGERR_PYSIGNAL) {
-      goto finish;
-    }
-    /* get the geometries: return on error */
-    if (!get_geom_with_prepared(*(GeometryObject**)ip1, &in1, &in1_prepared)) {
-      errstate = PGERR_NOT_A_GEOMETRY;
-      goto finish;
-    }
-    double in2 = *(double*)ip2;
-    double in3 = *(double*)ip3;
-    if ((in1 == NULL) || npy_isnan(in2) || npy_isnan(in3)) {
-      /* in case of a missing value: return 0 (False) */
-      ret = 0;
-    } else {
-      /* if input geometry is not yet prepared, prepare (and destroy) on the fly*/
-      char destroy_prepared = 0;
-      if (in1_prepared == NULL) {
-        prepared_geom_tmp = GEOSPrepare_r(ctx, in1);
-        if (prepared_geom_tmp == NULL) {
-          errstate = PGERR_GEOS_EXCEPTION;
-          goto finish;
-        }
-        destroy_prepared = 1;
-      } else {
-        prepared_geom_tmp = in1_prepared;
-      }
-
-#if GEOS_SINCE_3_12_0
-      ret = func(ctx, prepared_geom_tmp, in2, in3);
-#else
-      GEOSGeometry *geom = NULL;
-      errstate = create_point(ctx, in2, in3, NULL, SHAPELY_HANDLE_NAN_ALLOW, &geom);
-      if (errstate != PGERR_SUCCESS) {
-        if (destroy_prepared) {
-          GEOSPreparedGeom_destroy_r(ctx, prepared_geom_tmp);
-        }
-        goto finish;
-      }
-      ret = func(ctx, prepared_geom_tmp, geom);
-      GEOSGeom_destroy_r(ctx, geom);
-#endif
-
-      if (destroy_prepared) {
-        GEOSPreparedGeom_destroy_r(ctx, prepared_geom_tmp);
-      }
-      /* return for illegal values */
-      if (ret == 2) {
-        errstate = PGERR_GEOS_EXCEPTION;
-        goto finish;
-      }
-    }
-    *(npy_bool*)op1 = ret;
-  }
-
-finish:
-
-  GEOS_FINISH_THREADS;
-}
-static PyUFuncGenericFunction Ydd_b_p_funcs[1] = {&Ydd_b_p_func};
-
 /* Define the reducing geoms -> geom functions (Y_Y_reduce) */
 static void* intersection_all_data[1] = {GEOSIntersection_r};
 static void* symmetric_difference_all_data[1] = {GEOSSymDifference_r};
@@ -2586,11 +2500,6 @@ finish:
 }
 static PyUFuncGenericFunction to_geojson_funcs[1] = {&to_geojson_func};
 
-#define DEFINE_Ydd_b_p(NAME)                                                           \
-  ufunc = PyUFunc_FromFuncAndData(Ydd_b_p_funcs, NAME##_data, Ydd_b_p_dtypes, 1, 3, 1, \
-                                  PyUFunc_None, #NAME, "", 0);                         \
-  PyDict_SetItemString(d, #NAME, ufunc)
-
 #define DEFINE_Y_Y_reduce(NAME)                                                         \
   ufunc = PyUFunc_FromFuncAndDataAndSignature(Y_Y_reduce_funcs, NAME##_data,            \
                                               Y_Y_reduce_dtypes, 1, 1, 1, PyUFunc_None, \
@@ -2616,9 +2525,6 @@ static PyUFuncGenericFunction to_geojson_funcs[1] = {&to_geojson_func};
 
 int init_ufuncs(PyObject* m, PyObject* d) {
   PyObject* ufunc;
-
-  DEFINE_Ydd_b_p(contains_xy);
-  DEFINE_Ydd_b_p(intersects_xy);
 
   DEFINE_Y_Y_reduce(intersection_all);
   DEFINE_Y_Y_reduce(symmetric_difference_all);


### PR DESCRIPTION
This extends the work started in https://github.com/shapely/shapely/pull/2339 for the (Y,d,d -> b) functions like `contains_xy`
Please check the PR description there for a description of what happened here.