### PR TITLE
docs(geometry): document .xy limitation on non-single-sequence geometries

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2785,6 +2785,15 @@ Python arrays of `x` and `y` values via the ``xy`` attribute.
   >>> LineString([(0, 0), (1, 1)]).xy
   (array('d', [0.0, 1.0]), array('d', [0.0, 1.0]))
 
+The ``xy`` attribute is only available on these single coordinate sequence
+types. Other geometries, such as `Polygon` and the multi-part geometries
+(`MultiPoint`, `MultiLineString`, `MultiPolygon`, `GeometryCollection`), do not
+have a single sequence of coordinates, so accessing ``xy`` on them raises
+``NotImplementedError``. For those, use the ``xy`` attribute of a polygon's
+rings (``polygon.exterior.xy`` or ``polygon.interiors[i].xy``), iterate over
+the ``geoms`` of a multi-part geometry, or use :func:`shapely.get_coordinates`
+to obtain the coordinates of any geometry as a single array.
+
 Python Geo Interface
 --------------------
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -223,7 +223,27 @@ class BaseGeometry(shapely.Geometry):
 
     @property
     def xy(self):
-        """Separate arrays of X and Y coordinate values."""
+        """Separate arrays of X and Y coordinate values.
+
+        This property is only available on geometries that are backed by a
+        single coordinate sequence: :class:`~shapely.Point`,
+        :class:`~shapely.LineString` and :class:`~shapely.LinearRing`.
+
+        It is not implemented on :class:`~shapely.Polygon` or on the
+        multi-part geometries (:class:`~shapely.MultiPoint`,
+        :class:`~shapely.MultiLineString`, :class:`~shapely.MultiPolygon`,
+        :class:`~shapely.GeometryCollection`). A polygon consists of an
+        exterior ring and any number of interior rings (holes), and a
+        multi-part geometry consists of several geometries, so there is no
+        single sequence of (x, y) values to return. Accessing this property
+        on those types raises ``NotImplementedError``.
+
+        For a polygon, use the ``xy`` property of its rings, for example
+        ``polygon.exterior.xy`` or ``polygon.interiors[i].xy``. For a
+        multi-part geometry, iterate over ``geom.geoms`` and access ``xy`` on
+        each part. To get the coordinates of any geometry as a single array,
+        use :func:`shapely.get_coordinates`.
+        """
         raise NotImplementedError
 
     # Python feature protocol


### PR DESCRIPTION
## Intent

Document that Shapely's base Geometry.xy property is only implemented on single-coordinate-sequence geometries (Point, LineString, LinearRing) and raises NotImplementedError on Polygon and multi-part geometries, pointing users to the alternatives (exterior.xy, iterating geoms, shapely.get_coordinates), as the maintainer requested in issue #2411.

## What Changed

- Expanded the `BaseGeometry.xy` docstring in `shapely/geometry/base.py` to explain that the property is only backed by a single coordinate sequence (`Point`, `LineString`, `LinearRing`) and raises `NotImplementedError` on `Polygon` and the multi-part geometries, with explicit alternatives (`polygon.exterior.xy`, `polygon.interiors[i].xy`, iterating `geom.geoms`, or `shapely.get_coordinates`).
- Added a matching paragraph to the "Numpy and Python Arrays" section of `docs/manual.rst` describing the same `xy` limitation and alternatives for users reading the manual.
- Documentation-only: the `raise NotImplementedError` behavior was already present and is unchanged; verification confirmed the rendered docstring resolves all referenced APIs and that `.xy` raises on Polygon/multi-part geometries as now documented.

## Risk Assessment

✅ Low: The change is a documentation-only docstring addition whose every factual claim (which geometries implement xy vs. raise NotImplementedError, and the suggested alternatives) was verified accurate against the codebase, with no behavioral or runnable-doctest impact.

## Testing

Baseline showed the worktree's compiled extension wasn't built (no shapely.lib), so I overlaid the installed 2.1.2 wheel's GEOS .pyd/.dll to load the worktree's pure-Python source and rendered the actual help(shapely.Polygon.xy) output — the new expanded docstring appears exactly as written, which is the real end-user surface for this docs change. Because the worktree's dev C-extension references a function absent from the 2.1.2 lib (ABI mismatch, not a product issue), I verified the docstring's behavioral claims against the fully-built installed shapely (valid since the change is documentation-only and behaviour is unchanged): .xy works on Point/LineString/LinearRing, raises NotImplementedError on Polygon and all multi-part geometries, and every suggested alternative (exterior.xy, interiors[i].xy, iterating .geoms, get_coordinates) works. The captured docstring render is the reviewer-visible artifact (no graphical UI exists for a docstring). Transient .pyd files copied into the worktree were removed; git status is clean. All checks pass.

