### PR TITLE
Build Polygon.from_bounds ring counterclockwise to match box()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ calling `prepare` twice on a geometry will first return `True`, and then `False`
 Added `get_segments`, which returns individual linear features from all pairwise
 coordinates in each input LineString or LinearRing (#2306).
 
+`Polygon.from_bounds` now builds the ring in counterclockwise order, consistent
+with `shapely.box`, so the result satisfies the GeoJSON right-hand rule (#2396).
+
 
 2.1.2 (2025-09-24)
 ------------------

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -315,8 +315,12 @@ class Polygon(BaseGeometry):
 
     @classmethod
     def from_bounds(cls, xmin, ymin, xmax, ymax):
-        """Construct a `Polygon()` from spatial bounds."""
-        return cls([(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)])
+        """Construct a `Polygon()` from spatial bounds.
+
+        The ring is built in counterclockwise order, consistent with
+        ``shapely.box()``, so it satisfies the GeoJSON right-hand rule.
+        """
+        return cls([(xmax, ymin), (xmax, ymax), (xmin, ymax), (xmin, ymin)])
 
 
 shapely.lib.registry[3] = Polygon

--- a/shapely/tests/geometry/test_polygon.py
+++ b/shapely/tests/geometry/test_polygon.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+import shapely
 from shapely import LinearRing, LineString, Point, Polygon
 from shapely.coords import CoordinateSequence
 from shapely.errors import TopologicalError
@@ -398,8 +399,14 @@ class TestPolygon:
 
     def test_from_bounds(self):
         xmin, ymin, xmax, ymax = -180, -90, 180, 90
-        coords = [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)]
+        coords = [(xmax, ymin), (xmax, ymax), (xmin, ymax), (xmin, ymin)]
         assert Polygon(coords) == Polygon.from_bounds(xmin, ymin, xmax, ymax)
+
+    def test_from_bounds_orientation(self):
+        # from_bounds should match box() and be counterclockwise
+        poly = Polygon.from_bounds(1, 2, 3, 4)
+        assert poly.equals_exact(shapely.box(1, 2, 3, 4), tolerance=0)
+        assert poly.exterior.is_ccw
 
     def test_empty_polygon_exterior(self):
         p = Polygon()


### PR DESCRIPTION
`Polygon.from_bounds` produced a clockwise ring, so `mapping(Polygon.from_bounds(...))` yielded GeoJSON that violates the right-hand rule, unlike `shapely.box`. This builds the ring counterclockwise so the two constructors agree. Closes #2396