### PR TITLE
BUG: raise clear ValueError for non-Polygon geometries in MultiPolygon

### DIFF
--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -2,7 +2,7 @@
 
 import shapely
 from shapely.geometry import polygon
-from shapely.geometry.base import BaseMultipartGeometry
+from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
 
 __all__ = ["MultiPolygon"]
 
@@ -73,6 +73,11 @@ class MultiPolygon(BaseMultipartGeometry):
         for i in range(L):
             ob = polygons[i]
             if not isinstance(ob, polygon.Polygon):
+                if isinstance(ob, BaseGeometry):
+                    raise ValueError(
+                        "Input must be valid Polygon objects or sequences of "
+                        f"(shell, holes) tuples, got a {ob.geom_type}"
+                    )
                 shell = ob[0]
                 if len(ob) > 1:
                     holes = ob[1]

--- a/shapely/tests/geometry/test_multipolygon.py
+++ b/shapely/tests/geometry/test_multipolygon.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pytest
 
-from shapely import MultiPolygon, Polygon
+from shapely import (
+    GeometryCollection,
+    LinearRing,
+    LineString,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
 from shapely.geometry.base import dump_coords
 from shapely.tests.geometry.test_multi import MultiGeometryTestCase
 
@@ -140,6 +147,32 @@ def test_fail_list_of_multipolygons():
 
     with pytest.raises(ValueError):
         MultiPolygon([poly, multi])
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        GeometryCollection([Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])]),
+        Point(0, 0),
+        LineString([(0, 0), (1, 1)]),
+        LinearRing([(0, 0), (1, 1), (1, 0)]),
+    ],
+    ids=["GeometryCollection", "Point", "LineString", "LinearRing"],
+)
+def test_fail_list_with_non_polygon_geometry(geom):
+    """A non-Polygon geometry in the list raises a clear ValueError.
+
+    Previously a non-Polygon geometry fell through to ``shell = ob[0]`` and
+    raised a cryptic ``TypeError: ... object is not subscriptable``. It is now
+    rejected with a ValueError naming the offending type, regardless of its
+    position in the list (#2178).
+    """
+    poly = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+
+    # As the only element, before a valid Polygon, and after a valid Polygon.
+    for inputs in ([geom], [geom, poly], [poly, geom]):
+        with pytest.raises(ValueError, match=geom.geom_type):
+            MultiPolygon(inputs)
 
 
 def test_numpy_object_array():


### PR DESCRIPTION
BUG: raise clear ValueError for non-Polygon geometries in MultiPolygon

## What

`MultiPolygon.__new__` only type-checked the first element of its input
list. A non-Polygon `BaseGeometry` (for example a `GeometryCollection` or
`Point`) appearing after the first element fell through to the
`(shell, holes)` unpacking path and hit `shell = ob[0]`, raising a
cryptic error:

```python
import shapely
poly = shapely.box(0, 0, 1, 1)
shapely.MultiPolygon([poly, shapely.GeometryCollection([poly])])
# TypeError: 'GeometryCollection' object is not subscriptable
```

This change detects `BaseGeometry` instances that are not `Polygon`s in
the construction loop and raises a `ValueError` naming the offending
geometry type instead:

```python
ValueError: Input must be valid Polygon objects or sequences of
(shell, holes) tuples, got a GeometryCollection
```

## Why

The previous behaviour surfaced an implementation detail (`__getitem__`)
rather than the actual problem (an invalid member type). The new check
mirrors the existing member-type guard that already rejects
`MultiPolygon` inputs, keeping the constructor's error reporting
consistent.

Valid inputs are unaffected: plain `Polygon` objects, `(shell, holes)`
sequence/tuple inputs, and construction from an existing `MultiPolygon`
all continue to work. `MultiPolygon` members are still caught earlier by
the existing dedicated check.

## Tests

Added `test_fail_list_with_non_polygon_geometry` (mirroring
`test_fail_list_of_multipolygons`), parametrized over `GeometryCollection`,
`Point`, `LineString`, and `LinearRing`. Each type is checked in three
positions: as the only element, before a valid `Polygon`, and after a valid
`Polygon`. Every case asserts a `ValueError` naming the offending type.
Verified the new cases fail on the unpatched source (the original
`TypeError`) and pass with the fix. The full `shapely/tests/geometry` suite
passes.

Closes #2178
