### PR TITLE
Fix ValueError in multithreading_enabled decorator when restoring writeable flags for array views and original arrays

### DIFF
--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -88,7 +88,10 @@ def multithreading_enabled(func):
             return func(*args, **kwargs)
         finally:
             for arr, old_flag in zip(array_args, old_flags, strict=False):
-                arr.flags.writeable = old_flag
+                try:
+                    arr.flags.writeable = old_flag
+                except ValueError:
+                    pass
 
     return wrapped
 


### PR DESCRIPTION
Fixes #2410.

Fix ValueError in multithreading_enabled decorator when restoring writeable flags for array views and original arrays. The multithreading_enabled decorator collects all object-dtype ndarray arguments, sets their writeable flag to False, calls the function, and then restores each flag. When a view and its original array are both passed, restoring the view's flag can raise ValueError because the original array's flag is still False at that point (it is restored later). The fix wraps the flag restoration in a try-except to ignore ValueError, which matches the suggestion in the issue and ensures the decorator does not crash in this case.

I checked that the changed Python files still parse correctly.