### PR TITLE
TST: update test parametrization for non-collection iterables (pytest 9.1 compat)

### DIFF
--- a/shapely/tests/legacy/test_pickle.py
+++ b/shapely/tests/legacy/test_pickle.py
@@ -53,7 +53,7 @@ def test_pickle_round_trip(geom1):
 
 
 @pytest.mark.parametrize(
-    "fname", (HERE / "data").glob("*.pickle"), ids=lambda fname: fname.name
+    "fname", list((HERE / "data").glob("*.pickle")), ids=lambda fname: fname.name
 )
 def test_unpickle_pre_20(fname):
     from shapely.testing import assert_geometries_equal


### PR DESCRIPTION
See https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize