### PR TITLE
Preserve precision grid size when copying geometries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,11 @@ coordinates in each input LineString or LinearRing (#2306).
 `Polygon.from_bounds` now builds the ring in counterclockwise order, consistent
 with `shapely.box`, so the result satisfies the GeoJSON right-hand rule (#2396).
 
+Bug fixes:
+
+- `copy.deepcopy` and pickling now preserve the precision grid size set with
+  `set_precision` (#2073).
+
 
 2.1.2 (2025-09-24)
 ------------------

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -79,6 +79,14 @@ def _maybe_unpack(result):
         return result
 
 
+def _unpickle(wkb, precision=0.0):
+    geometry = shapely.from_wkb(wkb)
+    if precision:
+        # WKB does not carry the precision grid size, so restore it.
+        geometry = shapely.set_precision(geometry, precision)
+    return geometry
+
+
 class CAP_STYLE:
     """Buffer cap styles."""
 
@@ -189,7 +197,13 @@ class BaseGeometry(shapely.Geometry):
 
     def __reduce__(self):
         """Pickle support."""
-        return (shapely.from_wkb, (shapely.to_wkb(self, include_srid=True),))
+        return (
+            _unpickle,
+            (
+                shapely.to_wkb(self, include_srid=True),
+                float(shapely.get_precision(self)),
+            ),
+        )
 
     # Operators
     # ---------

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -13,12 +13,14 @@ from shapely.geometry.point import Point
 __all__ = ["LinearRing", "Polygon", "orient"]
 
 
-def _unpickle_linearring(wkb):
+def _unpickle_linearring(wkb, precision=0.0):
     linestring = shapely.from_wkb(wkb)
     srid = shapely.lib.get_srid_scalar(linestring)
     linearring = _geometry_helpers.linestring_to_linearring(linestring)
     if srid:
         linearring = shapely.lib.set_srid_scalar(linearring, int(srid))
+    if precision:
+        linearring = shapely.set_precision(linearring, precision)
     return linearring
 
 
@@ -117,7 +119,13 @@ class LinearRing(LineString):
         WKB doesn't differentiate between LineString and LinearRing so we
         need to move the coordinate sequence into the correct geometry type
         """
-        return (_unpickle_linearring, (shapely.to_wkb(self, include_srid=True),))
+        return (
+            _unpickle_linearring,
+            (
+                shapely.to_wkb(self, include_srid=True),
+                float(shapely.get_precision(self)),
+            ),
+        )
 
     @property
     def is_ccw(self):

--- a/shapely/tests/test_misc.py
+++ b/shapely/tests/test_misc.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import sys
 from copy import deepcopy
 from inspect import cleandoc
@@ -211,3 +212,37 @@ def test_deepcopy_empty_geometries(geom):
     geom_copied = deepcopy(geom)  # should not raise any exception
 
     assert geom.equals(geom_copied)
+
+
+def _via_pickle(geom):
+    return pickle.loads(pickle.dumps(geom, pickle.HIGHEST_PROTOCOL))
+
+
+@pytest.mark.parametrize("copy_func", [deepcopy, _via_pickle])
+@pytest.mark.parametrize(
+    "geom",
+    [
+        shapely.Point(0.14, 0.16),
+        shapely.Point(0.14, 0.16, 3.7),
+        shapely.LineString([(0, 0), (1.23, 4.56), (2, 2)]),
+        shapely.LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)]),
+        shapely.Polygon(
+            [(0, 0), (10, 0), (10, 10), (0, 10)], holes=[[(2, 2), (2, 4), (4, 4)]]
+        ),
+        shapely.MultiPolygon([shapely.box(0, 0, 1, 1), shapely.box(2, 2, 3, 3)]),
+    ],
+)
+def test_copy_preserves_precision(geom, copy_func):
+    """Copying a geometry should preserve the precision grid size.
+
+    https://github.com/shapely/shapely/issues/2073
+    """
+    geom = shapely.set_precision(geom, 0.5)
+    copied = copy_func(geom)
+
+    assert shapely.get_precision(copied) == shapely.get_precision(geom) == 0.5
+    assert type(copied) is type(geom)
+    assert copied.has_z == geom.has_z
+    # re-applying the precision on unpickle may renormalize polygon rings, so
+    # compare the normalized geometries rather than the exact coordinates
+    assert shapely.equals_exact(shapely.normalize(copied), shapely.normalize(geom))


### PR DESCRIPTION
`deepcopy` and pickle lose the precision grid size from `set_precision` (`get_precision` comes back `0.0`). The reduce methods only store WKB, and WKB doesn't carry the grid size.

So I stash `get_precision` next to the WKB and re-apply it on unpickle. Regression test in `test_misc.py`, plus a CHANGES entry. Suite's green.

One call I'd like your take on: @jorisvandenbossche noted set_precision might change the geometry, and it does for polygons. The default mode renormalizes the ring start vertex (geometry's still equal, just a different starting point) but keeps Z and M. `mode="pointwise"` avoids that but drops M, so I went with the default to not lose data. Fine as is, or would you rather have a lower-level grid-size setter?

Fixes #2073