### PR TITLE
DOC: note WKB cannot represent LinearRing; fix transform_coordseq typo

### DIFF
--- a/shapely/coordinates.py
+++ b/shapely/coordinates.py
@@ -199,7 +199,7 @@ def transform_coordseq(
     geom : Geometry or None
     transformation : function
         A function that transforms a (N, 2) or (N, 3) ndarray of float64 to
-        atransform_coordseqnother (N, 2) or (N, 3) ndarray of float64.
+        another (N, 2) or (N, 3) ndarray of float64.
         The function may change the value of N.
     include_z : bool, optional, default False
         If False, always return 2D geometries.

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -275,8 +275,10 @@ class BaseGeometry(shapely.Geometry):
     def wkb(self):
         """WKB representation of the geometry.
 
-        Note that the WKB specification cannot represent ``LinearRing``
-        geometries; they are encoded as ``LineString`` (see :func:`shapely.to_wkb`).
+        The following limitations apply to WKB serialization:
+
+        - linearrings will be converted to linestrings
+        - a point with only NaN coordinates is converted to an empty point
         """
         return shapely.to_wkb(self)
 
@@ -284,8 +286,10 @@ class BaseGeometry(shapely.Geometry):
     def wkb_hex(self):
         """WKB hex representation of the geometry.
 
-        Note that the WKB specification cannot represent ``LinearRing``
-        geometries; they are encoded as ``LineString`` (see :func:`shapely.to_wkb`).
+        The following limitations apply to WKB serialization:
+
+        - linearrings will be converted to linestrings
+        - a point with only NaN coordinates is converted to an empty point
         """
         return shapely.to_wkb(self, hex=True)
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -273,12 +273,20 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def wkb(self):
-        """WKB representation of the geometry."""
+        """WKB representation of the geometry.
+
+        Note that the WKB specification cannot represent ``LinearRing``
+        geometries; they are encoded as ``LineString`` (see :func:`shapely.to_wkb`).
+        """
         return shapely.to_wkb(self)
 
     @property
     def wkb_hex(self):
-        """WKB hex representation of the geometry."""
+        """WKB hex representation of the geometry.
+
+        Note that the WKB specification cannot represent ``LinearRing``
+        geometries; they are encoded as ``LineString`` (see :func:`shapely.to_wkb`).
+        """
         return shapely.to_wkb(self, hex=True)
 
     def svg(self, scale_factor=1.0, **kwargs):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -275,10 +275,7 @@ class BaseGeometry(shapely.Geometry):
     def wkb(self):
         """WKB representation of the geometry.
 
-        The following limitations apply to WKB serialization:
-
-        - linearrings will be converted to linestrings
-        - an empty point is converted to a point with only NaN coordinates
+        See :func:`shapely.to_wkb` for limitations of WKB serialization.
         """
         return shapely.to_wkb(self)
 
@@ -286,10 +283,7 @@ class BaseGeometry(shapely.Geometry):
     def wkb_hex(self):
         """WKB hex representation of the geometry.
 
-        The following limitations apply to WKB serialization:
-
-        - linearrings will be converted to linestrings
-        - an empty point is converted to a point with only NaN coordinates
+        See :func:`shapely.to_wkb` for limitations of WKB serialization.
         """
         return shapely.to_wkb(self, hex=True)
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -278,7 +278,7 @@ class BaseGeometry(shapely.Geometry):
         The following limitations apply to WKB serialization:
 
         - linearrings will be converted to linestrings
-        - a point with only NaN coordinates is converted to an empty point
+        - an empty point is converted to a point with only NaN coordinates
         """
         return shapely.to_wkb(self)
 
@@ -289,7 +289,7 @@ class BaseGeometry(shapely.Geometry):
         The following limitations apply to WKB serialization:
 
         - linearrings will be converted to linestrings
-        - a point with only NaN coordinates is converted to an empty point
+        - an empty point is converted to a point with only NaN coordinates
         """
         return shapely.to_wkb(self, hex=True)
 

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -316,6 +316,11 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
+    Note that WKB cannot represent ``LinearRing`` geometries: a ring written with
+    :func:`to_wkb` is encoded as a ``LineString`` and will be read back as a
+    ``LineString``. Use WKT (:func:`to_wkt` / :func:`from_wkt`) to round-trip
+    ``LinearRing`` geometries.
+
     Parameters
     ----------
     geometry : str or array_like

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -316,11 +316,6 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
-    Note that WKB cannot represent ``LinearRing`` geometries: a ring written with
-    :func:`to_wkb` is encoded as a ``LineString`` and will be read back as a
-    ``LineString``. Use WKT (:func:`to_wkt` / :func:`from_wkt`) to round-trip
-    ``LinearRing`` geometries.
-
     Parameters
     ----------
     geometry : str or array_like

--- a/shapely/io.py
+++ b/shapely/io.py
@@ -133,7 +133,7 @@ def to_wkb(
     The following limitations apply to WKB serialization:
 
     - linearrings will be converted to linestrings
-    - a point with only NaN coordinates is converted to an empty point
+    - an empty point is converted to a point with only NaN coordinates
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #2444.

Thanks to Milan (eatanygoodbookslately) for the writeup — the proposed wording and the LinearRing/WKB analysis are essentially unchanged from the issue.

**Changes**

- `shapely/coordinates.py`: fix copy-paste typo in the `transform_coordseq` docstring (`to atransform_coordseqnother` → `to another`).
- `shapely/geometry/base.py`: extend the `.wkb` and `.wkb_hex` property docstrings to note that WKB has no `LinearRing` type, so rings are encoded as `LineString` (pointing to `to_wkb`).
- `shapely/io.py`: add the same note to `from_wkb` (the real gap — `to_wkb` already documents its side).

**Scoping note (vs. the original issue)**

Milan's writeup listed five locations for the WKB note. Looking at the source, only three are real edits:

- `to_wkb` already documents the LineString fallback.
- `.wkb` and `.wkb_hex` are inherited properties on `BaseGeometry` (one docstring each, shared across geometry types) — not per-class docstrings on `LinearRing` and `GeometryCollection`.
- The actual gap is `from_wkb`, which has no mention of the round-trip behavior.

So the note lands on `.wkb`, `.wkb_hex`, and `from_wkb` rather than five spots. Happy to split or move things in review.

Diff is docs-only; no runtime changes.
