### PR TITLE
Use PEP-735 for dependency groups

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,7 +80,7 @@ installing Shapely with pip from PyPI, you clone the package from Github::
 
 Install it in development mode using ``pip``::
 
-    $ pip install -e .[test]
+    $ pip install -e . --group dev
 
 For development, use of a virtual environment is strongly recommended. For
 example using ``venv``:
@@ -89,7 +89,7 @@ example using ``venv``:
 
     $ python3 -m venv .
     $ source bin/activate
-    (env) $ pip install -e .[test]
+    (env) $ pip install -e . --group dev
 
 Or using ``conda``:
 
@@ -104,7 +104,7 @@ Testing Shapely
 
 Shapely can be tested using ``pytest``::
 
-    $ pip install pytest  # or shapely[test]
+    $ pip install pytest  # or shapely --group dev
     $ pytest --pyargs shapely.tests
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ dependencies = [
     "numpy>=1.23",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+dev = [
+    "pre-commit",
+    {include-group = "test"},
+]
 test = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This implements [PEP 735](https://peps.python.org/pep-0735/) to use dependency groups for "test" and "docs", as well as a new "dev" group, which includes "test" and "pre-commit".