### PR TITLE
TST: use Python 3.14t for free-threaded tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             numpy: 2.3.5
           # free threaded Python (no numpy version to indicate installing nightly cython and numpy)
           - os: ubuntu-22.04  # keep distinct from ubuntu-latest
-            python: "3.13t"
+            python: "3.14t"
             geos: 3.13.1  # keep distinct from pypy geos version
           # apple x86_64 (Intel)
           - os: macos-15-intel

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,9 @@ coverage.xml
 # Pipenv
 .venv
 Pipfile
-Pipfile.lock
+
+# lock files (e.g., uv, pixi, Pipfile)
+*.lock
 
 # Documentation
 docs/_build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pre-commit",
-    {include-group = "test"},
+    {include-group = "tests"},
 ]
-test = [
+tests = [
     "pytest",
     "pytest-cov",
     "scipy-doctest",


### PR DESCRIPTION
This changes testing free-threaded Python from 3.13t (which was [regarded as experimental](https://cibuildwheel.pypa.io/en/stable/changelog/#v400)) to 3.14t. This fixes an issue where the latest numpy does not have the experimental 3.13t wheels anymore; cibuildwheel v4.0 builds cp314t onwards.

Two other minor changes are put here for convenience (of not creating more PRs):

- Ignore `*.lock` files, e.g., uv, pixi, Pipfile
- Rename dependency group "test" to "tests", to align with the "tests" directory name (in "shapely")