<details>
<summary>Evidence: Rendered new docstring via help(shapely.Polygon.xy) from worktree source</summary>

Source: Rendered new docstring via help(shapely.Polygon.xy) from worktree source (local file: <code>C:\Users\madha\AppData\Local\Temp\no-mistakes-evidence\01KW8W4AHMT5QQHEKB7JWP5FRM\render_new_docstring_output.txt</code>)

```text
help(shapely.Polygon.xy) prints the full expanded docstring:
'Separate arrays of X and Y coordinate values. This property is only available on geometries backed by a single coordinate sequence: Point, LineString and LinearRing. It is not implemented on Polygon or the multi-part geometries (... raises NotImplementedError). For a polygon, use polygon.exterior.xy / polygon.interiors[i].xy; for a multi-part geometry, iterate geom.geoms; or use shapely.get_coordinates.'
Sanity check: shapely.get_coordinates callable = True; all 8 referenced geometry classes present = True
```
</details>
<details>
<summary>Evidence: Behavioral verification of every documented claim</summary>

<code>Point/LineString/LinearRing .xy -&gt; X/Y arrays returned.&#10;Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection .xy -&gt; raised NotImplementedError (as documented).&#10;Alternatives: polygon.exterior.xy and polygon.interiors[0].xy return arrays; iterating multilinestring.geoms yields per-part .xy; shapely.get_coordinates(polygon) -&gt; (10,2) array. ALL CLAIMS HOLD.</code>

```text
Behavior verified against installed shapely 2.1.2 | GEOS (3, 13, 1)
==============================================================================

### Claim A: .xy WORKS on single-coordinate-sequence geometries

  Point      .xy -> x=[1.0]  y=[2.0]
  LineString .xy -> x=[0.0, 1.0, 2.0]  y=[0.0, 1.0, 0.0]
  LinearRing .xy -> x=[0.0, 1.0, 1.0, 0.0]  y=[0.0, 0.0, 1.0, 0.0]

### Claim B: .xy RAISES NotImplementedError on Polygon + multi-part

  Polygon           .xy -> raised NotImplementedError  (as documented)
  MultiPoint        .xy -> raised NotImplementedError  (as documented)
  MultiLineString   .xy -> raised NotImplementedError  (as documented)
  MultiPolygon      .xy -> raised NotImplementedError  (as documented)
  GeometryCollection.xy -> raised NotImplementedError  (as documented)

### Claim C: every documented alternative works

  polygon.exterior.xy     -> x=[0.0, 4.0, 4.0, 0.0, 0.0]  y=[0.0, 0.0, 4.0, 4.0, 0.0]
  polygon.interiors[0].xy -> x=[1.0, 2.0, 2.0, 1.0, 1.0]  y=[1.0, 1.0, 2.0, 2.0, 1.0]
  iterate multilinestring.geoms and read .xy on each part ->
      geoms[0].xy -> x=[0.0, 1.0]  y=[0.0, 1.0]
      geoms[1].xy -> x=[2.0, 3.0]  y=[2.0, 3.0]
  shapely.get_coordinates(polygon) -> array shape (10, 2):
      [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0], [1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0], [1.0, 1.0]]

==============================================================================
ALL DOCUMENTED BEHAVIORAL CLAIMS HOLD AGAINST RUNNING CODE.
==============================================================================
```
</details>
<details>
<summary>Evidence: Before/after docstring contrast (base e10c6da vs target 4eef1c7)</summary>

```text
=== BEFORE (base commit e10c6da) — Geometry.xy docstring ===
    def xy(self):
        """Separate arrays of X and Y coordinate values."""
        raise NotImplementedError

=== AFTER (target commit 4eef1c7) — Geometry.xy docstring ===
    def xy(self):
        """Separate arrays of X and Y coordinate values.

        This property is only available on geometries that are backed by a
        single coordinate sequence: :class:`~shapely.Point`,
        :class:`~shapely.LineString` and :class:`~shapely.LinearRing`.

        It is not implemented on :class:`~shapely.Polygon` or on the
        multi-part geometries (:class:`~shapely.MultiPoint`,
        :class:`~shapely.MultiLineString`, :class:`~shapely.MultiPolygon`,
        :class:`~shapely.GeometryCollection`). A polygon consists of an
        exterior ring and any number of interior rings (holes), and a
        multi-part geometry consists of several geometries, so there is no
        single sequence of (x, y) values to return. Accessing this property
        on those types raises ``NotImplementedError``.

        For a polygon, use the ``xy`` property of its rings, for example
        ``polygon.exterior.xy`` or ``polygon.interiors[i].xy``. For a
        multi-part geometry, iterate over ``geom.geoms`` and access ``xy`` on
        each part. To get the coordinates of any geometry as a single array,
        use :func:`shapely.get_coordinates`.
        """
        raise NotImplementedError
```
</details>
<details>
<summary>Evidence: Verification scripts (docstring render + behavior)</summary>

