### PR TITLE
Fix writeable flag restore for array views

### DIFF
--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -87,8 +87,21 @@ def multithreading_enabled(func):
                 arr.flags.writeable = False
             return func(*args, **kwargs)
         finally:
-            for arr, old_flag in zip(array_args, old_flags, strict=False):
-                arr.flags.writeable = old_flag
+            pending = list(zip(array_args, old_flags, strict=False))
+            while pending:
+                remaining = []
+                last_error = None
+                for arr, old_flag in pending:
+                    try:
+                        arr.flags.writeable = old_flag
+                    except ValueError as err:
+                        if not old_flag:
+                            raise
+                        remaining.append((arr, old_flag))
+                        last_error = err
+                if len(remaining) == len(pending):
+                    raise last_error
+                pending = remaining
 
     return wrapped
 

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -171,6 +171,23 @@ def test_multithreading_enabled_preserves_flag():
     assert not arr.flags.writeable
 
 
+@pytest.mark.parametrize("view_first", [False, True])
+def test_multithreading_enabled_preserves_view_and_base_flags(view_first):
+    arr = np.array([shapely.Point(0, 0)], dtype=object)
+    view = arr.view()
+
+    args = (view, arr) if view_first else (arr, view)
+
+    @multithreading_enabled
+    def pass_through(*args):
+        return None
+
+    pass_through(*args)
+
+    assert arr.flags.writeable
+    assert view.flags.writeable
+
+
 @pytest.mark.parametrize(
     "args,kwargs",
     [


### PR DESCRIPTION
## Summary
- Retry restoring object-array writeable flags when NumPy rejects making a view writeable before its base array is restored.
- Add regression coverage for passing a base array and a view to a `multithreading_enabled` function in either order.

Fixes #2410

## Tests
- `.venv/bin/python -m pytest shapely/tests/test_misc.py -q`
- `.venv/bin/python -m pytest shapely/tests/test_misc.py::test_multithreading_enabled_preserves_view_and_base_flags -q`
- Manual reproduction script for `shapely.equals(arr.view(), arr)`
- `uvx ruff check shapely/decorators.py shapely/tests/test_misc.py`
- `git diff --check`
