### PR TITLE
Fix multithreading flag restoration for array views

### DIFF
--- a/shapely/decorators.py
+++ b/shapely/decorators.py
@@ -12,6 +12,15 @@ from shapely import lib
 from shapely.errors import UnsupportedGEOSVersionError
 
 
+def _array_view_depth(arr: np.ndarray) -> int:
+    depth = 0
+    base = arr.base
+    while isinstance(base, np.ndarray):
+        depth += 1
+        base = base.base
+    return depth
+
+
 class requires_geos:
     """Decorator to require a minimum GEOS version."""
 
@@ -87,7 +96,11 @@ def multithreading_enabled(func):
                 arr.flags.writeable = False
             return func(*args, **kwargs)
         finally:
-            for arr, old_flag in zip(array_args, old_flags, strict=False):
+            restore_order = sorted(
+                zip(array_args, old_flags, strict=False),
+                key=lambda item: (item[1], _array_view_depth(item[0])),
+            )
+            for arr, old_flag in restore_order:
                 arr.flags.writeable = old_flag
 
     return wrapped

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -171,6 +171,17 @@ def test_multithreading_enabled_preserves_flag():
     assert not arr.flags.writeable
 
 
+def test_multithreading_enabled_restores_view_before_base():
+    arr = np.array([shapely.Point(1, 1)], dtype=object)
+    view = arr.view()
+
+    result = shapely.equals(view, arr)
+
+    assert result.tolist() == [True]
+    assert view.flags.writeable
+    assert arr.flags.writeable
+
+
 @pytest.mark.parametrize(
     "args,kwargs",
     [


### PR DESCRIPTION
## Summary
- restore ndarray writeable flags in a view-safe order
- add a regression test for passing a view before its base array

Fixes #2410

## Testing
- LD_LIBRARY_PATH=/data/whn/.hermes/hermes-agent/venv/lib/python3.11/site-packages/shapely.libs:${LD_LIBRARY_PATH} python -m pytest -q shapely/tests/test_misc.py -k multithreading_enabled
- python -m ruff check shapely/decorators.py shapely/tests/test_misc.py