```text
"""Verify every behavioral claim the new Geometry.xy docstring makes.

Run against the fully-built installed shapely (a complete GEOS-backed build).
The change is documentation-only -- behaviour is unchanged from this build to
the branch -- so confirming behaviour here proves the new docstring is accurate.
"""

import shapely
from shapely import (
    Point,
    LineString,
    LinearRing,
    Polygon,
    MultiPoint,
    MultiLineString,
    MultiPolygon,
    GeometryCollection,
)

print("Behavior verified against installed shapely", shapely.__version__,
      "| GEOS", shapely.geos_version)
print("=" * 78)

print("\n### Claim A: .xy WORKS on single-coordinate-sequence geometries\n")
pt = Point(1, 2)
ls = LineString([(0, 0), (1, 1), (2, 0)])
lr = LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)])
for name, g in [("Point", pt), ("LineString", ls), ("LinearRing", lr)]:
    x, y = g.xy
    print(f"  {name:11s}.xy -> x={list(x)}  y={list(y)}")

print("\n### Claim B: .xy RAISES NotImplementedError on Polygon + multi-part\n")
poly = Polygon(
    [(0, 0), (4, 0), (4, 4), (0, 4)],
    holes=[[(1, 1), (2, 1), (2, 2), (1, 2)]],
)
unsupported = [
    ("Polygon", poly),
    ("MultiPoint", MultiPoint([(0, 0), (1, 1)])),
    ("MultiLineString", MultiLineString([[(0, 0), (1, 1)], [(2, 2), (3, 3)]])),
    ("MultiPolygon", MultiPolygon([poly, Polygon([(5, 5), (6, 5), (6, 6)])])),
    ("GeometryCollection", GeometryCollection([pt, ls])),
]
all_raised = True
for name, g in unsupported:
    try:
        g.xy
        all_raised = False
        print(f"  {name:18s}.xy -> NO ERROR  <-- UNEXPECTED!")
    except NotImplementedError:
        print(f"  {name:18s}.xy -> raised NotImplementedError  (as documented)")
assert all_raised, "Some unsupported type did not raise NotImplementedError"

print("\n### Claim C: every documented alternative works\n")
ex_x, ex_y = poly.exterior.xy
print(f"  polygon.exterior.xy     -> x={list(ex_x)}  y={list(ex_y)}")
in_x, in_y = poly.interiors[0].xy
print(f"  polygon.interiors[0].xy -> x={list(in_x)}  y={list(in_y)}")

mls = MultiLineString([[(0, 0), (1, 1)], [(2, 2), (3, 3)]])
print("  iterate multilinestring.geoms and read .xy on each part ->")
for i, part in enumerate(mls.geoms):
    px, py = part.xy
    print(f"      geoms[{i}].xy -> x={list(px)}  y={list(py)}")

coords = shapely.get_coordinates(poly)
print(f"  shapely.get_coordinates(polygon) -> array shape {coords.shape}:")
print("     ", coords.tolist())

print("\n" + "=" * 78)
print("ALL DOCUMENTED BEHAVIORAL CLAIMS HOLD AGAINST RUNNING CODE.")
print("=" * 78)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python render_new_docstring.py` — loaded the worktree shapely source (against the wheel&#39;s bundled GEOS DLLs via os.add_dll_directory) and ran `help(shapely.Polygon.xy)`; confirmed the full expanded docstring renders and all referenced APIs (8 geometry classes + shapely.get_coordinates) exist</code>
- <code>`python verify_xy_behavior.py` — against installed shapely 2.1.2/GEOS 3.13.1: confirmed `.xy` returns X/Y arrays on Point, LineString, LinearRing</code>
- <code>verify_xy_behavior.py — confirmed `.xy` raises NotImplementedError on Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection (as newly documented)</code>
- `verify_xy_behavior.py — confirmed the documented alternatives all work: polygon.exterior.xy, polygon.interiors[0].xy, iterating multilinestring.geoms with per-part .xy, and shapely.get_coordinates(polygon)`
- <code>`git show e10c6da/4eef1c7:shapely/geometry/base.py` — captured before/after docstring contrast (one-liner -&gt; expanded)</code>
- <code>Cross-checked existing coverage: `shapely/tests/geometry/test_polygon.py:297` asserts polygon.coords raises NotImplementedError (parallel to the documented .xy behavior); `shapely/tests/geometry/test_coords.py:92` exercises LineString().xy</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
