### PR TITLE
MNT: Move pytest configuration from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ ignore = ["D000", "D004"]
 allow-long-titles = true
 max-line-length = 79
 
+[tool.pytest.ini_options]
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+xfail_strict = true
+
 [tool.ruff]
 line-length = 88
 extend-exclude = ["docs/*", "benchmarks/*", "shapely/_version.py", "versioneer.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,3 @@ versionfile_source = shapely/_version.py
 versionfile_build = shapely/_version.py
 tag_prefix =
 parentdir_prefix = shapely-
-
-[tool:pytest]
-doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
-xfail_strict = true


### PR DESCRIPTION
This moves the pytest configuration from `setup.cfg` to `pyproject.toml`, as supported since [version 6](https://docs.pytest.org/en/8.4.x/reference/customize.html#pyproject-toml) under `[tool.pytest.ini_options]`. No options are changed, just translated. The motivation is to clear out and remove `setup.cfg`.

An upgrade to require pytest>=9 with options slightly re-written under `[tool.pytest]` can happen at a later time.