### PR TITLE
BLD: harden Windows ARM64 wheel releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ on:
 
 env:
   GEOS_VERSION: "3.13.1"
+  GEOS_SHA256: "df2c50503295f325e7c8d7b783aca8ba4773919cde984193850cf9e361dfd28c"
+  GEOS_CHECKSUM_PROVENANCE_URL: "https://github.com/libgeos/geos/releases/tag/3.13.1"
 
 jobs:
   build_sdist:
@@ -162,7 +164,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.GEOS_VERSION }}-${{ hashFiles('ci/*') }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.GEOS_VERSION }}-${{ env.GEOS_SHA256 }}-${{ hashFiles('ci/*') }}
 
       - name: Add GEOS LICENSE
         run: cp ci/wheelbuilder/LICENSE_GEOS .
@@ -196,22 +198,162 @@ jobs:
             GEOS_INSTALL='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}'
             GEOS_LIBRARY_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\lib'
             GEOS_INCLUDE_PATH='${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\include'
+            GEOS_SHA256='${{ env.GEOS_SHA256 }}'
           CIBW_BEFORE_ALL_MACOS: ./ci/install_geos.sh
           CIBW_BEFORE_ALL_WINDOWS: ci\install_geos.cmd
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path ${{ runner.temp }}\geos-${{ env.GEOS_VERSION }}\bin -w {dest_dir} -v {wheel}
-      - name: Upload artifacts
+      - name: Retain all non-Windows-ARM64 distributions
+        if: ${{ !(matrix.os == 'windows-11-arm' && matrix.arch == 'ARM64') }}
         uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
+          if-no-files-found: error
           retention-days: 5
+          compression-level: 0
+      - name: Produce and retain Windows ARM64 evidence
+        if: ${{ matrix.os == 'windows-11-arm' && matrix.arch == 'ARM64' }}
+        shell: pwsh
+        env:
+          GEOS_SHA256: ${{ env.GEOS_SHA256 }}
+          GEOS_CHECKSUM_PROVENANCE_URL: ${{ env.GEOS_CHECKSUM_PROVENANCE_URL }}
+        run: |
+          python -m pip install --disable-pip-version-check "packaging>=24"
+          python ci\wheel_evidence.py producer --wheelhouse wheelhouse --output arm64-wheel-producer.json
+          python ci\wheel_evidence.py validate --kind producer --input arm64-wheel-producer.json
+          if (-not (Test-Path arm64-wheel-producer.json) -or (Get-Item arm64-wheel-producer.json).Length -eq 0) { throw 'empty producer record' }
+      - name: Retain Windows ARM64 wheels
+        if: ${{ matrix.os == 'windows-11-arm' && matrix.arch == 'ARM64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-windows-11-arm-ARM64
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+      - name: Retain Windows ARM64 producer metadata
+        if: ${{ matrix.os == 'windows-11-arm' && matrix.arch == 'ARM64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-producer-metadata
+          path: arm64-wheel-producer.json
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+
+  verify_windows_arm64_artifact:
+    name: Verify Windows ARM64 wheels (${{ matrix.label }})
+    needs: build_wheels_mac_win
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { label: cp311, numeric: "3.11", free_threaded: false, allow_prereleases: false }
+          - { label: cp312, numeric: "3.12", free_threaded: false, allow_prereleases: false }
+          - { label: cp313, numeric: "3.13", free_threaded: false, allow_prereleases: false }
+          - { label: cp314, numeric: "3.14", free_threaded: false, allow_prereleases: false }
+          - { label: cp314t, numeric: "3.14", free_threaded: true, allow_prereleases: false }
+          - { label: cp315, numeric: "3.15", free_threaded: false, allow_prereleases: true }
+          - { label: cp315t, numeric: "3.15", free_threaded: true, allow_prereleases: true }
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-windows-11-arm-ARM64
+          path: retained-wheel
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-arm64-producer-metadata
+          path: retained-metadata
+      - name: Resolve local ARM64 verifier runtime
+        shell: pwsh
+        run: |
+          python -m pip install --disable-pip-version-check "packaging>=24"
+          python ci\arm64_python_runtime.py plan --label ${{ matrix.label }} --allow-prereleases ${{ matrix.allow_prereleases }} --output arm64-runtime-plan-${{ matrix.label }}.json
+          $runtimePlan = Get-Content arm64-runtime-plan-${{ matrix.label }}.json | ConvertFrom-Json
+          $runtime = $runtimePlan.runtimes | Select-Object -First 1
+          if (-not $runtime.available) { throw "ARM64 runtime unavailable for ${{ matrix.label }}: $($runtime.reason)" }
+          python ci\arm64_python_runtime.py install --label ${{ matrix.label }} --allow-prereleases ${{ matrix.allow_prereleases }} --root local-python --output arm64-runtime-install-${{ matrix.label }}.json
+          $runtimeInstall = Get-Content arm64-runtime-install-${{ matrix.label }}.json | ConvertFrom-Json
+          $pythonExe = $runtimeInstall.runtime.python_executable
+          if (-not (Test-Path $pythonExe)) { throw "runtime executable missing: $pythonExe" }
+          Add-Content -Path $env:GITHUB_ENV -Value ('WHEEL_EVIDENCE_PYTHON_EXE=' + $pythonExe)
+      - name: Retain ARM64 runtime plan
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-runtime-plan-${{ matrix.label }}
+          path: arm64-runtime-plan-${{ matrix.label }}.json
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+      - name: Verify retained wheels for one ABI
+        shell: pwsh
+        run: |
+          python -m pip install --disable-pip-version-check "packaging>=24" delvewheel
+          python ci\wheel_evidence.py verify --producer retained-metadata\arm64-wheel-producer.json --wheelhouse retained-wheel --source-root . --label ${{ matrix.label }} --python-exe $env:WHEEL_EVIDENCE_PYTHON_EXE --output arm64-wheel-verifier-${{ matrix.label }}.json --report-dir repair-reports
+          python ci\wheel_evidence.py validate --kind verifier --input arm64-wheel-verifier-${{ matrix.label }}.json
+          if (-not (Test-Path arm64-wheel-verifier-${{ matrix.label }}.json) -or (Get-Item arm64-wheel-verifier-${{ matrix.label }}.json).Length -eq 0) { throw 'empty verifier record' }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-verifier-${{ matrix.label }}
+          path: |
+            arm64-wheel-verifier-${{ matrix.label }}.json
+            repair-reports/*.delvewheel.txt
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+
+  finalize_windows_arm64_evidence:
+    name: Finalize Windows ARM64 wheel evidence
+    needs: verify_windows_arm64_artifact
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-windows-11-arm-ARM64
+          path: retained-wheel
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-arm64-producer-metadata
+          path: retained-metadata
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: windows-arm64-verifier-*
+          merge-multiple: true
+          path: verifier-records
+      - name: Finalize retained ARM64 evidence
+        shell: pwsh
+        run: |
+          python -m pip install --disable-pip-version-check "packaging>=24"
+          python ci\wheel_evidence.py finalize --producer retained-metadata\arm64-wheel-producer.json --verifier-dir verifier-records --output arm64-wheel-provenance.json
+          python ci\wheel_evidence.py validate --kind final --input arm64-wheel-provenance.json
+          if (-not (Test-Path arm64-wheel-provenance.json) -or (Get-Item arm64-wheel-provenance.json).Length -eq 0) { throw 'empty final provenance record' }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-wheel-provenance
+          path: arm64-wheel-provenance.json
+          if-no-files-found: error
+          retention-days: 30
           compression-level: 0
 
   nightly_upload:
     name: Upload nightly wheels
-    needs: [build_sdist, build_wheels_linux, build_wheels_mac_win]
+    needs: [build_sdist, build_wheels_linux, build_wheels_mac_win, finalize_windows_arm64_evidence]
     runs-on: ubuntu-latest
-    if: github.repository == 'shapely/shapely' && github.ref == 'refs/heads/main'
+    if: ${{ success() && github.repository == 'shapely/shapely' && github.ref == 'refs/heads/main' && needs.finalize_windows_arm64_evidence.result == 'success' }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -226,49 +368,89 @@ jobs:
 
   publish:
     name: Publish on GitHub and PyPI
-    needs: [build_sdist, build_wheels_linux, build_wheels_mac_win]
+    needs: [build_sdist, build_wheels_linux, build_wheels_mac_win, finalize_windows_arm64_evidence]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # release on every tag
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+    if: ${{ success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') && needs.finalize_windows_arm64_evidence.result == 'success' }}
     steps:
+      - name: Checkout publication verifier
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve publication target commit
+        id: publication_target
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="$(git rev-parse --verify 'HEAD^{commit}')"
+          if [[ ! "$target" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'Invalid publication target commit: %s\n' "$target" >&2
+            exit 1
+          fi
+          printf 'commit=%s\n' "$target" >> "$GITHUB_OUTPUT"
+
+      - name: Set up publication verifier Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+
       - uses: actions/download-artifact@v8
         with:
           pattern: release-*
           merge-multiple: true
           path: dist
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      - name: Download finalized Windows ARM64 provenance
+        uses: actions/download-artifact@v8
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
+          name: windows-arm64-wheel-provenance
+          path: publication-provenance
 
-      - name: Get Asset name
+      - name: Install publication verifier dependencies
+        run: python -m pip install --disable-pip-version-check "packaging>=24"
+
+      - name: Stage distributions missing from PyPI
+        id: stage_pypi
         run: |
-          export PKG=$(ls dist/ | grep tar)
-          set -- $PKG
-          echo "name=$1" >> $GITHUB_ENV
+          python ci/wheel_evidence.py stage-pypi \
+            --wheelhouse dist \
+            --staging-dir pypi-upload \
+            --manifest publication-provenance/arm64-wheel-provenance.json \
+            --distribution shapely \
+            --version "${{ github.ref_name }}" \
+            --attempts 3 \
+            --retry-delay-seconds 5 \
+            --github-output "$GITHUB_OUTPUT"
 
-      - name: Upload Release Asset (sdist) to GitHub
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/${{ env.name }}
-          asset_name: ${{ env.name }}
-          asset_content_type: application/zip
-
-      - name: Upload Release Assets to PyPI
+      - name: Upload missing release distributions to PyPI
+        if: ${{ steps.stage_pypi.outputs.has_files == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
-          skip-existing: true
+          packages-dir: pypi-upload
+          # Existing files were hash-verified and excluded; immutable collisions fail.
+          print-hash: true
           # To test: repository_url: https://test.pypi.org/legacy/
+
+      - name: Prove PyPI ARM64 wheels match finalized provenance
+        run: |
+          python ci/wheel_evidence.py pypi \
+            --manifest publication-provenance/arm64-wheel-provenance.json \
+            --distribution shapely \
+            --version "${{ github.ref_name }}" \
+            --attempts 12 \
+            --retry-delay-seconds 10
+
+      - name: Publish verified GitHub Release transaction
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python ci/release_transaction.py \
+            --repository "${{ github.repository }}" \
+            --tag "${{ github.ref_name }}" \
+            --target "${{ steps.publication_target.outputs.commit }}" \
+            --asset dist/*.tar.gz

--- a/ci/arm64_python_runtime.py
+++ b/ci/arm64_python_runtime.py
@@ -1,0 +1,675 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from packaging.version import InvalidVersion, Version
+
+from wheel_evidence import EXPECTED_LABELS, RUNTIMES
+
+ROOT_INDEX_URL = "https://www.python.org/ftp/python/"
+PYTHON_FTP_ROOT = "https://www.python.org/ftp/python"
+ENTRY_PATTERN = re.compile(r'href="([^"/]+)/"')
+PRERELEASE_MANIFEST_PATTERN = re.compile(r'href="windows-([^"/]+)\.json"')
+MANIFEST_ENTRY_KEYS = {
+    "schema",
+    "id",
+    "sort-version",
+    "company",
+    "tag",
+    "install-for",
+    "alias",
+    "display-name",
+    "executable",
+    "url",
+    "hash",
+}
+WINDOWS_REPARSE_POINT = 0x400
+WINDOWS_INVALID_COMPONENT_CHARACTERS = frozenset('<>"|?*')
+WINDOWS_MAX_COMPONENT_UTF16_UNITS = 255
+WINDOWS_RESERVED_NAMES = {
+    "AUX",
+    "CON",
+    "CONIN$",
+    "CONOUT$",
+    "NUL",
+    "PRN",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"COM{number}" for number in "¹²³"),
+    *(f"LPT{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in "¹²³"),
+}
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    label: str
+    series: str
+    free_threaded: bool
+    allow_prereleases: bool
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def runtime_specs() -> list[RuntimeSpec]:
+    specs = []
+    for label in sorted(EXPECTED_LABELS):
+        runtime = next(value for value in RUNTIMES.values() if value["label"] == label)
+        specs.append(
+            RuntimeSpec(
+                label=label,
+                series=runtime["numeric_version"],
+                free_threaded=runtime["free_threaded"],
+                allow_prereleases=label in {"cp315", "cp315t"},
+            )
+        )
+    return specs
+
+
+def fetch_text(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "shapely-arm64-runtime-plan"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def fetch_json(url: str) -> object:
+    return json.loads(fetch_text(url))
+
+
+def canonical_write(path: os.PathLike[str] | str, value: object) -> None:
+    destination = pathlib.Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def parse_versions(html: str, spec: RuntimeSpec) -> list[str]:
+    releases = []
+    for match in ENTRY_PATTERN.finditer(html):
+        candidate = match.group(1)
+        if not candidate.startswith(spec.series + "."):
+            continue
+        try:
+            parsed = Version(candidate)
+        except InvalidVersion:
+            continue
+        if f"{parsed.major}.{parsed.minor}" != spec.series:
+            continue
+        if parsed.is_prerelease and not spec.allow_prereleases:
+            continue
+        releases.append(candidate)
+    return sorted(set(releases), key=Version, reverse=True)
+
+
+def manifest_url(release: str) -> str:
+    return f"{PYTHON_FTP_ROOT}/{release}/windows-{release}.json"
+
+
+def prerelease_manifest_url(directory_release: str, release: str) -> str:
+    return f"{PYTHON_FTP_ROOT}/{directory_release}/windows-{release}.json"
+
+
+def parse_prerelease_manifest_versions(
+    html: str, spec: RuntimeSpec, directory_release: str
+) -> list[str]:
+    directory_version = Version(directory_release)
+    releases = []
+    for match in PRERELEASE_MANIFEST_PATTERN.finditer(html):
+        candidate = match.group(1)
+        if not candidate.startswith(spec.series + "."):
+            continue
+        try:
+            parsed = Version(candidate)
+        except InvalidVersion:
+            continue
+        if not parsed.is_prerelease or not spec.allow_prereleases:
+            continue
+        if parsed.base_version != directory_version.base_version:
+            continue
+        releases.append(candidate)
+    return sorted(set(releases), key=Version, reverse=True)
+
+
+def manifest_entry_id(spec: RuntimeSpec) -> str:
+    suffix = "t" if spec.free_threaded else ""
+    return f"pythoncore-{spec.series}{suffix}-arm64"
+
+
+def parse_cli_bool(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    fail(f"invalid boolean value: {value}")
+
+
+def normalize_runtime_executable_path(root: pathlib.Path, value: object) -> pathlib.Path:
+    if not isinstance(value, str) or not value:
+        fail("runtime executable path missing or malformed")
+    text = value.replace("\\", "/")
+    if text.startswith("//") or value.startswith("\\\\"):
+        fail("runtime executable path must be relative")
+    if text.startswith("/") or re.match(r"^[A-Za-z]:", text):
+        fail("runtime executable path must be relative")
+    pure = pathlib.PurePosixPath(text)
+    parts = []
+    for part in pure.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            fail("runtime executable path cannot escape runtime root")
+        if ":" in part:
+            fail("runtime executable path must be relative")
+        parts.append(part)
+    if not parts:
+        fail("runtime executable path missing or malformed")
+    candidate = (root.resolve() / pathlib.Path(*parts)).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as error:
+        fail(f"runtime executable path escapes runtime root ({error})")
+    return candidate
+
+
+def validate_runtime_executable_text(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        fail("runtime executable path missing or malformed")
+    normalize_runtime_executable_path(pathlib.Path.cwd(), value)
+    return value
+
+
+def runtime_spec_for_label(label: str, allow_prereleases: bool | None = None) -> RuntimeSpec:
+    specs = {spec.label: spec for spec in runtime_specs()}
+    if label not in specs:
+        fail(f"unknown runtime label(s): {label}")
+    spec = specs[label]
+    if allow_prereleases is None:
+        return spec
+    return RuntimeSpec(
+        label=spec.label,
+        series=spec.series,
+        free_threaded=spec.free_threaded,
+        allow_prereleases=allow_prereleases,
+    )
+
+
+def manifest_record_for(
+    spec: RuntimeSpec, release: str, directory_release: str | None = None
+) -> dict[str, object] | None:
+    url = (
+        manifest_url(release)
+        if directory_release is None
+        else prerelease_manifest_url(directory_release, release)
+    )
+    try:
+        payload = fetch_json(url)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    if not isinstance(payload, dict):
+        return None
+    versions = payload.get("versions")
+    if not isinstance(versions, list):
+        return None
+    wanted = manifest_entry_id(spec)
+    for item in versions:
+        if not isinstance(item, dict):
+            continue
+        if item.get("id") == wanted:
+            return item
+    return None
+
+
+def discover_runtime(spec: RuntimeSpec) -> dict[str, object]:
+    root_index = fetch_text(ROOT_INDEX_URL)
+    releases = parse_versions(root_index, spec)
+    if not releases:
+        return {
+            "label": spec.label,
+            "series": spec.series,
+            "free_threaded": spec.free_threaded,
+            "allow_prereleases": spec.allow_prereleases,
+            "available": False,
+            "release": None,
+            "manifest_url": None,
+            "download_url": None,
+            "sha256": None,
+            "executable": None,
+            "reason": f"no python.org FTP releases found for {spec.series}",
+        }
+    for directory_release in releases:
+        release = directory_release
+        location = manifest_url(release)
+        record = manifest_record_for(spec, release)
+        if record is None and spec.allow_prereleases:
+            directory_url = f"{PYTHON_FTP_ROOT}/{directory_release}/"
+            try:
+                directory_index = fetch_text(directory_url)
+            except urllib.error.HTTPError as error:
+                if error.code == 404:
+                    continue
+                raise
+            prereleases = parse_prerelease_manifest_versions(
+                directory_index, spec, directory_release
+            )
+            for prerelease in prereleases:
+                record = manifest_record_for(spec, prerelease, directory_release)
+                if record is not None:
+                    release = prerelease
+                    location = prerelease_manifest_url(directory_release, prerelease)
+                    break
+        if record is None:
+            continue
+        if set(record) != MANIFEST_ENTRY_KEYS:
+            fail(f"{release}: unexpected manifest key set")
+        download_url = record.get("url")
+        executable = record.get("executable")
+        hashes = record.get("hash")
+        digest = hashes.get("sha256") if isinstance(hashes, dict) else None
+        if not isinstance(download_url, str) or not download_url.startswith("https://"):
+            fail(f"{release}: runtime URL missing or non-HTTPS")
+        executable = validate_runtime_executable_text(executable)
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            fail(f"{release}: runtime SHA-256 missing or malformed")
+        return {
+            "label": spec.label,
+            "series": spec.series,
+            "free_threaded": spec.free_threaded,
+            "allow_prereleases": spec.allow_prereleases,
+            "available": True,
+            "release": release,
+            "manifest_url": location,
+            "download_url": download_url,
+            "sha256": digest,
+            "executable": executable,
+            "reason": None,
+        }
+    return {
+        "label": spec.label,
+        "series": spec.series,
+        "free_threaded": spec.free_threaded,
+        "allow_prereleases": spec.allow_prereleases,
+        "available": False,
+        "release": None,
+        "manifest_url": None,
+        "download_url": None,
+        "sha256": None,
+        "executable": None,
+        "reason": (
+            f"no python.org Windows ARM64 manifest entry found for {spec.label}; "
+            "serialized runner must record this as unavailable rather than verified"
+        ),
+    }
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    with open(path, "rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def output_path(root: pathlib.Path, spec: RuntimeSpec, release: str) -> pathlib.Path:
+    return root / f"{spec.label}-{release}"
+
+
+def path_is_link_or_reparse_point(path: pathlib.Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & WINDOWS_REPARSE_POINT
+    )
+
+
+def existing_path_metadata(path: pathlib.Path) -> os.stat_result | None:
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def validated_extraction_target(target: pathlib.Path) -> pathlib.Path:
+    target = pathlib.Path(os.path.abspath(target))
+    anchor = pathlib.Path(target.anchor)
+    if not target.anchor or existing_path_metadata(anchor) is None:
+        fail(f"ZIP extraction target has no existing filesystem anchor: {target}")
+
+    current = anchor
+    relative_parts = target.parts[1:]
+    for index, part in enumerate(relative_parts):
+        current = current / part
+        metadata = existing_path_metadata(current)
+        if metadata is None:
+            break
+        if stat.S_ISLNK(metadata.st_mode) or bool(
+            getattr(metadata, "st_file_attributes", 0) & WINDOWS_REPARSE_POINT
+        ):
+            fail(
+                "ZIP extraction target path contains a link or reparse point: "
+                f"{current}"
+            )
+        if index < len(relative_parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            fail(f"ZIP extraction target ancestor is not a directory: {current}")
+
+    target_metadata = existing_path_metadata(target)
+    if target_metadata is not None and not stat.S_ISDIR(target_metadata.st_mode):
+        fail(f"ZIP extraction target is not a directory: {target}")
+    return target
+
+
+def validated_zip_member(
+    target_root: pathlib.Path, member: zipfile.ZipInfo
+) -> tuple[tuple[str, ...], bool]:
+    filename = member.filename
+    normalized = filename.replace("\\", "/")
+    windows_path = pathlib.PureWindowsPath(filename)
+    if windows_path.drive or windows_path.root or normalized.startswith("/"):
+        fail(f"unsafe absolute ZIP member path: {filename}")
+
+    parts = []
+    for part in pathlib.PurePosixPath(normalized).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            fail(f"unsafe ZIP member path traversal: {filename}")
+        if ":" in part:
+            fail(f"unsafe ZIP member drive or stream path: {filename}")
+        if any(ord(character) <= 0x1F for character in part):
+            fail(f"unsafe Windows control character in ZIP member path: {filename}")
+        if any(
+            character in WINDOWS_INVALID_COMPONENT_CHARACTERS
+            for character in part
+        ):
+            fail(f"unsafe Windows character in ZIP member path: {filename}")
+        utf16_units = sum(
+            2 if ord(character) > 0xFFFF else 1 for character in part
+        )
+        if utf16_units > WINDOWS_MAX_COMPONENT_UTF16_UNITS:
+            fail(f"unsafe overlong Windows ZIP member component: {filename}")
+        if part.rstrip(" .") != part:
+            fail(f"unsafe Windows-normalized ZIP member path: {filename}")
+        reserved_name = part.partition(".")[0].rstrip(" ").upper()
+        if reserved_name in WINDOWS_RESERVED_NAMES:
+            fail(f"unsafe Windows device ZIP member path: {filename}")
+        parts.append(part)
+    if not parts:
+        fail(f"unsafe empty ZIP member path: {filename}")
+
+    mode = member.external_attr >> 16
+    file_type = stat.S_IFMT(mode)
+    if file_type not in (0, stat.S_IFREG, stat.S_IFDIR):
+        fail(f"unsafe link or special ZIP member: {filename}")
+    if member.external_attr & WINDOWS_REPARSE_POINT:
+        fail(f"unsafe reparse-point ZIP member: {filename}")
+
+    is_directory = member.is_dir() or normalized.endswith("/")
+    if file_type == stat.S_IFDIR and not is_directory:
+        fail(f"malformed ZIP directory member: {filename}")
+
+    destination = target_root.joinpath(*parts)
+    try:
+        destination.relative_to(target_root)
+    except ValueError:
+        fail(f"unsafe normalized ZIP member path: {filename}")
+    return tuple(parts), is_directory
+
+
+def preflight_zip_destination(
+    target_root: pathlib.Path,
+    member: zipfile.ZipInfo,
+    parts: tuple[str, ...],
+    is_directory: bool,
+) -> None:
+    current = target_root
+    for index, part in enumerate(parts):
+        current = current / part
+        metadata = existing_path_metadata(current)
+        if metadata is None:
+            return
+        if stat.S_ISLNK(metadata.st_mode) or bool(
+            getattr(metadata, "st_file_attributes", 0) & WINDOWS_REPARSE_POINT
+        ):
+            fail(
+                "ZIP extraction destination contains a link or reparse point: "
+                f"{member.filename}"
+            )
+
+        is_destination = index == len(parts) - 1
+        if not is_destination:
+            if not stat.S_ISDIR(metadata.st_mode):
+                fail(
+                    "ZIP extraction destination ancestor is not a directory: "
+                    f"{member.filename}"
+                )
+            continue
+
+        if is_directory and not stat.S_ISDIR(metadata.st_mode):
+            fail(
+                "ZIP extraction directory conflicts with an existing file: "
+                f"{member.filename}"
+            )
+        if not is_directory and stat.S_ISDIR(metadata.st_mode):
+            fail(
+                "ZIP extraction file conflicts with an existing directory: "
+                f"{member.filename}"
+            )
+        if not is_directory and not stat.S_ISREG(metadata.st_mode):
+            fail(
+                "ZIP extraction file conflicts with an existing special file: "
+                f"{member.filename}"
+            )
+
+
+def ensure_safe_directory(target_root: pathlib.Path, directory: pathlib.Path) -> None:
+    try:
+        relative = directory.relative_to(target_root)
+    except ValueError:
+        fail(f"ZIP extraction directory escapes target: {directory}")
+
+    current = target_root
+    for part in relative.parts:
+        current = current / part
+        if path_is_link_or_reparse_point(current):
+            fail(f"ZIP extraction encountered link or reparse point: {current}")
+        try:
+            current.mkdir()
+        except FileExistsError:
+            if not current.is_dir():
+                raise
+        resolved = current.resolve()
+        try:
+            resolved.relative_to(target_root)
+        except ValueError:
+            fail(f"ZIP extraction directory escapes target: {current}")
+
+
+def safe_extract_zip(payload: zipfile.ZipFile, target: pathlib.Path) -> None:
+    target_root = validated_extraction_target(target)
+    members = [
+        (member, *validated_zip_member(target_root, member))
+        for member in payload.infolist()
+    ]
+    destinations: dict[tuple[str, ...], tuple[zipfile.ZipInfo, bool]] = {}
+    for member, parts, is_directory in members:
+        destination_key = tuple(part.casefold() for part in parts)
+        previous = destinations.get(destination_key)
+        if previous is not None:
+            previous_member, previous_is_directory = previous
+            collision = (
+                "file/directory"
+                if previous_is_directory != is_directory
+                else "duplicate"
+            )
+            fail(
+                f"unsafe {collision} ZIP member destination: {member.filename} "
+                f"conflicts with {previous_member.filename}"
+            )
+        destinations[destination_key] = (member, is_directory)
+
+    for member, parts, _ in members:
+        destination_key = tuple(part.casefold() for part in parts)
+        for depth in range(1, len(destination_key)):
+            ancestor = destinations.get(destination_key[:depth])
+            if ancestor is not None and not ancestor[1]:
+                fail(
+                    f"unsafe ZIP member path beneath file: {member.filename} "
+                    f"conflicts with {ancestor[0].filename}"
+                )
+
+    for member, parts, is_directory in members:
+        preflight_zip_destination(target_root, member, parts, is_directory)
+
+    target_root.mkdir(parents=True, exist_ok=True)
+    if path_is_link_or_reparse_point(target_root):
+        fail(f"ZIP extraction target is a link or reparse point: {target_root}")
+    target_root = target_root.resolve(strict=True)
+
+    for member, parts, is_directory in members:
+        destination = target_root.joinpath(*parts)
+        if is_directory:
+            ensure_safe_directory(target_root, destination)
+            continue
+
+        ensure_safe_directory(target_root, destination.parent)
+        if path_is_link_or_reparse_point(destination):
+            fail(f"ZIP extraction encountered link or reparse point: {destination}")
+        resolved_parent = destination.parent.resolve(strict=True)
+        try:
+            resolved_parent.relative_to(target_root)
+        except ValueError:
+            fail(f"ZIP extraction destination escapes target: {destination}")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(destination, flags, 0o666)
+        with os.fdopen(descriptor, "wb") as output, payload.open(member) as source:
+            shutil.copyfileobj(source, output)
+
+
+def install_runtime(spec: RuntimeSpec, root: pathlib.Path) -> dict[str, object]:
+    plan = discover_runtime(spec)
+    if not plan["available"]:
+        return plan
+
+    release = str(plan["release"])
+    download_url = str(plan["download_url"])
+    expected_sha256 = str(plan["sha256"])
+    target = output_path(root, spec, release)
+    archive = root / "downloads" / pathlib.Path(download_url).name
+    archive.parent.mkdir(parents=True, exist_ok=True)
+
+    with urllib.request.urlopen(download_url, timeout=60) as response:
+        archive.write_bytes(response.read())
+    actual_sha256 = sha256_file(archive)
+    if actual_sha256 != expected_sha256:
+        fail(
+            f"{spec.label}: runtime digest mismatch: expected {expected_sha256}; "
+            f"actual {actual_sha256}"
+        )
+
+    with zipfile.ZipFile(archive) as payload:
+        safe_extract_zip(payload, target)
+
+    python_executable = normalize_runtime_executable_path(target, plan["executable"])
+    if not python_executable.exists():
+        fail(f"{spec.label}: runtime executable missing after extraction")
+    subprocess.check_call([str(python_executable), "-m", "ensurepip", "--upgrade"])
+    subprocess.check_call([str(python_executable), "-m", "pip", "install", "--upgrade", "pip"])
+
+    return {
+        **plan,
+        "target_dir": str(target.resolve()),
+        "python_executable": str(python_executable),
+        "downloaded_sha256": actual_sha256,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    plan = commands.add_parser("plan")
+    plan.add_argument("--label", action="append", help="Specific ABI label(s) to plan")
+    plan.add_argument("--allow-prereleases", choices=("true", "false"))
+    plan.add_argument("--output", required=True)
+
+    install = commands.add_parser("install")
+    install.add_argument("--label", required=True)
+    install.add_argument("--allow-prereleases", choices=("true", "false"))
+    install.add_argument("--root", required=True)
+    install.add_argument("--output", required=True)
+    return parser
+
+
+def selected_specs(labels: list[str] | None, allow_prereleases: bool | None = None) -> list[RuntimeSpec]:
+    specs = {spec.label: spec for spec in runtime_specs()}
+    if not labels:
+        if allow_prereleases is None:
+            return [specs[label] for label in sorted(specs)]
+        return [runtime_spec_for_label(label, allow_prereleases) for label in sorted(specs)]
+    missing = [label for label in labels if label not in specs]
+    if missing:
+        fail(f"unknown runtime label(s): {', '.join(sorted(missing))}")
+    return [runtime_spec_for_label(label, allow_prereleases) for label in labels]
+
+
+def plan_command(args: argparse.Namespace) -> None:
+    allow_prereleases = None if args.allow_prereleases is None else parse_cli_bool(args.allow_prereleases)
+    runtimes = [discover_runtime(spec) for spec in selected_specs(args.label, allow_prereleases)]
+    doc = {
+        "schema_version": 1,
+        "record_type": "runtime_plan",
+        "created_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "runtimes": runtimes,
+    }
+    canonical_write(args.output, doc)
+
+
+def install_command(args: argparse.Namespace) -> int:
+    allow_prereleases = None if args.allow_prereleases is None else parse_cli_bool(args.allow_prereleases)
+    spec = selected_specs([args.label], allow_prereleases)[0]
+    record = install_runtime(spec, pathlib.Path(args.root))
+    doc = {
+        "schema_version": 1,
+        "record_type": "runtime_install",
+        "created_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "runtime": record,
+    }
+    canonical_write(args.output, doc)
+    return 0 if record["available"] else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "plan":
+        plan_command(args)
+        return 0
+    return install_command(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.CalledProcessError, urllib.error.URLError, zipfile.BadZipFile) as error:
+        print(f"arm64-python-runtime: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/ci/install_geos.cmd
+++ b/ci/install_geos.cmd
@@ -1,20 +1,67 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
 :: Build and install GEOS on Windows system, save cache for later
 ::
 :: This script requires environment variables to be set
 ::  - set GEOS_INSTALL=C:\path\to\cached\prefix -- to build or use as cache
-::  - set GEOS_VERSION=3.7.3 -- to download and compile
+::  - set GEOS_VERSION=3.13.1 -- to download and compile
+::  - set GEOS_SHA256=<authoritative 64-hex digest> -- to verify before extraction
 
-if exist %GEOS_INSTALL% (
-  echo Using cached %GEOS_INSTALL%
+if not defined GEOS_INSTALL exit /B 10
+if not defined GEOS_VERSION exit /B 10
+if not defined GEOS_SHA256 exit /B 10
+
+powershell.exe -NoProfile -NonInteractive -Command "$expected=$env:GEOS_SHA256; if($expected -notmatch '^[0-9A-Fa-f]{64}$'){throw 'GEOS_SHA256 must be exactly 64 hexadecimal characters.'}"
+if errorlevel 1 exit /B 10
+
+set "GEOS_ARCHIVE=geos-%GEOS_VERSION%.tar.bz2"
+set "GEOS_URL=https://download.osgeo.org/geos/%GEOS_ARCHIVE%"
+set "GEOS_CACHE_MARKER=%GEOS_INSTALL%\.geos-source-sha256"
+
+if exist "%GEOS_INSTALL%" (
+  if not exist "%GEOS_CACHE_MARKER%" exit /B 13
+  set "CACHED_GEOS_SHA256="
+  set /P CACHED_GEOS_SHA256=<"%GEOS_CACHE_MARKER%"
+  if /I not "!CACHED_GEOS_SHA256!"=="!GEOS_SHA256!" exit /B 13
+  if not exist "%GEOS_INSTALL%\include\geos_c.h" exit /B 13
+  if not exist "%GEOS_INSTALL%\bin\geos_c.dll" exit /B 13
+  echo Verified GEOS version=!GEOS_VERSION! url=!GEOS_URL! sha256=!CACHED_GEOS_SHA256!
   exit /B 0
 )
 
 echo Building %GEOS_INSTALL%
 
-curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
-7z x geos-%GEOS_VERSION%.tar.bz2
-7z x geos-%GEOS_VERSION%.tar
-cd geos-%GEOS_VERSION% || exit /B 1
+curl.exe --fail --location --proto "=https" --tlsv1.2 --retry 3 --output "%GEOS_ARCHIVE%" "%GEOS_URL%"
+if errorlevel 1 (
+  del /Q "%GEOS_ARCHIVE%" >NUL 2>&1
+  exit /B 11
+)
+
+set "ACTUAL_GEOS_SHA256="
+set "GEOS_HASH_FILE=%CD%\geos-%GEOS_VERSION%.sha256"
+powershell.exe -NoProfile -NonInteractive -Command "$ErrorActionPreference='Stop'; $sha=[System.Security.Cryptography.SHA256]::Create(); try { $stream=[System.IO.File]::OpenRead('%GEOS_ARCHIVE%'); try { $hash=-join ($sha.ComputeHash($stream) | ForEach-Object { $_.ToString('x2') }); Set-Content -NoNewline -Encoding ascii -LiteralPath '%GEOS_HASH_FILE%' -Value $hash } finally { $stream.Dispose() } } finally { $sha.Dispose() }"
+if errorlevel 1 (
+  del /Q "%GEOS_ARCHIVE%" >NUL 2>&1
+  exit /B 12
+)
+set /P ACTUAL_GEOS_SHA256=<"%GEOS_HASH_FILE%"
+del /Q "%GEOS_HASH_FILE%" >NUL 2>&1
+if not defined ACTUAL_GEOS_SHA256 (
+  del /Q "%GEOS_ARCHIVE%" >NUL 2>&1
+  exit /B 12
+)
+if /I not "!ACTUAL_GEOS_SHA256!"=="!GEOS_SHA256!" (
+  del /Q "%GEOS_ARCHIVE%" >NUL 2>&1
+  exit /B 12
+)
+echo Verified GEOS version=!GEOS_VERSION! url=!GEOS_URL! sha256=!ACTUAL_GEOS_SHA256!
+
+7z x "%GEOS_ARCHIVE%"
+if errorlevel 1 exit /B 14
+7z x "geos-%GEOS_VERSION%.tar"
+if errorlevel 1 exit /B 15
+cd "geos-%GEOS_VERSION%" || exit /B 16
 
 cmake -GNinja ^
   -D CMAKE_BUILD_TYPE=Release ^
@@ -34,3 +81,6 @@ IF %ERRORLEVEL% NEQ 0 exit /B 3
 
 cmake --install build
 IF %ERRORLEVEL% NEQ 0 exit /B 5
+
+> "%GEOS_CACHE_MARKER%" echo !GEOS_SHA256!
+if errorlevel 1 exit /B 6

--- a/ci/release_transaction.py
+++ b/ci/release_transaction.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import urllib.parse
+from dataclasses import dataclass
+
+
+HEX_OBJECT_ID = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+SAFE_ASSET_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+@-]*$")
+
+
+class ReleaseCommandError(RuntimeError):
+    pass
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class LocalAsset:
+    path: pathlib.Path
+    digest: str
+    size: int
+
+
+def local_assets(paths: list[str]) -> dict[str, LocalAsset]:
+    assets: dict[str, LocalAsset] = {}
+    for value in paths:
+        path = pathlib.Path(value)
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"{path}: regular release asset required")
+        resolved = path.resolve(strict=True)
+        name = resolved.name
+        if not SAFE_ASSET_NAME.fullmatch(name):
+            raise ValueError(f"{name}: GitHub-safe release asset name required")
+        if name in assets:
+            raise ValueError(f"duplicate local release asset: {name}")
+        assets[name] = LocalAsset(
+            path=resolved,
+            digest=sha256(resolved),
+            size=resolved.stat().st_size,
+        )
+    if not assets:
+        raise ValueError("at least one release asset is required")
+    return assets
+
+
+class GhReleaseClient:
+    def __init__(self, repository: str) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise ValueError("repository must be OWNER/REPO")
+        self.repository = repository
+
+    def _run(
+        self,
+        arguments: list[str],
+        *,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            arguments,
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise ReleaseCommandError(
+                f"{' '.join(arguments[:3])} failed: {detail}"
+            )
+        return completed
+
+    def _api_json(
+        self,
+        endpoint: str,
+        *,
+        method: str = "GET",
+        payload: dict[str, object] | None = None,
+        paginate: bool = False,
+    ) -> object:
+        command = [
+            "gh",
+            "api",
+            "--method",
+            method,
+            "-H",
+            "Accept: application/vnd.github+json",
+            endpoint,
+        ]
+        input_text = None
+        if payload is not None:
+            command.extend(["--input", "-"])
+            input_text = json.dumps(payload, separators=(",", ":"))
+        if paginate:
+            command.extend(["--paginate", "--slurp"])
+        output = self._run(command, input_text=input_text).stdout
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as error:
+            raise ReleaseCommandError(
+                f"GitHub API returned invalid JSON for {endpoint}: {error}"
+            ) from error
+
+    def _paged_list(self, endpoint: str) -> list[object]:
+        pages = self._api_json(endpoint, paginate=True)
+        if not isinstance(pages, list):
+            raise ReleaseCommandError("GitHub API pagination returned non-list")
+        flattened: list[object] = []
+        for page in pages:
+            if not isinstance(page, list):
+                raise ReleaseCommandError(
+                    "GitHub API pagination returned a non-list page"
+                )
+            flattened.extend(page)
+        return flattened
+
+    def get_release(self, tag: str) -> dict[str, object] | None:
+        releases = self._paged_list(
+            f"repos/{self.repository}/releases?per_page=100"
+        )
+        matches = [
+            release
+            for release in releases
+            if isinstance(release, dict) and release.get("tag_name") == tag
+        ]
+        if len(matches) > 1:
+            raise ReleaseCommandError(f"multiple releases found for tag {tag}")
+        if not matches:
+            return None
+        release_id = matches[0].get("id")
+        if not isinstance(release_id, int):
+            raise ReleaseCommandError("GitHub release has invalid id")
+        release = self._api_json(
+            f"repos/{self.repository}/releases/{release_id}"
+        )
+        if not isinstance(release, dict):
+            raise ReleaseCommandError("GitHub release response is not an object")
+        release["assets"] = self._paged_list(
+            f"repos/{self.repository}/releases/{release_id}/assets?per_page=100"
+        )
+        return release
+
+    def get_tag_target(self, tag: str) -> str:
+        encoded = urllib.parse.quote(tag, safe="")
+        value = self._api_json(
+            f"repos/{self.repository}/git/ref/tags/{encoded}"
+        )
+        if not isinstance(value, dict) or not isinstance(value.get("object"), dict):
+            raise ReleaseCommandError("GitHub tag reference response is invalid")
+        target = value["object"]
+        seen: set[str] = set()
+        for _ in range(8):
+            object_type = target.get("type")
+            object_id = target.get("sha")
+            if (
+                object_type not in {"commit", "tag"}
+                or not isinstance(object_id, str)
+                or not HEX_OBJECT_ID.fullmatch(object_id.lower())
+            ):
+                raise ReleaseCommandError("GitHub tag target is invalid")
+            object_id = object_id.lower()
+            if object_type == "commit":
+                return object_id
+            if object_id in seen:
+                raise ReleaseCommandError("GitHub tag target cycle detected")
+            seen.add(object_id)
+            annotated = self._api_json(
+                f"repos/{self.repository}/git/tags/{object_id}"
+            )
+            if (
+                not isinstance(annotated, dict)
+                or not isinstance(annotated.get("object"), dict)
+            ):
+                raise ReleaseCommandError(
+                    "GitHub annotated tag response is invalid"
+                )
+            target = annotated["object"]
+        raise ReleaseCommandError("GitHub tag target nesting is too deep")
+
+    def create_draft(self, tag: str, target: str) -> dict[str, object]:
+        created = self._api_json(
+            f"repos/{self.repository}/releases",
+            method="POST",
+            payload={
+                "tag_name": tag,
+                "target_commitish": target,
+                "name": tag,
+                "body": "",
+                "draft": True,
+                "prerelease": False,
+                "generate_release_notes": False,
+            },
+        )
+        if not isinstance(created, dict):
+            raise ReleaseCommandError("created GitHub release is invalid")
+        release = self.get_release(tag)
+        if release is None:
+            raise ReleaseCommandError("created GitHub release cannot be found")
+        return release
+
+    def delete_asset(self, asset_id: int) -> None:
+        self._run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "DELETE",
+                f"repos/{self.repository}/releases/assets/{asset_id}",
+                "--silent",
+            ]
+        )
+
+    def upload_asset(self, tag: str, path: pathlib.Path) -> None:
+        self._run(
+            [
+                "gh",
+                "release",
+                "upload",
+                tag,
+                str(path),
+                "--repo",
+                self.repository,
+            ]
+        )
+
+    def publish(self, release_id: int, tag: str) -> None:
+        value = self._api_json(
+            f"repos/{self.repository}/releases/{release_id}",
+            method="PATCH",
+            payload={
+                "tag_name": tag,
+                "name": tag,
+                "draft": False,
+                "prerelease": False,
+                "make_latest": "true",
+            },
+        )
+        if not isinstance(value, dict):
+            raise ReleaseCommandError("published GitHub release is invalid")
+
+
+def release_id(release: dict[str, object]) -> int:
+    value = release.get("id")
+    if not isinstance(value, int):
+        raise ValueError("GitHub release has invalid id")
+    return value
+
+
+def verify_release_identity(
+    release: dict[str, object],
+    tag: str,
+) -> None:
+    if release.get("tag_name") != tag:
+        raise ValueError("GitHub release tag identity mismatch")
+    if not isinstance(release.get("draft"), bool):
+        raise ValueError("GitHub release has invalid draft state")
+    if release.get("prerelease") is not False:
+        raise ValueError("GitHub release must not be a prerelease")
+    release_id(release)
+
+
+def asset_map(release: dict[str, object]) -> dict[str, dict[str, object]]:
+    values = release.get("assets")
+    if not isinstance(values, list):
+        raise ValueError("GitHub release has invalid assets")
+    assets: dict[str, dict[str, object]] = {}
+    for value in values:
+        if not isinstance(value, dict):
+            raise ValueError("GitHub release has invalid asset")
+        name = value.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("GitHub release asset has invalid name")
+        if name in assets:
+            raise ValueError(f"duplicate GitHub release asset: {name}")
+        assets[name] = value
+    return assets
+
+
+def asset_matches(asset: dict[str, object], local: LocalAsset) -> bool:
+    return (
+        asset.get("state") == "uploaded"
+        and asset.get("size") == local.size
+        and asset.get("digest") == f"sha256:{local.digest}"
+    )
+
+
+def verify_exact_assets(
+    release: dict[str, object],
+    expected: dict[str, LocalAsset],
+) -> None:
+    actual = asset_map(release)
+    if actual.keys() != expected.keys():
+        missing = sorted(expected.keys() - actual.keys())
+        extra = sorted(actual.keys() - expected.keys())
+        raise ValueError(
+            "GitHub release asset set mismatch "
+            f"(missing={missing}, extra={extra})"
+        )
+    mismatched = sorted(
+        name
+        for name, local in expected.items()
+        if not asset_matches(actual[name], local)
+    )
+    if mismatched:
+        raise ValueError(
+            f"GitHub release asset digest/state mismatch: {mismatched}"
+        )
+
+
+def run_transaction(
+    client: GhReleaseClient,
+    tag: str,
+    target: str,
+    paths: list[str],
+) -> str:
+    target = target.lower()
+    if not HEX_OBJECT_ID.fullmatch(target):
+        raise ValueError("target must be a full Git object id")
+    if client.get_tag_target(tag) != target:
+        raise ValueError("GitHub tag does not resolve to the expected target")
+    expected = local_assets(paths)
+
+    release = client.get_release(tag)
+    if release is None:
+        try:
+            release = client.create_draft(tag, target)
+        except ReleaseCommandError:
+            release = client.get_release(tag)
+            if release is None:
+                raise
+    verify_release_identity(release, tag)
+
+    if release["draft"] is False:
+        verify_exact_assets(release, expected)
+        return "already-published"
+
+    existing = asset_map(release)
+    extras = sorted(existing.keys() - expected.keys())
+    if extras:
+        raise ValueError(f"unexpected GitHub release assets: {extras}")
+
+    for name, local in expected.items():
+        current = existing.get(name)
+        if current is not None and asset_matches(current, local):
+            continue
+        if current is not None:
+            asset_id = current.get("id")
+            if not isinstance(asset_id, int):
+                raise ValueError(f"{name}: GitHub release asset has invalid id")
+            client.delete_asset(asset_id)
+        if sha256(local.path) != local.digest:
+            raise ValueError(f"{name}: local asset changed during transaction")
+        client.upload_asset(tag, local.path)
+        release = client.get_release(tag)
+        if release is None:
+            raise ValueError("GitHub release disappeared during asset upload")
+        verify_release_identity(release, tag)
+        if release["draft"] is False:
+            verify_exact_assets(release, expected)
+            return "already-published"
+        existing = asset_map(release)
+        uploaded = existing.get(name)
+        if uploaded is None or not asset_matches(uploaded, local):
+            raise ValueError(f"{name}: uploaded GitHub release asset not verified")
+
+    release = client.get_release(tag)
+    if release is None:
+        raise ValueError("GitHub release disappeared before publication")
+    verify_release_identity(release, tag)
+    verify_exact_assets(release, expected)
+    if release["draft"] is False:
+        return "already-published"
+
+    client.publish(release_id(release), tag)
+    completed = client.get_release(tag)
+    if completed is None:
+        raise ValueError("GitHub release disappeared after publication")
+    verify_release_identity(completed, tag)
+    if completed["draft"] is not False:
+        raise ValueError("GitHub release remained a draft after publication")
+    verify_exact_assets(completed, expected)
+    return "published"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--asset", nargs="+", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = run_transaction(
+        GhReleaseClient(args.repository),
+        args.tag,
+        args.target,
+        args.asset,
+    )
+    print(f"release-transaction: {result} {args.tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, ReleaseCommandError) as error:
+        print(f"release-transaction: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ci/tests/test_arm64_python_runtime.py
+++ b/ci/tests/test_arm64_python_runtime.py
@@ -1,0 +1,807 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ci"))
+
+import arm64_python_runtime as apr
+
+
+ROOT_INDEX = """
+<a href="3.13.4/">3.13.4/</a>
+<a href="3.13.5/">3.13.5/</a>
+<a href="3.14.7/">3.14.7/</a>
+<a href="3.14.8rc1/">3.14.8rc1/</a>
+<a href="3.15.0/">3.15.0/</a>
+""".strip()
+
+PRERELEASE_ROOT_INDEX = '<a href="3.15.0rc1/">3.15.0rc1/</a>'
+PYTHON_315_DIRECTORY = '<a href="windows-3.15.0rc1.json">windows-3.15.0rc1.json</a>'
+
+
+def write_zip_member(
+    payload: zipfile.ZipFile, member_name: str, data: bytes
+) -> None:
+    member = zipfile.ZipInfo("placeholder")
+    member.filename = member_name
+    payload.writestr(member, data)
+
+
+def zip_member(member_name: str) -> zipfile.ZipInfo:
+    member = zipfile.ZipInfo("placeholder")
+    member.filename = member_name
+    return member
+
+
+def make_manifest(*, entry_id: str, download_url: str, executable: str, sort_version: str = "3.14.7") -> dict[str, object]:
+    return {
+        "versions": [
+            {
+                "schema": 1,
+                "id": entry_id,
+                "sort-version": sort_version,
+                "company": "PythonCore",
+                "tag": "tag",
+                "install-for": ["x"],
+                "alias": [],
+                "display-name": "display",
+                "executable": executable,
+                "url": download_url,
+                "hash": {"sha256": "a" * 64},
+            }
+        ]
+    }
+
+
+def mock_python_org(monkeypatch, mapping):
+    def fake_fetch_text(url):
+        if url not in mapping:
+            raise apr.urllib.error.HTTPError(url, 404, "missing", {}, None)
+        return mapping[url]
+
+    monkeypatch.setattr(apr, "fetch_text", fake_fetch_text)
+    monkeypatch.setattr(apr, "fetch_json", lambda url: json.loads(fake_fetch_text(url)))
+
+
+def test_parse_versions_prefers_stable_for_non_prerelease_rows():
+    spec = apr.RuntimeSpec("cp314", "3.14", False, False)
+
+    releases = apr.parse_versions(ROOT_INDEX, spec)
+
+    assert releases == ["3.14.7"]
+
+
+def test_parse_versions_allows_prereleases_only_when_configured():
+    spec = apr.RuntimeSpec("cp315", "3.15", False, True)
+
+    releases = apr.parse_versions(PRERELEASE_ROOT_INDEX, spec)
+
+    assert releases == ["3.15.0rc1"]
+
+
+def test_parse_prerelease_manifest_versions_filters_and_orders_candidates():
+    directory_index = """
+    <a href="windows-3.15.0rc1.json">rc1</a>
+    <a href="windows-3.15.0rc2.json">rc2</a>
+    <a href="windows-3.15.0.json">stable</a>
+    <a href="windows-3.15.1a1.json">other patch</a>
+    <a href="windows-3.14.9rc1.json">other series</a>
+    <a href="windows-3.15.0rc2-extra.json">malformed</a>
+    <a href="linux-3.15.0rc3.json">other platform</a>
+    """.strip()
+
+    releases = apr.parse_prerelease_manifest_versions(
+        directory_index,
+        apr.RuntimeSpec("cp315", "3.15", False, True),
+        "3.15.0",
+    )
+
+    assert releases == ["3.15.0rc2", "3.15.0rc1"]
+
+
+@pytest.mark.parametrize(
+    ("label", "free_threaded", "entry_id", "executable"),
+    [
+        ("cp315", False, "pythoncore-3.15-arm64", "./python3.15.exe"),
+        ("cp315t", True, "pythoncore-3.15t-arm64", "./python3.15t.exe"),
+    ],
+)
+def test_discover_runtime_finds_315_prerelease_in_base_version_directory(
+    monkeypatch, label, free_threaded, entry_id, executable
+):
+    manifest_location = apr.prerelease_manifest_url("3.15.0", "3.15.0rc1")
+    mapping = {
+        apr.ROOT_INDEX_URL: ROOT_INDEX,
+        f"{apr.PYTHON_FTP_ROOT}/3.15.0/": PYTHON_315_DIRECTORY,
+        manifest_location: json.dumps(
+            make_manifest(
+                entry_id=entry_id,
+                download_url=f"https://www.python.org/ftp/python/3.15.0/python-{label}-arm64.zip",
+                executable=executable,
+                sort_version="3.15.0rc1",
+            )
+        ),
+    }
+    mock_python_org(monkeypatch, mapping)
+
+    record = apr.discover_runtime(
+        apr.RuntimeSpec(label, "3.15", free_threaded, True)
+    )
+
+    assert record["available"] is True
+    assert record["release"] == "3.15.0rc1"
+    assert record["manifest_url"] == manifest_location
+    assert record["executable"] == executable
+
+
+def test_discover_runtime_uses_newest_compatible_prerelease_manifest(monkeypatch):
+    directory_index = """
+    <a href="windows-3.15.0rc1.json">rc1</a>
+    <a href="windows-3.15.0rc2.json">rc2</a>
+    <a href="windows-3.15.1a1.json">other patch</a>
+    """.strip()
+    rc2_location = apr.prerelease_manifest_url("3.15.0", "3.15.0rc2")
+    mapping = {
+        apr.ROOT_INDEX_URL: ROOT_INDEX,
+        f"{apr.PYTHON_FTP_ROOT}/3.15.0/": directory_index,
+        rc2_location: json.dumps(
+            make_manifest(
+                entry_id="pythoncore-3.15-arm64",
+                download_url="https://www.python.org/ftp/python/3.15.0/python-3.15.0rc2-arm64.zip",
+                executable="./python3.15.exe",
+                sort_version="3.15.0rc2",
+            )
+        ),
+    }
+    mock_python_org(monkeypatch, mapping)
+
+    record = apr.discover_runtime(apr.RuntimeSpec("cp315", "3.15", False, True))
+
+    assert record["release"] == "3.15.0rc2"
+    assert record["manifest_url"] == rc2_location
+
+
+def test_discover_runtime_prefers_exact_stable_manifest(monkeypatch):
+    stable_location = apr.manifest_url("3.15.0")
+    mapping = {
+        apr.ROOT_INDEX_URL: ROOT_INDEX,
+        stable_location: json.dumps(
+            make_manifest(
+                entry_id="pythoncore-3.15-arm64",
+                download_url="https://www.python.org/ftp/python/3.15.0/python-3.15.0-arm64.zip",
+                executable="./python3.15.exe",
+                sort_version="3.15.0",
+            )
+        ),
+    }
+    mock_python_org(monkeypatch, mapping)
+
+    record = apr.discover_runtime(apr.RuntimeSpec("cp315", "3.15", False, True))
+
+    assert record["release"] == "3.15.0"
+    assert record["manifest_url"] == stable_location
+
+
+def test_discover_runtime_rejects_malformed_prerelease_manifest(monkeypatch):
+    manifest_location = apr.prerelease_manifest_url("3.15.0", "3.15.0rc1")
+    manifest = make_manifest(
+        entry_id="pythoncore-3.15-arm64",
+        download_url="https://www.python.org/ftp/python/3.15.0/python-3.15.0rc1-arm64.zip",
+        executable="./python3.15.exe",
+        sort_version="3.15.0rc1",
+    )
+    manifest["versions"][0]["unexpected"] = True
+    mapping = {
+        apr.ROOT_INDEX_URL: ROOT_INDEX,
+        f"{apr.PYTHON_FTP_ROOT}/3.15.0/": PYTHON_315_DIRECTORY,
+        manifest_location: json.dumps(manifest),
+    }
+    mock_python_org(monkeypatch, mapping)
+
+    with pytest.raises(ValueError, match="unexpected manifest key set"):
+        apr.discover_runtime(apr.RuntimeSpec("cp315", "3.15", False, True))
+
+
+def test_discover_runtime_finds_latest_free_threaded_manifest(monkeypatch):
+    mapping = {
+        apr.ROOT_INDEX_URL: ROOT_INDEX,
+        apr.manifest_url("3.14.7"): json.dumps(
+            make_manifest(
+                entry_id="pythoncore-3.14t-arm64",
+                download_url="https://www.python.org/ftp/python/3.14.7/python-3.14.7t-arm64.zip",
+                executable="./python3.14t.exe",
+            )
+        ),
+    }
+
+    monkeypatch.setattr(apr, "fetch_text", lambda url: mapping[url])
+    monkeypatch.setattr(apr, "fetch_json", lambda url: json.loads(mapping[url]))
+
+    record = apr.discover_runtime(apr.RuntimeSpec("cp314t", "3.14", True, False))
+
+    assert record["available"] is True
+    assert record["release"] == "3.14.7"
+    assert record["download_url"].endswith("python-3.14.7t-arm64.zip")
+    assert record["executable"] == "./python3.14t.exe"
+    assert record["allow_prereleases"] is False
+
+
+def test_discover_runtime_marks_unavailable_when_manifest_missing(monkeypatch):
+    monkeypatch.setattr(apr, "fetch_text", lambda url: ROOT_INDEX)
+
+    def fake_fetch_json(url):
+        raise apr.urllib.error.HTTPError(url, 404, "missing", {}, None)
+
+    monkeypatch.setattr(apr, "fetch_json", fake_fetch_json)
+
+    record = apr.discover_runtime(apr.RuntimeSpec("cp315t", "3.15", True, True))
+
+    assert record["available"] is False
+    assert record["allow_prereleases"] is True
+    assert "no python.org Windows ARM64 manifest entry found" in record["reason"]
+
+
+def test_install_runtime_extracts_zip_and_bootstraps_pip(tmp_path, monkeypatch):
+    runtime_zip = tmp_path / "python-3.13.5-arm64.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("bin/python.exe", b"stub")
+
+    plan = {
+        "label": "cp313",
+        "series": "3.13",
+        "free_threaded": False,
+        "allow_prereleases": False,
+        "available": True,
+        "release": "3.13.5",
+        "manifest_url": apr.manifest_url("3.13.5"),
+        "download_url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.zip",
+        "sha256": apr.sha256_file(runtime_zip),
+        "executable": ".\\bin/python.exe",
+        "reason": None,
+    }
+
+    monkeypatch.setattr(apr, "discover_runtime", lambda spec: plan)
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return runtime_zip.read_bytes()
+
+    monkeypatch.setattr(apr.urllib.request, "urlopen", lambda url, timeout=60: FakeResponse())
+    calls = []
+    monkeypatch.setattr(apr.subprocess, "check_call", lambda command: calls.append(command))
+
+    record = apr.install_runtime(apr.RuntimeSpec("cp313", "3.13", False, False), tmp_path / "runtime-root")
+
+    assert record["available"] is True
+    assert pathlib.Path(record["python_executable"]).exists()
+    assert calls == [
+        [record["python_executable"], "-m", "ensurepip", "--upgrade"],
+        [record["python_executable"], "-m", "pip", "install", "--upgrade", "pip"],
+    ]
+
+
+def test_safe_extract_zip_extracts_valid_archive(tmp_path):
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("bin/", b"")
+        payload.writestr("bin/python.exe", b"stub")
+        payload.writestr("Lib/site.py", b"site")
+
+    target = tmp_path / "target"
+    with zipfile.ZipFile(runtime_zip) as payload:
+        apr.safe_extract_zip(payload, target)
+
+    assert (target / "bin" / "python.exe").read_bytes() == b"stub"
+    assert (target / "Lib" / "site.py").read_bytes() == b"site"
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escaped.txt",
+        "nested/../../escaped.txt",
+        "..\\escaped.txt",
+        "nested\\..\\..\\escaped.txt",
+        "/absolute.txt",
+        "\\absolute.txt",
+        "C:/drive.txt",
+        "C:\\drive.txt",
+        "\\\\server\\share\\unc.txt",
+        "nested/.. /escaped.txt",
+    ],
+)
+def test_safe_extract_zip_rejects_unsafe_paths_without_writes(
+    tmp_path, member_name
+):
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("valid-before-malicious.txt", b"must not be written")
+        payload.writestr(member_name, b"escape")
+
+    target = tmp_path / "target"
+    outside = tmp_path / "escaped.txt"
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="unsafe"):
+            apr.safe_extract_zip(payload, target)
+
+    assert not target.exists()
+    assert not outside.exists()
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "CONIN$",
+        "conin$.txt",
+        "nested/CoNiN$ .cfg",
+        "CONOUT$",
+        "conout$.log",
+        "nested/CoNoUt$ .cfg",
+        "COM¹",
+        "com².txt",
+        "nested/CoM³ .cfg",
+        "LPT¹",
+        "lpt².txt",
+        "nested/LpT³ .cfg",
+    ],
+)
+def test_safe_extract_zip_rejects_windows_device_variants_without_writes(
+    tmp_path, member_name
+):
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("valid-before-device.txt", b"must not be written")
+        payload.writestr(member_name, b"device")
+
+    target = tmp_path / "target"
+    outside = tmp_path / "outside.txt"
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="unsafe Windows device"):
+            apr.safe_extract_zip(payload, target)
+
+    assert not target.exists()
+    assert not outside.exists()
+
+
+@pytest.mark.parametrize(
+    ("member_name", "error_match"),
+    [
+        *[
+            (f"nested/bad{chr(codepoint)}name", "control character")
+            for codepoint in range(0x20)
+        ],
+        *[
+            (f"nested/bad{character}name", "Windows character")
+            for character in '<>"|?*'
+        ],
+        ("nested/file.txt:stream", "drive or stream"),
+        (f"nested/{'a' * 256}", "overlong Windows"),
+        (f"nested/{'😀' * 128}", "overlong Windows"),
+    ],
+    ids=[
+        *[f"control-u+{codepoint:04x}" for codepoint in range(0x20)],
+        "less-than",
+        "greater-than",
+        "double-quote",
+        "pipe",
+        "question-mark",
+        "asterisk",
+        "ads-colon",
+        "256-ascii-units",
+        "256-supplementary-units",
+    ],
+)
+def test_safe_extract_zip_rejects_windows_invalid_components_without_writes(
+    tmp_path, member_name, error_match
+):
+    valid_member = zipfile.ZipInfo("valid-before-invalid.txt")
+    invalid_member = zip_member(member_name)
+
+    class InvalidPayload:
+        def infolist(self):
+            return [valid_member, invalid_member]
+
+        def open(self, member):
+            raise AssertionError(f"unexpected extraction of {member.filename}")
+
+    target = tmp_path / "target"
+    with pytest.raises(ValueError, match=error_match):
+        apr.safe_extract_zip(InvalidPayload(), target)
+
+    assert not target.exists()
+    assert not (target / valid_member.filename).exists()
+
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        "a" * 255,
+        ("😀" * 127) + "a",
+    ],
+    ids=["255-ascii-units", "255-mixed-supplementary-units"],
+)
+def test_validated_zip_member_accepts_255_utf16_unit_components(
+    tmp_path, component
+):
+    target = tmp_path / "target"
+    member = zip_member(f"nested/{component}/python.exe")
+
+    parts, is_directory = apr.validated_zip_member(target, member)
+
+    assert parts == ("nested", component, "python.exe")
+    assert is_directory is False
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "conflicting_members",
+    [
+        ("pkg/module.py", "PKG/MODULE.PY"),
+        ("pkg/module.py", "pkg\\module.py"),
+        ("pkg/module.py", "pkg/./module.py"),
+        ("pkg/", "PKG"),
+        ("pkg", "PKG/"),
+    ],
+)
+def test_safe_extract_zip_rejects_destination_collisions_without_writes(
+    tmp_path, conflicting_members
+):
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("valid-before-collision.txt", b"must not be written")
+        for member_name in conflicting_members:
+            write_zip_member(payload, member_name, b"collision")
+
+    target = tmp_path / "target"
+    outside = tmp_path / "outside.txt"
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(
+            ValueError, match="unsafe (duplicate|file/directory) ZIP member"
+        ):
+            apr.safe_extract_zip(payload, target)
+
+    assert not target.exists()
+    assert not outside.exists()
+
+
+@pytest.mark.parametrize(
+    "conflicting_members",
+    [
+        ("pkg", "pkg/child.py"),
+        ("pkg/child.py", "pkg"),
+        ("PKG", "pkg/child.py"),
+        ("pkg/child.py", "PKG"),
+    ],
+)
+def test_safe_extract_zip_rejects_file_ancestor_without_writes(
+    tmp_path, conflicting_members
+):
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("valid-before-collision.txt", b"must not be written")
+        for member_name in conflicting_members:
+            write_zip_member(payload, member_name, b"collision")
+
+    target = tmp_path / "target"
+    outside = tmp_path / "outside.txt"
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="unsafe ZIP member path beneath file"):
+            apr.safe_extract_zip(payload, target)
+
+    assert not target.exists()
+    assert not outside.exists()
+
+
+@pytest.mark.parametrize(
+    ("create_system", "external_attr"),
+    [
+        (3, (stat.S_IFLNK | 0o777) << 16),
+        (0, apr.WINDOWS_REPARSE_POINT),
+    ],
+)
+def test_safe_extract_zip_rejects_link_entries(
+    tmp_path, create_system, external_attr
+):
+    runtime_zip = tmp_path / "runtime.zip"
+    link = zipfile.ZipInfo("link")
+    link.create_system = create_system
+    link.external_attr = external_attr
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr(link, "../escaped.txt")
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="link or special|reparse-point"):
+            apr.safe_extract_zip(payload, tmp_path / "target")
+
+    assert not (tmp_path / "target").exists()
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_safe_extract_zip_rejects_existing_symlink_escape(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    try:
+        os.symlink(outside, target / "redirect", target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("redirect/escaped.txt", b"escape")
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(
+            ValueError, match="unsafe normalized|link or reparse point"
+        ):
+            apr.safe_extract_zip(payload, target)
+
+    assert not (outside / "escaped.txt").exists()
+
+
+def test_safe_extract_zip_rejects_target_ancestor_symlink_without_writes(
+    tmp_path,
+):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = tmp_path / "target-link"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("python.exe", b"must not be written")
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="target path contains a link"):
+            apr.safe_extract_zip(payload, link / "runtime")
+
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
+def test_safe_extract_zip_rejects_target_ancestor_junction_without_writes(
+    tmp_path,
+):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    junction = tmp_path / "target-junction"
+    result = subprocess.run(
+        [
+            os.environ.get("COMSPEC", "cmd.exe"),
+            "/c",
+            "mklink",
+            "/J",
+            str(junction),
+            str(outside),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        pytest.skip(f"directory junctions unavailable: {result.stderr.strip()}")
+
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("python.exe", b"must not be written")
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match="target path contains a link"):
+            apr.safe_extract_zip(payload, junction / "runtime")
+
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.parametrize("valid_member_first", [True, False])
+@pytest.mark.parametrize(
+    ("existing_kind", "conflicting_member", "error_match"),
+    [
+        (
+            "file",
+            "conflict/child.py",
+            "destination ancestor is not a directory",
+        ),
+        (
+            "directory",
+            "conflict",
+            "file conflicts with an existing directory",
+        ),
+    ],
+)
+def test_safe_extract_zip_preflights_existing_conflicts_without_partial_writes(
+    tmp_path,
+    valid_member_first,
+    existing_kind,
+    conflicting_member,
+    error_match,
+):
+    target = tmp_path / "target"
+    target.mkdir()
+    conflict = target / "conflict"
+    if existing_kind == "file":
+        conflict.write_bytes(b"existing")
+    else:
+        conflict.mkdir()
+
+    members = [
+        ("valid.txt", b"must not be written"),
+        (conflicting_member, b"conflict"),
+    ]
+    if not valid_member_first:
+        members.reverse()
+
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        for member_name, data in members:
+            payload.writestr(member_name, data)
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(ValueError, match=error_match):
+            apr.safe_extract_zip(payload, target)
+
+    assert not (target / "valid.txt").exists()
+    if existing_kind == "file":
+        assert conflict.read_bytes() == b"existing"
+    else:
+        assert list(conflict.iterdir()) == []
+
+
+def test_safe_extract_zip_preflight_preserves_existing_file_on_later_conflict(
+    tmp_path,
+):
+    target = tmp_path / "target"
+    target.mkdir()
+    existing = target / "existing.txt"
+    existing.write_bytes(b"original")
+    (target / "blocked").write_bytes(b"not a directory")
+
+    runtime_zip = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("existing.txt", b"replacement")
+        payload.writestr("blocked/child.txt", b"must not be written")
+
+    with zipfile.ZipFile(runtime_zip) as payload:
+        with pytest.raises(
+            ValueError, match="destination ancestor is not a directory"
+        ):
+            apr.safe_extract_zip(payload, target)
+
+    assert existing.read_bytes() == b"original"
+    assert (target / "blocked").read_bytes() == b"not a directory"
+
+
+@pytest.mark.parametrize("executable", ["C:/python.exe", "C:\\python.exe", "\\\\server\\share\\python.exe", "..\\python.exe"])
+def test_install_runtime_rejects_escape_paths(tmp_path, monkeypatch, executable):
+    runtime_zip = tmp_path / "python-3.13.5-arm64.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("python.exe", b"stub")
+
+    plan = {
+        "label": "cp313",
+        "series": "3.13",
+        "free_threaded": False,
+        "allow_prereleases": False,
+        "available": True,
+        "release": "3.13.5",
+        "manifest_url": apr.manifest_url("3.13.5"),
+        "download_url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.zip",
+        "sha256": apr.sha256_file(runtime_zip),
+        "executable": executable,
+        "reason": None,
+    }
+
+    monkeypatch.setattr(apr, "discover_runtime", lambda spec: plan)
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return runtime_zip.read_bytes()
+
+    monkeypatch.setattr(apr.urllib.request, "urlopen", lambda url, timeout=60: FakeResponse())
+
+    with pytest.raises(ValueError, match="runtime executable path"):
+        apr.install_runtime(apr.RuntimeSpec("cp313", "3.13", False, False), tmp_path / "runtime-root")
+
+
+def test_install_runtime_normalizes_mixed_separators(tmp_path, monkeypatch):
+    runtime_zip = tmp_path / "python-3.13.5-arm64.zip"
+    with zipfile.ZipFile(runtime_zip, "w") as payload:
+        payload.writestr("bin/python/python.exe", b"stub")
+
+    plan = {
+        "label": "cp313",
+        "series": "3.13",
+        "free_threaded": False,
+        "allow_prereleases": False,
+        "available": True,
+        "release": "3.13.5",
+        "manifest_url": apr.manifest_url("3.13.5"),
+        "download_url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.zip",
+        "sha256": apr.sha256_file(runtime_zip),
+        "executable": ".\\bin/python\\python.exe",
+        "reason": None,
+    }
+
+    monkeypatch.setattr(apr, "discover_runtime", lambda spec: plan)
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return runtime_zip.read_bytes()
+
+    monkeypatch.setattr(apr.urllib.request, "urlopen", lambda url, timeout=60: FakeResponse())
+    monkeypatch.setattr(apr.subprocess, "check_call", lambda command: None)
+
+    record = apr.install_runtime(apr.RuntimeSpec("cp313", "3.13", False, False), tmp_path / "runtime-root")
+
+    assert pathlib.Path(record["python_executable"]).name == "python.exe"
+    assert pathlib.Path(record["python_executable"]).parts[-3:] == ("bin", "python", "python.exe")
+
+
+def test_selected_specs_override_allow_prereleases():
+    specs = apr.selected_specs(["cp315", "cp314"], allow_prereleases=True)
+
+    assert [spec.allow_prereleases for spec in specs] == [True, True]
+
+
+def test_install_command_returns_one_for_unavailable_runtime(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        apr,
+        "install_runtime",
+        lambda spec, root: {
+            "label": spec.label,
+            "series": spec.series,
+            "free_threaded": spec.free_threaded,
+            "allow_prereleases": spec.allow_prereleases,
+            "available": False,
+            "release": None,
+            "manifest_url": None,
+            "download_url": None,
+            "sha256": None,
+            "executable": None,
+            "reason": "missing",
+        },
+    )
+
+    code = apr.install_command(
+        SimpleNamespace(
+            label="cp315t",
+            allow_prereleases="true",
+            root=str(tmp_path / "runtimes"),
+            output=str(tmp_path / "runtime.json"),
+        )
+    )
+
+    assert code == 1
+    runtime = json.loads((tmp_path / "runtime.json").read_text(encoding="utf-8"))["runtime"]
+    assert runtime["available"] is False
+    assert runtime["allow_prereleases"] is True

--- a/ci/tests/test_install_geos.py
+++ b/ci/tests/test_install_geos.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.request
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ci" / "install_geos.cmd"
+REAL_GEOS_SHA256 = "df2c50503295f325e7c8d7b783aca8ba4773919cde984193850cf9e361dfd28c"
+DOWNLOAD_OSGEO_TEST_ENV = "SHAPELY_TEST_DOWNLOAD_OSGEO"
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="install_geos.cmd tests require Windows",
+)
+
+
+def _run_download_osgeo_test() -> bool:
+    return os.environ.get(DOWNLOAD_OSGEO_TEST_ENV, "").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _hash_command() -> str:
+    prefix = 'powershell.exe -NoProfile -NonInteractive -Command "'
+    for line in SCRIPT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix) and "SHA256]::Create()" in line:
+            return line.removeprefix(prefix).removesuffix('"')
+    raise AssertionError("SHA-256 PowerShell command not found")
+
+
+def run_install_geos(
+    cwd: pathlib.Path, geos_install: pathlib.Path, geos_sha256: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GEOS_INSTALL"] = str(geos_install)
+    env["GEOS_VERSION"] = "3.13.1"
+    env["GEOS_SHA256"] = geos_sha256
+    env["PATH"] = str(cwd) + os.pathsep + env["PATH"]
+    return subprocess.run(
+        ["cmd.exe", "/d", "/c", "call", str(SCRIPT)],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_install_geos_uses_verified_cache(tmp_path):
+    geos_install = tmp_path / "install"
+    (geos_install / "include").mkdir(parents=True)
+    (geos_install / "bin").mkdir()
+    (geos_install / "include" / "geos_c.h").write_text("", encoding="utf-8")
+    (geos_install / "bin" / "geos_c.dll").write_text("", encoding="utf-8")
+    (geos_install / ".geos-source-sha256").write_text(REAL_GEOS_SHA256, encoding="utf-8")
+
+    result = run_install_geos(tmp_path, geos_install, REAL_GEOS_SHA256)
+
+    assert result.returncode == 0
+    assert "Verified GEOS version=3.13.1" in result.stdout
+    assert "https://download.osgeo.org/geos/geos-3.13.1.tar.bz2" in result.stdout
+
+
+@pytest.mark.parametrize("marker", [None, "not-a-sha256", "f" * 64])
+def test_install_geos_rejects_invalid_cache_marker(tmp_path, marker):
+    geos_install = tmp_path / "install"
+    (geos_install / "include").mkdir(parents=True)
+    (geos_install / "bin").mkdir()
+    (geos_install / "include" / "geos_c.h").write_text("", encoding="utf-8")
+    (geos_install / "bin" / "geos_c.dll").write_text("", encoding="utf-8")
+    if marker is not None:
+        (geos_install / ".geos-source-sha256").write_text(marker, encoding="utf-8")
+
+    result = run_install_geos(tmp_path, geos_install, REAL_GEOS_SHA256)
+
+    assert result.returncode == 13
+
+
+def test_install_geos_hash_file_is_cmd_compatible(tmp_path):
+    archive = tmp_path / "archive.bin"
+    hash_file = tmp_path / "archive.sha256"
+    archive.write_bytes(b"local GEOS archive fixture")
+    expected = hashlib.sha256(archive.read_bytes()).hexdigest()
+    command = (
+        _hash_command()
+        .replace("%GEOS_ARCHIVE%", archive.name)
+        .replace("%GEOS_HASH_FILE%", str(hash_file))
+    )
+
+    result = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", command],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    raw_hash = hash_file.read_bytes()
+    assert raw_hash == expected.encode("ascii")
+    assert len(raw_hash) == 64
+    assert b"\0" not in raw_hash
+    assert not raw_hash.startswith((b"\xef\xbb\xbf", b"\xff\xfe", b"\xfe\xff"))
+
+    readback_script = tmp_path / "readback.cmd"
+    readback_script.write_text(
+        "@echo off\n"
+        "setlocal EnableDelayedExpansion\n"
+        f'set /P ACTUAL_GEOS_SHA256=<"{hash_file}"\n'
+        "echo(!ACTUAL_GEOS_SHA256!\n",
+        encoding="ascii",
+    )
+    readback = subprocess.run(
+        ["cmd.exe", "/d", "/c", str(readback_script)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert readback.returncode == 0
+    assert readback.stdout.strip() == expected
+
+
+@pytest.mark.skipif(
+    not _run_download_osgeo_test(),
+    reason=f"set {DOWNLOAD_OSGEO_TEST_ENV} to run the download.osgeo.org network test",
+)
+def test_install_geos_rejects_bad_hash_before_extraction(tmp_path):
+    geos_install = tmp_path / "install"
+    result = run_install_geos(tmp_path, geos_install, "0" * 64)
+
+    assert result.returncode == 12
+    assert not (tmp_path / "geos-3.13.1.tar.bz2").exists()
+    assert not (tmp_path / "geos-3.13.1.tar").exists()
+    assert not (tmp_path / "geos-3.13.1").exists()
+    assert not geos_install.exists()
+    assert not (geos_install / ".geos-source-sha256").exists()
+
+
+@pytest.mark.skipif(
+    not _run_download_osgeo_test(),
+    reason=f"set {DOWNLOAD_OSGEO_TEST_ENV} to run the download.osgeo.org network test",
+)
+def test_geos_sha256_literal_matches_official_archive(tmp_path):
+    archive = tmp_path / "geos-3.13.1.tar.bz2"
+    with urllib.request.urlopen("https://download.osgeo.org/geos/geos-3.13.1.tar.bz2", timeout=30) as response:
+        archive.write_bytes(response.read())
+
+    actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    assert actual == REAL_GEOS_SHA256

--- a/ci/tests/test_release_transaction.py
+++ b/ci/tests/test_release_transaction.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import copy
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ci"))
+
+import release_transaction as rt
+
+
+TARGET = "a" * 40
+TAG = "2.1.2"
+
+
+class FakeClient:
+    def __init__(
+        self,
+        release: dict[str, object] | None = None,
+        *,
+        target: str = TARGET,
+    ) -> None:
+        self.release = copy.deepcopy(release)
+        self.target = target
+        self.calls: list[tuple[object, ...]] = []
+        self.next_asset_id = 10
+        self.fail_upload = False
+        self.fail_publish = False
+
+    def get_tag_target(self, tag: str) -> str:
+        self.calls.append(("get_tag_target", tag))
+        return self.target
+
+    def get_release(self, tag: str) -> dict[str, object] | None:
+        self.calls.append(("get_release", tag))
+        return copy.deepcopy(self.release)
+
+    def create_draft(self, tag: str, target: str) -> dict[str, object]:
+        self.calls.append(("create_draft", tag, target))
+        self.release = make_release(draft=True)
+        return copy.deepcopy(self.release)
+
+    def delete_asset(self, asset_id: int) -> None:
+        self.calls.append(("delete_asset", asset_id))
+        self.release["assets"] = [
+            asset
+            for asset in self.release["assets"]
+            if asset["id"] != asset_id
+        ]
+
+    def upload_asset(self, tag: str, path: pathlib.Path) -> None:
+        self.calls.append(("upload_asset", tag, path.name))
+        if self.fail_upload:
+            raise rt.ReleaseCommandError("upload failed")
+        self.release["assets"].append(
+            make_asset(path, asset_id=self.next_asset_id)
+        )
+        self.next_asset_id += 1
+
+    def publish(self, release_id: int, tag: str) -> None:
+        self.calls.append(("publish", release_id, tag))
+        if self.fail_publish:
+            raise rt.ReleaseCommandError("publish failed")
+        self.release["draft"] = False
+
+
+def make_release(
+    *,
+    draft: bool,
+    assets: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": 1,
+        "tag_name": TAG,
+        "draft": draft,
+        "prerelease": False,
+        "assets": [] if assets is None else assets,
+    }
+
+
+def make_asset(
+    path: pathlib.Path,
+    *,
+    asset_id: int = 1,
+    digest: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": asset_id,
+        "name": path.name,
+        "state": "uploaded",
+        "size": path.stat().st_size,
+        "digest": digest or f"sha256:{rt.sha256(path)}",
+    }
+
+
+def create_asset(tmp_path: pathlib.Path, name: str, contents: bytes) -> pathlib.Path:
+    path = tmp_path / name
+    path.write_bytes(contents)
+    return path
+
+
+def mutation_calls(client: FakeClient) -> list[str]:
+    return [
+        call[0]
+        for call in client.calls
+        if call[0] in {"create_draft", "delete_asset", "upload_asset", "publish"}
+    ]
+
+
+def test_absent_release_is_created_as_draft_uploaded_verified_and_published(
+    tmp_path,
+):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient()
+
+    assert rt.run_transaction(client, TAG, TARGET, [str(asset)]) == "published"
+
+    assert client.release["draft"] is False
+    assert mutation_calls(client) == ["create_draft", "upload_asset", "publish"]
+
+
+def test_partial_draft_preserves_identical_asset_and_uploads_only_missing(
+    tmp_path,
+):
+    first = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    second = create_asset(tmp_path, "checksums.txt", b"checksums")
+    client = FakeClient(
+        make_release(draft=True, assets=[make_asset(first)])
+    )
+
+    assert (
+        rt.run_transaction(client, TAG, TARGET, [str(first), str(second)])
+        == "published"
+    )
+
+    assert mutation_calls(client) == ["upload_asset", "publish"]
+    assert client.calls.count(("upload_asset", TAG, first.name)) == 0
+
+
+def test_identical_draft_asset_is_not_reuploaded(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient(
+        make_release(draft=True, assets=[make_asset(asset)])
+    )
+
+    assert rt.run_transaction(client, TAG, TARGET, [str(asset)]) == "published"
+
+    assert mutation_calls(client) == ["publish"]
+
+
+def test_conflicting_draft_asset_is_replaced_and_digest_verified(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"new-sdist")
+    conflicting = make_asset(asset, digest=f"sha256:{'0' * 64}")
+    client = FakeClient(make_release(draft=True, assets=[conflicting]))
+
+    assert rt.run_transaction(client, TAG, TARGET, [str(asset)]) == "published"
+
+    assert mutation_calls(client) == ["delete_asset", "upload_asset", "publish"]
+    assert client.release["assets"][0]["digest"] == f"sha256:{rt.sha256(asset)}"
+
+
+def test_conflicting_published_asset_fails_without_replacement(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"new-sdist")
+    conflicting = make_asset(asset, digest=f"sha256:{'0' * 64}")
+    client = FakeClient(make_release(draft=False, assets=[conflicting]))
+
+    with pytest.raises(ValueError, match="digest/state mismatch"):
+        rt.run_transaction(client, TAG, TARGET, [str(asset)])
+
+    assert mutation_calls(client) == []
+
+
+def test_completed_release_rerun_with_identical_assets_succeeds(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient()
+
+    assert rt.run_transaction(client, TAG, TARGET, [str(asset)]) == "published"
+    first_calls = list(client.calls)
+    assert (
+        rt.run_transaction(client, TAG, TARGET, [str(asset)])
+        == "already-published"
+    )
+
+    assert mutation_calls(client) == [
+        call[0]
+        for call in first_calls
+        if call[0] in {"create_draft", "delete_asset", "upload_asset", "publish"}
+    ]
+
+
+def test_asset_failure_leaves_incomplete_release_draft(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient()
+    client.fail_upload = True
+
+    with pytest.raises(rt.ReleaseCommandError, match="upload failed"):
+        rt.run_transaction(client, TAG, TARGET, [str(asset)])
+
+    assert client.release["draft"] is True
+    assert "publish" not in mutation_calls(client)
+
+
+def test_publish_failure_leaves_verified_release_draft(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient()
+    client.fail_publish = True
+
+    with pytest.raises(rt.ReleaseCommandError, match="publish failed"):
+        rt.run_transaction(client, TAG, TARGET, [str(asset)])
+
+    assert client.release["draft"] is True
+    rt.verify_exact_assets(client.release, rt.local_assets([str(asset)]))
+
+
+def test_target_mismatch_fails_before_release_creation(tmp_path):
+    asset = create_asset(tmp_path, "shapely-2.1.2.tar.gz", b"sdist")
+    client = FakeClient(target="b" * 40)
+
+    with pytest.raises(ValueError, match="expected target"):
+        rt.run_transaction(client, TAG, TARGET, [str(asset)])
+
+    assert mutation_calls(client) == []

--- a/ci/tests/test_wheel_evidence.py
+++ b/ci/tests/test_wheel_evidence.py
@@ -1,0 +1,878 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import shutil
+import struct
+import subprocess
+import sys
+import urllib.error
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ci"))
+
+import wheel_evidence as we
+
+
+REAL_GEOS_SHA256 = "df2c50503295f325e7c8d7b783aca8ba4773919cde984193850cf9e361dfd28c"
+
+
+def arm64_pe_bytes(machine: int = 0xAA64) -> bytes:
+    data = bytearray(0x90)
+    data[:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, 0x80)
+    data[0x80:0x84] = b"PE\0\0"
+    struct.pack_into("<H", data, 0x84, machine)
+    return bytes(data)
+
+
+def tag_for_label(label: str) -> str:
+    runtime = we.runtime_for_label(label)
+    return f"{runtime['interpreter']}-{runtime['abi']}-win_arm64"
+
+
+def create_wheel(
+    directory: pathlib.Path,
+    tag: str,
+    *,
+    wheel_tag: str | None = None,
+    repaired: bool = True,
+) -> pathlib.Path:
+    interpreter, abi, platform = tag.split("-")
+    path = directory / f"shapely-2.1.2-{interpreter}-{abi}-{platform}.whl"
+    dist_info = "shapely-2.1.2.dist-info"
+    license_dir = ROOT / "ci" / "wheelbuilder"
+    with zipfile.ZipFile(path, "w") as wheel:
+        wheel.writestr(
+            f"{dist_info}/WHEEL",
+            "\n".join(
+                [
+                    "Wheel-Version: 1.0",
+                    "Generator: pytest",
+                    "Root-Is-Purelib: false",
+                    f"Tag: {wheel_tag or tag}",
+                    "",
+                ]
+            ),
+        )
+        wheel.writestr(
+            f"shapely/lib.{interpreter}-{platform}.pyd",
+            arm64_pe_bytes(),
+        )
+        wheel.writestr(
+            "shapely.libs/libgeos-test.dll",
+            arm64_pe_bytes(),
+        )
+        wheel.writestr(
+            f"{dist_info}/LICENSE_GEOS",
+            (license_dir / "LICENSE_GEOS").read_bytes(),
+        )
+        wheel.writestr(
+            f"{dist_info}/LICENSE_win32",
+            (license_dir / "LICENSE_win32").read_bytes(),
+        )
+        if repaired:
+            wheel.writestr(
+                f"{dist_info}/DELVEWHEEL",
+                "Version: 1.13.0\nArguments: ['delvewheel', 'repair']\n",
+            )
+    return path
+
+
+def create_all_wheels(directory: pathlib.Path) -> dict[str, pathlib.Path]:
+    wheels = {}
+    for label in sorted(we.EXPECTED_LABELS):
+        wheels[label] = create_wheel(directory, tag_for_label(label))
+    return wheels
+
+
+def set_github_env(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, *, job_key: str) -> None:
+    env = {
+        "GITHUB_REPOSITORY": "shapely/shapely",
+        "GITHUB_RUN_ID": "123456789",
+        "GITHUB_JOB": job_key,
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
+        "GITHUB_REF": "refs/heads/main",
+        "ImageOS": "windows11",
+        "ImageVersion": "20260830.1",
+        "GEOS_VERSION": "3.13.1",
+        "GEOS_SHA256": REAL_GEOS_SHA256,
+        "GEOS_CHECKSUM_PROVENANCE_URL": "https://github.com/libgeos/geos/releases/tag/3.13.1",
+        "RUNNER_TEMP": str(tmp_path),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
+def read_json(path: pathlib.Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def install_fake_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command, **kwargs):
+        argv = [str(item) for item in command]
+        if len(argv) >= 4 and argv[1:4] == ["-m", "delvewheel", "show"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    f"Analyzing {argv[4]}\n\n"
+                    "delvewheel 1.13.0 has already repaired this wheel\n"
+                ),
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    monkeypatch.setattr(we.subprocess, "run", fake_run)
+
+
+def build_round_trip(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> tuple[pathlib.Path, pathlib.Path]:
+    wheelhouse = tmp_path / "wheelhouse"
+    verifier_dir = tmp_path / "verifier-records"
+    wheelhouse.mkdir()
+    verifier_dir.mkdir()
+    create_all_wheels(wheelhouse)
+
+    set_github_env(monkeypatch, tmp_path, job_key="build-windows-arm64")
+    monkeypatch.setattr(we.platform, "machine", lambda: "ARM64")
+    monkeypatch.setattr(we, "command_version", lambda *command: f"{command[0]} version")
+
+    producer_path = tmp_path / "arm64-wheel-producer.json"
+    we.producer_command(SimpleNamespace(wheelhouse=str(wheelhouse), output=str(producer_path)))
+    we.validate_producer(read_json(producer_path))
+
+    python_exe = tmp_path / "python.exe"
+    python_exe.write_bytes(b"")
+
+    monkeypatch.setattr(we, "require_arm64", lambda exe, expected: None)
+    monkeypatch.setattr(we, "package_version", lambda name: "1.17.0")
+    install_fake_subprocess(monkeypatch)
+
+    for label in sorted(we.EXPECTED_LABELS):
+        set_github_env(monkeypatch, tmp_path, job_key=f"verify-{label}")
+        we.verify_command(
+            SimpleNamespace(
+                producer=str(producer_path),
+                wheelhouse=str(wheelhouse),
+                source_root=str(ROOT),
+                label=label,
+                python_exe=str(python_exe),
+                output=str(verifier_dir / f"arm64-wheel-verifier-{label}.json"),
+                report_dir="repair-reports",
+            )
+        )
+        we.validate_verifier(read_json(verifier_dir / f"arm64-wheel-verifier-{label}.json"))
+
+    set_github_env(monkeypatch, tmp_path, job_key="finalize-windows-arm64")
+    final_path = tmp_path / "arm64-wheel-provenance.json"
+    we.finalize_command(
+        SimpleNamespace(
+            producer=str(producer_path),
+            verifier_dir=str(verifier_dir),
+            output=str(final_path),
+        )
+    )
+    we.validate_final(read_json(final_path))
+    return producer_path, final_path
+
+
+def test_producer_verify_finalize_round_trip(tmp_path, monkeypatch):
+    producer_path, final_path = build_round_trip(tmp_path, monkeypatch)
+    assert producer_path.exists()
+    assert final_path.exists()
+    final = read_json(final_path)
+    assert {artifact["runtime"]["label"] for artifact in final["artifacts"]} == we.EXPECTED_LABELS
+    assert len(final["artifacts"]) == 7
+
+
+def test_verify_command_rejects_missing_matching_wheel(tmp_path, monkeypatch):
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    create_wheel(wheelhouse, tag_for_label("cp313"))
+
+    set_github_env(monkeypatch, tmp_path, job_key="build-windows-arm64")
+    monkeypatch.setattr(we.platform, "machine", lambda: "ARM64")
+    monkeypatch.setattr(we, "command_version", lambda *command: f"{command[0]} version")
+    producer_path = tmp_path / "arm64-wheel-producer.json"
+    we.producer_command(SimpleNamespace(wheelhouse=str(wheelhouse), output=str(producer_path)))
+
+    set_github_env(monkeypatch, tmp_path, job_key="verify-cp314")
+    monkeypatch.setattr(we, "require_arm64", lambda exe, expected: None)
+    install_fake_subprocess(monkeypatch)
+    python_exe = tmp_path / "python.exe"
+    python_exe.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="no retained wheel matches verifier label"):
+        we.verify_command(
+            SimpleNamespace(
+                producer=str(producer_path),
+                wheelhouse=str(wheelhouse),
+                source_root=str(ROOT),
+                label="cp314",
+                python_exe=str(python_exe),
+                output=str(tmp_path / "arm64-wheel-verifier-cp314.json"),
+                report_dir="repair-reports",
+            )
+        )
+
+
+def test_validate_producer_rejects_unknown_key(tmp_path):
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    wheel = create_wheel(wheelhouse, tag_for_label("cp313"))
+    doc = {
+        "schema_version": 1,
+        "record_type": "producer",
+        "created_at_utc": we.now_utc(),
+        "job": {
+            "repository": "shapely/shapely",
+            "run_id": "123456789",
+            "job_key": "build-windows-arm64",
+            "run_url": "https://github.com/shapely/shapely/actions/runs/123456789",
+            "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+            "ref": "refs/heads/main",
+        },
+        "source_artifact": dict(we.SOURCE_ARTIFACT),
+        "producer": {
+            "runner": {
+                "os": "Windows",
+                "architecture": "ARM64",
+                "image_os": "windows11",
+                "image_version": "20260830.1",
+            },
+            "toolchain": {
+                "cibuildwheel_action": "pypa/cibuildwheel@v4.2.0",
+                "msvc_toolset": "14.44",
+                "cmake": "cmake version",
+                "ninja": "ninja version",
+            },
+        },
+        "geos": {
+            "version": "3.13.1",
+            "archive_url": "https://download.osgeo.org/geos/geos-3.13.1.tar.bz2",
+            "sha256": REAL_GEOS_SHA256,
+            "checksum_provenance_url": "https://github.com/libgeos/geos/releases/tag/3.13.1",
+        },
+        "artifacts": [we.wheel_core(wheel)],
+        "extra": "boom",
+    }
+    with pytest.raises(ValueError, match="exact keys required"):
+        we.validate_producer(doc)
+
+
+def test_validate_final_rejects_missing_verifier_label(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    final["verifiers"] = final["verifiers"][:-1]
+    with pytest.raises(ValueError, match="seven verifier rows required"):
+        we.validate_final(final)
+
+
+def test_validate_final_rejects_seven_labels_with_one_wheel(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    final["artifacts"] = final["artifacts"][:1]
+    with pytest.raises(ValueError, match="exact ABI label coverage required"):
+        we.validate_final(final)
+
+
+def test_validate_final_rejects_absolute_repair_report(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    final["artifacts"][0]["repair_report"] = "C:/escape.txt"
+    with pytest.raises(ValueError, match="relative path required"):
+        we.validate_final(final)
+
+
+def test_finalize_command_rejects_parent_traversal_repair_report(tmp_path, monkeypatch):
+    producer_path, _ = build_round_trip(tmp_path, monkeypatch)
+    verifier_dir = tmp_path / "verifier-records"
+    cp311_path = verifier_dir / "arm64-wheel-verifier-cp311.json"
+    cp311 = read_json(cp311_path)
+    cp311["artifacts"][0]["repair_report"] = "../escape.txt"
+    we.canonical_write(cp311_path, cp311)
+
+    set_github_env(monkeypatch, tmp_path, job_key="finalize-windows-arm64")
+    with pytest.raises(ValueError, match="parent traversal forbidden"):
+        we.finalize_command(
+            SimpleNamespace(
+                producer=str(producer_path),
+                verifier_dir=str(verifier_dir),
+                output=str(tmp_path / "broken.json"),
+            )
+        )
+
+
+def test_pypi_check_requires_matching_digest(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+
+    payload = {
+        "info": {"name": "shapely", "version": "2.1.2"},
+        "urls": [
+            {
+                "filename": "shapely-2.1.2-cp311-cp311-win_arm64.whl",
+                "digests": {"sha256": "0" * 64},
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        we.urllib.request,
+        "urlopen",
+        lambda url, timeout: fake_pypi_response(payload),
+    )
+    with pytest.raises(ValueError, match="PyPI ARM64 wheel map mismatch"):
+        we.pypi_check(str(final_path), "shapely", "2.1.2")
+
+
+def fake_pypi_response(payload: object) -> io.StringIO:
+    return io.StringIO(json.dumps(payload))
+
+
+def pypi_payload(final_path: pathlib.Path) -> dict[str, object]:
+    final = read_json(final_path)
+    return {
+        "info": {"name": "Shapely", "version": "2.1.2"},
+        "urls": [
+            {
+                "filename": artifact["filename"],
+                "digests": {"sha256": artifact["sha256"]},
+            }
+            for artifact in final["artifacts"]
+        ],
+    }
+
+
+def test_pypi_check_succeeds_for_exact_finalized_wheels(tmp_path, monkeypatch, capsys):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        we.urllib.request,
+        "urlopen",
+        lambda url, timeout: fake_pypi_response(pypi_payload(final_path)),
+    )
+
+    we.pypi_check(str(final_path), "shapely", "2.1.2")
+
+    assert "verified 7 PyPI ARM64 wheels for shapely 2.1.2" in capsys.readouterr().out
+
+
+def test_verify_pypi_release_rejects_extra_arm64_wheel(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    payload = pypi_payload(final_path)
+    payload["urls"].append(
+        {
+            "filename": "shapely-2.1.2-cp310-cp310-win_arm64.whl",
+            "digests": {"sha256": "a" * 64},
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"extra=.*cp310"):
+        we.verify_pypi_release(final, payload, we.Version("2.1.2"))
+
+
+def test_verify_pypi_release_ignores_non_arm64_files(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    payload = pypi_payload(final_path)
+    payload["urls"].extend(
+        [
+            {
+                "filename": "shapely-2.1.2-cp311-cp311-manylinux_2_17_x86_64.whl",
+                "digests": {"sha256": "a" * 64},
+            },
+            {
+                "filename": "shapely-2.1.2.tar.gz",
+                "digests": {"sha256": "b" * 64},
+            },
+        ]
+    )
+
+    we.verify_pypi_release(final, payload, we.Version("2.1.2"))
+
+
+def test_verify_pypi_release_rejects_wrong_version_wheel(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    payload = pypi_payload(final_path)
+    payload["urls"].append(
+        {
+            "filename": "shapely-2.1.1-cp311-cp311-win_arm64.whl",
+            "digests": {"sha256": "a" * 64},
+        }
+    )
+
+    with pytest.raises(ValueError, match="wrong-version PyPI distribution"):
+        we.verify_pypi_release(final, payload, we.Version("2.1.2"))
+
+
+def test_verify_pypi_release_rejects_duplicate_filename(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    final = read_json(final_path)
+    payload = pypi_payload(final_path)
+    payload["urls"].append(dict(payload["urls"][0]))
+
+    with pytest.raises(ValueError, match="duplicate PyPI filename"):
+        we.verify_pypi_release(final, payload, we.Version("2.1.2"))
+
+
+def test_pypi_check_retries_until_index_contains_finalized_wheels(
+    tmp_path, monkeypatch
+):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    responses = [
+        {"info": {"name": "shapely", "version": "2.1.2"}, "urls": []},
+        pypi_payload(final_path),
+    ]
+    sleeps = []
+
+    def fake_urlopen(url, timeout):
+        return fake_pypi_response(responses.pop(0))
+
+    monkeypatch.setattr(we.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(we.time, "sleep", sleeps.append)
+
+    we.pypi_check(
+        str(final_path),
+        "shapely",
+        "2.1.2",
+        attempts=3,
+        retry_delay_seconds=0.25,
+    )
+
+    assert responses == []
+    assert sleeps == [0.25]
+
+
+def test_pypi_check_fails_after_bounded_retries(tmp_path, monkeypatch):
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    calls = []
+    sleeps = []
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        return fake_pypi_response(
+            {"info": {"name": "shapely", "version": "2.1.2"}, "urls": []}
+        )
+
+    monkeypatch.setattr(we.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(we.time, "sleep", sleeps.append)
+
+    with pytest.raises(ValueError, match="PyPI verification failed after 3 attempts"):
+        we.pypi_check(
+            str(final_path),
+            "shapely",
+            "2.1.2",
+            attempts=3,
+            retry_delay_seconds=0.25,
+        )
+
+    assert len(calls) == 3
+    assert sleeps == [0.25, 0.25]
+
+
+def create_release_distributions(
+    directory: pathlib.Path,
+    arm64_wheels: list[pathlib.Path] | None = None,
+) -> dict[str, pathlib.Path]:
+    distributions = {}
+    for filename, contents in [
+        ("shapely-2.1.2.tar.gz", b"sdist"),
+        (
+            "shapely-2.1.2-cp311-cp311-manylinux_2_17_x86_64.whl",
+            b"linux-wheel",
+        ),
+        (
+            "shapely-2.1.2-cp311-cp311-macosx_11_0_arm64.whl",
+            b"macos-wheel",
+        ),
+        ("shapely-2.1.2-cp311-cp311-win_amd64.whl", b"win-amd64-wheel"),
+    ]:
+        path = directory / filename
+        path.write_bytes(contents)
+        distributions[filename] = path
+    if arm64_wheels is None:
+        arm64_wheels = []
+        path = directory / "shapely-2.1.2-cp311-cp311-win_arm64.whl"
+        path.write_bytes(b"arm64-wheel")
+        distributions[path.name] = path
+    for source in arm64_wheels:
+        path = directory / source.name
+        shutil.copy2(source, path)
+        distributions[path.name] = path
+    return distributions
+
+
+def release_payload_for_files(paths: list[pathlib.Path]) -> dict[str, object]:
+    return {
+        "info": {"name": "Shapely", "version": "2.1.2"},
+        "urls": [
+            {
+                "filename": path.name,
+                "digests": {"sha256": we.sha256(path)},
+            }
+            for path in paths
+        ],
+    }
+
+
+def stage_args(
+    wheelhouse: pathlib.Path,
+    staging: pathlib.Path,
+    manifest: pathlib.Path,
+    github_output: pathlib.Path | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        wheelhouse=str(wheelhouse),
+        staging_dir=str(staging),
+        manifest=str(manifest),
+        distribution="shapely",
+        version="2.1.2",
+        attempts=3,
+        retry_delay_seconds=0,
+        github_output=None if github_output is None else str(github_output),
+    )
+
+
+def create_provenance_bound_release(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[pathlib.Path, pathlib.Path, dict[str, pathlib.Path]]:
+    _, final_path = build_round_trip(tmp_path, monkeypatch)
+    wheelhouse = tmp_path / "dist"
+    wheelhouse.mkdir()
+    distributions = create_release_distributions(
+        wheelhouse,
+        sorted((tmp_path / "wheelhouse").glob("*.whl")),
+    )
+    return wheelhouse, final_path, distributions
+
+
+def test_stage_pypi_404_stages_sdist_and_all_platform_wheels(
+    tmp_path, monkeypatch, capsys
+):
+    staging = tmp_path / "pypi-upload"
+    output = tmp_path / "github-output"
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    monkeypatch.setattr(we, "load_pypi_release", lambda *args, **kwargs: None)
+
+    assert (
+        we.main(
+            [
+                "stage-pypi",
+                "--wheelhouse",
+                str(wheelhouse),
+                "--staging-dir",
+                str(staging),
+                "--manifest",
+                str(final_path),
+                "--distribution",
+                "shapely",
+                "--version",
+                "2.1.2",
+                "--attempts",
+                "1",
+                "--github-output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    assert {path.name for path in staging.iterdir()} == set(distributions)
+    assert output.read_text(encoding="utf-8").splitlines() == [
+        "has_files=true",
+        f"staged_count={len(distributions)}",
+    ]
+    assert (
+        f"verified 0 existing and staged {len(distributions)} missing"
+        in capsys.readouterr().out
+    )
+
+
+def test_load_pypi_release_treats_404_as_new_version(monkeypatch):
+    def not_found(url, timeout):
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(we.urllib.request, "urlopen", not_found)
+
+    assert (
+        we.load_pypi_release("shapely", we.Version("2.1.2"), allow_not_found=True)
+        is None
+    )
+
+
+def test_stage_pypi_published_subset_recovery_stages_only_missing_and_cleans_stale(
+    tmp_path, monkeypatch
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    staging.mkdir()
+    (staging / "stale.whl").write_bytes(b"stale")
+    existing_arm64 = next(
+        path for name, path in distributions.items() if "win_arm64" in name
+    )
+    existing = [
+        distributions["shapely-2.1.2.tar.gz"],
+        distributions[
+            "shapely-2.1.2-cp311-cp311-manylinux_2_17_x86_64.whl"
+        ],
+        existing_arm64,
+    ]
+    monkeypatch.setattr(
+        we,
+        "load_pypi_release",
+        lambda *args, **kwargs: release_payload_for_files(existing),
+    )
+
+    we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert {path.name for path in staging.iterdir()} == set(distributions) - {
+        path.name for path in existing
+    }
+
+
+def test_stage_pypi_rejects_extra_published_arm64_before_staging(
+    tmp_path, monkeypatch
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, _ = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    extra = tmp_path / "shapely-2.1.2-cp310-cp310-win_arm64.whl"
+    extra.write_bytes(b"unexpected-arm64")
+    monkeypatch.setattr(
+        we,
+        "load_pypi_release",
+        lambda *args, **kwargs: release_payload_for_files([extra]),
+    )
+
+    def forbid_copy(*args, **kwargs):
+        raise AssertionError("preflight must fail before staging")
+
+    monkeypatch.setattr(we.shutil, "copy2", forbid_copy)
+
+    with pytest.raises(
+        ValueError,
+        match="not a digest-matching finalized provenance subset",
+    ):
+        we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert list(staging.iterdir()) == []
+
+
+@pytest.mark.parametrize("difference", ["missing", "mismatched", "extra"])
+def test_stage_pypi_requires_local_arm64_exactly_match_final_provenance(
+    tmp_path, monkeypatch, difference
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    arm64 = sorted(
+        path for name, path in distributions.items() if "win_arm64" in name
+    )
+    if difference == "missing":
+        arm64[0].unlink()
+    elif difference == "mismatched":
+        arm64[0].write_bytes(b"different-local-wheel")
+    else:
+        (wheelhouse / "shapely-2.1.2-cp310-cp310-win_arm64.whl").write_bytes(
+            b"unexpected-local-wheel"
+        )
+
+    def forbid_metadata(*args, **kwargs):
+        raise AssertionError("local/provenance preflight must precede PyPI lookup")
+
+    monkeypatch.setattr(we, "load_pypi_release", forbid_metadata)
+
+    with pytest.raises(
+        ValueError,
+        match="local/finalized provenance ARM64 wheel map mismatch",
+    ):
+        we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert list(staging.iterdir()) == []
+
+
+def test_stage_pypi_rejects_existing_digest_mismatch_and_leaves_clean_staging(
+    tmp_path, monkeypatch
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    staging.mkdir()
+    (staging / "stale.whl").write_bytes(b"stale")
+    payload = release_payload_for_files([distributions["shapely-2.1.2.tar.gz"]])
+    payload["urls"][0]["digests"]["sha256"] = "0" * 64
+    monkeypatch.setattr(
+        we, "load_pypi_release", lambda *args, **kwargs: payload
+    )
+
+    with pytest.raises(ValueError, match="immutable PyPI file has different SHA-256"):
+        we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert list(staging.iterdir()) == []
+
+
+def test_stage_pypi_all_existing_skips_upload(tmp_path, monkeypatch):
+    staging = tmp_path / "pypi-upload"
+    output = tmp_path / "github-output"
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    monkeypatch.setattr(
+        we,
+        "load_pypi_release",
+        lambda *args, **kwargs: release_payload_for_files(
+            list(distributions.values())
+        ),
+    )
+
+    we.stage_pypi_command(stage_args(wheelhouse, staging, final_path, output))
+
+    assert list(staging.iterdir()) == []
+    assert output.read_text(encoding="utf-8").splitlines() == [
+        "has_files=false",
+        "staged_count=0",
+    ]
+
+
+def test_stage_pypi_network_failure_is_bounded_and_cleans_staging(
+    tmp_path, monkeypatch
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, _ = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    staging.mkdir()
+    (staging / "stale.whl").write_bytes(b"stale")
+    calls = []
+
+    def unavailable(*args, **kwargs):
+        calls.append(None)
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(we, "load_pypi_release", unavailable)
+    monkeypatch.setattr(we.time, "sleep", lambda delay: None)
+
+    with pytest.raises(ValueError, match="PyPI metadata failed after 3 attempts"):
+        we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert len(calls) == 3
+    assert list(staging.iterdir()) == []
+
+
+def test_stage_pypi_copy_failure_removes_partially_staged_files(
+    tmp_path, monkeypatch
+):
+    staging = tmp_path / "pypi-upload"
+    wheelhouse, final_path, _ = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+    monkeypatch.setattr(we, "load_pypi_release", lambda *args, **kwargs: None)
+    real_copy2 = we.shutil.copy2
+    calls = []
+
+    def fail_second_copy(source, destination):
+        calls.append(source)
+        if len(calls) == 2:
+            raise OSError("copy failed")
+        return real_copy2(source, destination)
+
+    monkeypatch.setattr(we.shutil, "copy2", fail_second_copy)
+
+    with pytest.raises(OSError, match="copy failed"):
+        we.stage_pypi_command(stage_args(wheelhouse, staging, final_path))
+
+    assert list(staging.iterdir()) == []
+
+
+def test_stage_pypi_rejects_overlapping_staging_without_deleting_wheelhouse(
+    tmp_path, monkeypatch
+):
+    wheelhouse, final_path, distributions = create_provenance_bound_release(
+        tmp_path, monkeypatch
+    )
+
+    with pytest.raises(ValueError, match="must not overlap wheelhouse"):
+        we.stage_pypi_command(
+            stage_args(wheelhouse, wheelhouse / "staging", final_path)
+        )
+
+    assert {path.name for path in wheelhouse.iterdir()} == set(distributions)
+
+
+def test_verify_one_accepts_realistic_already_repaired_delvewheel_output(tmp_path, monkeypatch):
+    wheel = create_wheel(tmp_path, tag_for_label("cp313"))
+    core = we.wheel_core(wheel)
+    python_exe = tmp_path / "python.exe"
+    python_exe.write_bytes(b"")
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    def fake_run(command, **kwargs):
+        argv = [str(item) for item in command]
+        if len(argv) >= 4 and argv[1:4] == ["-m", "delvewheel", "show"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    f"Analyzing {argv[4]}\n\n"
+                    "delvewheel 1.13.0 has already repaired this wheel\n"
+                ),
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    monkeypatch.setattr(we.subprocess, "run", fake_run)
+
+    verified = we.verify_one(
+        core,
+        wheel,
+        ROOT,
+        str(python_exe),
+        tmp_path / "artifacts",
+        "repair-reports",
+    )
+
+    assert verified["repair_report"].startswith("repair-reports/")
+
+
+def test_verify_one_rejects_already_repaired_output_without_delvewheel_marker(tmp_path, monkeypatch):
+    wheel = create_wheel(tmp_path, tag_for_label("cp313"), repaired=False)
+    core = we.wheel_core(wheel)
+    python_exe = tmp_path / "python.exe"
+    python_exe.write_bytes(b"")
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    def fake_run(command, **kwargs):
+        argv = [str(item) for item in command]
+        if len(argv) >= 4 and argv[1:4] == ["-m", "delvewheel", "show"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    f"Analyzing {argv[4]}\n\n"
+                    "delvewheel 1.13.0 has already repaired this wheel\n"
+                ),
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    monkeypatch.setattr(we.subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError, match="per-wheel delvewheel evidence failed"):
+        we.verify_one(
+            core,
+            wheel,
+            ROOT,
+            str(python_exe),
+            tmp_path / "artifacts",
+            "repair-reports",
+        )

--- a/ci/wheel_evidence.py
+++ b/ci/wheel_evidence.py
@@ -1,0 +1,1514 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timedelta, timezone
+from importlib.metadata import version as package_version
+
+from packaging.tags import Tag, parse_tag
+from packaging.utils import (
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+from packaging.version import Version
+
+NAME = canonicalize_name("shapely")
+HEX = re.compile(r"^[0-9a-f]{64}$")
+UTC = re.compile(r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ$")
+JOB_KEYS = {"repository", "run_id", "job_key", "run_url", "commit_sha", "ref"}
+SOURCE_ARTIFACT = {"name": "release-windows-11-arm-ARM64", "retention_days": 30}
+CORE_KEYS = {
+    "filename",
+    "distribution",
+    "version",
+    "sha256",
+    "size_bytes",
+    "filename_tags",
+    "wheel_tags",
+    "runtime",
+}
+RUNTIME_KEYS = {
+    "label",
+    "setup_selector",
+    "numeric_version",
+    "free_threaded",
+    "interpreter",
+    "abi",
+}
+PRODUCER_METADATA_KEYS = {"created_at_utc", "job", "runner", "toolchain"}
+VERIFIED_ARTIFACT_KEYS = CORE_KEYS | {
+    "pe_machines",
+    "license_members",
+    "repair_report",
+    "repair_report_sha256",
+    "checks",
+}
+PRODUCER_KEYS = {
+    "schema_version",
+    "record_type",
+    "created_at_utc",
+    "job",
+    "source_artifact",
+    "producer",
+    "geos",
+    "artifacts",
+}
+VERIFIER_KEYS = {
+    "schema_version",
+    "record_type",
+    "created_at_utc",
+    "producer_sha256",
+    "job",
+    "runtime",
+    "verifier",
+    "artifacts",
+}
+FINAL_KEYS = {
+    "schema_version",
+    "record_type",
+    "created_at_utc",
+    "finalizer_job",
+    "producer_sha256",
+    "source_artifact",
+    "producer",
+    "geos",
+    "verifiers",
+    "artifacts",
+}
+CHECK_KEYS = {
+    "wheel_tag",
+    "pe_architecture",
+    "license_contents",
+    "delvewheel_repair",
+    "clean_external_cwd_tests",
+}
+RUNTIMES = {
+    ("cp311", "cp311"): {
+        "label": "cp311",
+        "setup_selector": "3.11",
+        "numeric_version": "3.11",
+        "free_threaded": False,
+        "interpreter": "cp311",
+        "abi": "cp311",
+    },
+    ("cp312", "cp312"): {
+        "label": "cp312",
+        "setup_selector": "3.12",
+        "numeric_version": "3.12",
+        "free_threaded": False,
+        "interpreter": "cp312",
+        "abi": "cp312",
+    },
+    ("cp313", "cp313"): {
+        "label": "cp313",
+        "setup_selector": "3.13",
+        "numeric_version": "3.13",
+        "free_threaded": False,
+        "interpreter": "cp313",
+        "abi": "cp313",
+    },
+    ("cp314", "cp314"): {
+        "label": "cp314",
+        "setup_selector": "3.14",
+        "numeric_version": "3.14",
+        "free_threaded": False,
+        "interpreter": "cp314",
+        "abi": "cp314",
+    },
+    ("cp314", "cp314t"): {
+        "label": "cp314t",
+        "setup_selector": "3.14t",
+        "numeric_version": "3.14",
+        "free_threaded": True,
+        "interpreter": "cp314",
+        "abi": "cp314t",
+    },
+    ("cp315", "cp315"): {
+        "label": "cp315",
+        "setup_selector": "3.15",
+        "numeric_version": "3.15",
+        "free_threaded": False,
+        "interpreter": "cp315",
+        "abi": "cp315",
+    },
+    ("cp315", "cp315t"): {
+        "label": "cp315t",
+        "setup_selector": "3.15t",
+        "numeric_version": "3.15",
+        "free_threaded": True,
+        "interpreter": "cp315",
+        "abi": "cp315t",
+    },
+}
+EXPECTED_LABELS = {value["label"] for value in RUNTIMES.values()}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def ensure_exact_keys(value: object, expected: set[str], where: str) -> None:
+    if not isinstance(value, dict) or set(value) != expected:
+        fail(f"{where}: exact keys required")
+
+
+def require_text(value: object, where: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{where}: non-empty string required")
+    return value
+
+
+def require_bool(value: object, where: str) -> bool:
+    if not isinstance(value, bool):
+        fail(f"{where}: boolean required")
+    return value
+
+
+def require_int(value: object, where: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        fail(f"{where}: integer required")
+    return value
+
+
+def validate_utc(value: object, where: str) -> str:
+    text = require_text(value, where)
+    if not UTC.fullmatch(text):
+        fail(f"{where}: RFC-3339 UTC required")
+    if datetime.fromisoformat(text[:-1] + "+00:00").utcoffset() != timedelta(0):
+        fail(f"{where}: UTC offset required")
+    return text
+
+
+def now_utc() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def sha256(path: os.PathLike[str] | str) -> str:
+    with open(path, "rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def document(path: os.PathLike[str] | str) -> object:
+    with open(path, encoding="utf-8") as source:
+        return json.load(source)
+
+
+def canonical_write(path: os.PathLike[str] | str, value: object) -> None:
+    destination = pathlib.Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=destination.name + ".",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as out:
+            out.write(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
+            out.flush()
+            os.fsync(out.fileno())
+        os.replace(temp_name, destination)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def environment(name: str) -> str:
+    return require_text(os.environ.get(name, ""), f"environment.{name}")
+
+
+def command_version(*command: str) -> str:
+    lines = subprocess.check_output(command, text=True).splitlines()
+    if not lines:
+        fail("tool version: command returned no output")
+    return require_text(lines[0].strip(), "tool version")
+
+
+def require_hex64(value: object, where: str) -> str:
+    text = require_text(value, where)
+    if not HEX.fullmatch(text):
+        fail(f"{where}: lower-case SHA-256 required")
+    return text
+
+
+def validate_job(value: object, where: str) -> dict[str, str]:
+    ensure_exact_keys(value, JOB_KEYS, where)
+    job = value
+    repository = require_text(job["repository"], f"{where}.repository")
+    if not re.fullmatch(r"[^/\s]+/shapely", repository):
+        fail(f"{where}.repository: owner/shapely required")
+    run_id = require_text(job["run_id"], f"{where}.run_id")
+    if not run_id.isdigit():
+        fail(f"{where}.run_id: decimal string required")
+    require_text(job["job_key"], f"{where}.job_key")
+    run_url = require_text(job["run_url"], f"{where}.run_url")
+    if not run_url.startswith("https://"):
+        fail(f"{where}.run_url: HTTPS URL required")
+    commit_sha = require_text(job["commit_sha"], f"{where}.commit_sha")
+    if not re.fullmatch(r"[0-9a-f]{40}", commit_sha):
+        fail(f"{where}.commit_sha: 40 lowercase hex required")
+    require_text(job["ref"], f"{where}.ref")
+    return job
+
+
+def validate_source_artifact(value: object, where: str = "source_artifact") -> dict[str, object]:
+    ensure_exact_keys(value, {"name", "retention_days"}, where)
+    if value != SOURCE_ARTIFACT:
+        fail(f"{where}: unexpected source artifact contract")
+    return value
+
+
+def validate_runner(value: object, where: str) -> dict[str, str]:
+    ensure_exact_keys(value, {"os", "architecture", "image_os", "image_version"}, where)
+    runner = value
+    if runner["os"] != "Windows" or runner["architecture"] != "ARM64":
+        fail(f"{where}: Windows ARM64 runner required")
+    require_text(runner["image_os"], f"{where}.image_os")
+    require_text(runner["image_version"], f"{where}.image_version")
+    return runner
+
+
+def validate_toolchain(value: object, where: str) -> dict[str, str]:
+    ensure_exact_keys(value, {"cibuildwheel_action", "msvc_toolset", "cmake", "ninja"}, where)
+    toolchain = value
+    if toolchain["cibuildwheel_action"] != "pypa/cibuildwheel@v4.2.0":
+        fail(f"{where}.cibuildwheel_action: unexpected value")
+    if toolchain["msvc_toolset"] != "14.44":
+        fail(f"{where}.msvc_toolset: unexpected value")
+    require_text(toolchain["cmake"], f"{where}.cmake")
+    require_text(toolchain["ninja"], f"{where}.ninja")
+    return toolchain
+
+
+def validate_geos(value: object, where: str = "geos") -> dict[str, str]:
+    ensure_exact_keys(value, {"version", "archive_url", "sha256", "checksum_provenance_url"}, where)
+    geos = value
+    version = require_text(geos["version"], f"{where}.version")
+    archive_url = require_text(geos["archive_url"], f"{where}.archive_url")
+    if archive_url != f"https://download.osgeo.org/geos/geos-{version}.tar.bz2":
+        fail(f"{where}.archive_url: unexpected GEOS archive URL")
+    require_hex64(geos["sha256"], f"{where}.sha256")
+    provenance = require_text(geos["checksum_provenance_url"], f"{where}.checksum_provenance_url")
+    if not provenance.startswith("https://"):
+        fail(f"{where}.checksum_provenance_url: HTTPS URL required")
+    return geos
+
+
+def runtime_for_tag(tag: Tag, where: str) -> dict[str, object]:
+    runtime = RUNTIMES.get((tag.interpreter, tag.abi))
+    if tag.platform != "win_arm64" or runtime is None:
+        fail(f"{where}: unsupported ARM64 CPython ABI")
+    return dict(runtime)
+
+
+def runtime_for_label(label: str) -> dict[str, object]:
+    for runtime in RUNTIMES.values():
+        if runtime["label"] == label:
+            return dict(runtime)
+    fail(f"unknown verifier label: {label}")
+
+
+def parse_single_tag_string(value: object, where: str) -> Tag:
+    if not isinstance(value, list) or len(value) != 1:
+        fail(f"{where}: exactly one tag required")
+    raw = require_text(value[0], f"{where}[0]")
+    try:
+        parsed = parse_tag(raw)
+    except ValueError as error:
+        fail(f"{where}: malformed tag: {error}")
+    if len(parsed) != 1:
+        fail(f"{where}: compressed/ambiguous tag forbidden")
+    return next(iter(parsed))
+
+
+def validate_runtime(value: object, where: str) -> dict[str, object]:
+    ensure_exact_keys(value, RUNTIME_KEYS, where)
+    tag = Tag(
+        require_text(value["interpreter"], f"{where}.interpreter"),
+        require_text(value["abi"], f"{where}.abi"),
+        "win_arm64",
+    )
+    expected = runtime_for_tag(tag, where)
+    if value != expected:
+        fail(f"{where}: runtime mapping mismatch")
+    require_bool(value["free_threaded"], f"{where}.free_threaded")
+    return value
+
+
+def validate_core(value: object, where: str) -> dict[str, object]:
+    ensure_exact_keys(value, CORE_KEYS, where)
+    core = value
+    filename = require_text(core["filename"], f"{where}.filename")
+    distribution = require_text(core["distribution"], f"{where}.distribution")
+    version = require_text(core["version"], f"{where}.version")
+    require_hex64(core["sha256"], f"{where}.sha256")
+    size_bytes = require_int(core["size_bytes"], f"{where}.size_bytes")
+    if size_bytes <= 0:
+        fail(f"{where}.size_bytes: positive integer required")
+    filename_tag = parse_single_tag_string(core["filename_tags"], f"{where}.filename_tags")
+    wheel_tag = parse_single_tag_string(core["wheel_tags"], f"{where}.wheel_tags")
+    if filename_tag != wheel_tag:
+        fail(f"{where}: filename/WHEEL tag-set mismatch")
+    try:
+        got_name, got_version, _, filename_tags = parse_wheel_filename(filename)
+    except (TypeError, ValueError) as error:
+        fail(f"{where}.filename: invalid wheel filename: {error}")
+    if distribution != NAME or got_name != NAME:
+        fail(f"{where}.distribution: canonical shapely name required")
+    if str(got_version) != version:
+        fail(f"{where}.version: filename/version mismatch")
+    if filename_tags != frozenset({filename_tag}):
+        fail(f"{where}: filename tag mismatch")
+    if core["runtime"] != runtime_for_tag(filename_tag, where):
+        fail(f"{where}.runtime: runtime mapping mismatch")
+    Version(version)
+    validate_runtime(core["runtime"], f"{where}.runtime")
+    return core
+
+
+def validate_producer_environment(value: object) -> dict[str, object]:
+    ensure_exact_keys(value, {"runner", "toolchain"}, "producer")
+    validate_runner(value["runner"], "producer.runner")
+    validate_toolchain(value["toolchain"], "producer.toolchain")
+    return value
+
+
+def validate_verifier_environment(runtime: dict[str, object], value: object) -> dict[str, object]:
+    ensure_exact_keys(
+        value,
+        {"runner", "python_executable", "python_version", "free_threaded", "delvewheel_version"},
+        "verifier",
+    )
+    validate_runner(value["runner"], "verifier.runner")
+    python_executable = pathlib.Path(require_text(value["python_executable"], "verifier.python_executable"))
+    if not python_executable.is_absolute() or python_executable.suffix.lower() != ".exe":
+        fail("verifier.python_executable: absolute *.exe path required")
+    python_version = require_text(value["python_version"], "verifier.python_version")
+    if python_version != runtime["numeric_version"]:
+        fail("verifier.python_version: runtime mismatch")
+    free_threaded = require_bool(value["free_threaded"], "verifier.free_threaded")
+    if free_threaded != runtime["free_threaded"]:
+        fail("verifier.free_threaded: runtime mismatch")
+    require_text(value["delvewheel_version"], "verifier.delvewheel_version")
+    return value
+
+
+def normalize_relative_report_path(value: object, where: str = "repair_report") -> str:
+    text = require_text(value, where)
+    if text.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:", text):
+        fail(f"{where}: relative path required")
+    pure = pathlib.PurePosixPath(text.replace("\\", "/"))
+    parts = []
+    for part in pure.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            fail(f"{where}: parent traversal forbidden")
+        if ":" in part:
+            fail(f"{where}: relative path required")
+        parts.append(part)
+    if not parts:
+        fail(f"{where}: relative path required")
+    return pathlib.PurePosixPath(*parts).as_posix()
+
+
+def require_artifact_label_coverage(
+    artifacts: list[dict[str, object]],
+    expected_labels: set[str],
+    where: str,
+) -> set[str]:
+    labels = {artifact["runtime"]["label"] for artifact in artifacts}
+    if labels != expected_labels:
+        fail(f"{where}: exact ABI label coverage required")
+    return labels
+
+
+def validate_verified_artifact(value: object, where: str, runtime: dict[str, object] | None = None) -> dict[str, object]:
+    ensure_exact_keys(value, VERIFIED_ARTIFACT_KEYS, where)
+    artifact = value
+    validate_core({key: artifact[key] for key in CORE_KEYS}, where)
+    if runtime is not None and artifact["runtime"] != runtime:
+        fail(f"{where}.runtime: verifier/runtime mismatch")
+    if not isinstance(artifact["pe_machines"], dict) or not artifact["pe_machines"]:
+        fail(f"{where}.pe_machines: non-empty mapping required")
+    for member, machine in artifact["pe_machines"].items():
+        require_text(member, f"{where}.pe_machines.key")
+        if require_text(machine, f"{where}.pe_machines[{member}]") != "0xAA64":
+            fail(f"{where}.pe_machines[{member}]: ARM64 0xAA64 required")
+    if not isinstance(artifact["license_members"], dict):
+        fail(f"{where}.license_members: mapping required")
+    if set(artifact["license_members"]) != {"LICENSE_GEOS", "LICENSE_win32"}:
+        fail(f"{where}.license_members: exact keys required")
+    for key, path in artifact["license_members"].items():
+        require_text(key, f"{where}.license_members.key")
+        require_text(path, f"{where}.license_members.{key}")
+    artifact["repair_report"] = normalize_relative_report_path(
+        artifact["repair_report"],
+        f"{where}.repair_report",
+    )
+    require_hex64(artifact["repair_report_sha256"], f"{where}.repair_report_sha256")
+    ensure_exact_keys(artifact["checks"], CHECK_KEYS, f"{where}.checks")
+    for key, code in artifact["checks"].items():
+        if require_int(code, f"{where}.checks.{key}") != 0:
+            fail(f"{where}.checks.{key}: expected zero exit")
+    return artifact
+
+
+def validate_producer(value: object) -> dict[str, object]:
+    ensure_exact_keys(value, PRODUCER_KEYS, "producer")
+    producer = value
+    if require_int(producer["schema_version"], "producer.schema_version") != 1:
+        fail("producer.schema_version: version 1 required")
+    if producer["record_type"] != "producer":
+        fail("producer.record_type: producer required")
+    validate_utc(producer["created_at_utc"], "producer.created_at_utc")
+    validate_job(producer["job"], "producer.job")
+    validate_source_artifact(producer["source_artifact"])
+    validate_producer_environment(producer["producer"])
+    validate_geos(producer["geos"])
+    artifacts = producer["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("producer.artifacts: non-empty list required")
+    seen = set()
+    for index, artifact in enumerate(artifacts):
+        validate_core(artifact, f"producer.artifacts[{index}]")
+        key = (artifact["filename"], artifact["sha256"])
+        if key in seen:
+            fail("producer.artifacts: duplicate wheel forbidden")
+        seen.add(key)
+    return producer
+
+
+def validate_verifier(value: object) -> dict[str, object]:
+    ensure_exact_keys(value, VERIFIER_KEYS, "verifier")
+    verifier = value
+    if require_int(verifier["schema_version"], "verifier.schema_version") != 1:
+        fail("verifier.schema_version: version 1 required")
+    if verifier["record_type"] != "verifier":
+        fail("verifier.record_type: verifier required")
+    validate_utc(verifier["created_at_utc"], "verifier.created_at_utc")
+    require_hex64(verifier["producer_sha256"], "verifier.producer_sha256")
+    validate_job(verifier["job"], "verifier.job")
+    runtime = validate_runtime(verifier["runtime"], "verifier.runtime")
+    validate_verifier_environment(runtime, verifier["verifier"])
+    artifacts = verifier["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("verifier.artifacts: non-empty list required")
+    seen = set()
+    for index, artifact in enumerate(artifacts):
+        validate_verified_artifact(artifact, f"verifier.artifacts[{index}]", runtime)
+        key = (artifact["filename"], artifact["sha256"])
+        if key in seen:
+            fail("verifier.artifacts: duplicate wheel forbidden")
+        seen.add(key)
+    require_artifact_label_coverage(artifacts, {runtime["label"]}, "verifier.artifacts")
+    return verifier
+
+
+def producer_metadata(value: dict[str, object]) -> dict[str, object]:
+    return {
+        "created_at_utc": value["created_at_utc"],
+        "job": value["job"],
+        "runner": value["producer"]["runner"],
+        "toolchain": value["producer"]["toolchain"],
+    }
+
+
+def validate_producer_metadata(value: object, where: str = "final.producer") -> dict[str, object]:
+    ensure_exact_keys(value, PRODUCER_METADATA_KEYS, where)
+    validate_utc(value["created_at_utc"], f"{where}.created_at_utc")
+    validate_job(value["job"], f"{where}.job")
+    validate_runner(value["runner"], f"{where}.runner")
+    validate_toolchain(value["toolchain"], f"{where}.toolchain")
+    return value
+
+
+def same_job_identity(first: dict[str, str], second: dict[str, str], where: str) -> None:
+    for key in ("repository", "run_id", "run_url", "commit_sha", "ref"):
+        if first[key] != second[key]:
+            fail(f"{where}: mismatched job identity for {key}")
+
+
+def validate_final(value: object) -> dict[str, object]:
+    ensure_exact_keys(value, FINAL_KEYS, "final")
+    final = value
+    if require_int(final["schema_version"], "final.schema_version") != 1:
+        fail("final.schema_version: version 1 required")
+    if final["record_type"] != "final":
+        fail("final.record_type: final required")
+    validate_utc(final["created_at_utc"], "final.created_at_utc")
+    finalizer_job = validate_job(final["finalizer_job"], "final.finalizer_job")
+    require_hex64(final["producer_sha256"], "final.producer_sha256")
+    validate_source_artifact(final["source_artifact"])
+    producer = validate_producer_metadata(final["producer"])
+    validate_geos(final["geos"])
+    same_job_identity(finalizer_job, producer["job"], "final.finalizer_job")
+
+    artifacts = final["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("final.artifacts: non-empty list required")
+    seen = set()
+    for index, artifact in enumerate(artifacts):
+        validate_verified_artifact(artifact, f"final.artifacts[{index}]")
+        key = (artifact["filename"], artifact["sha256"])
+        if key in seen:
+            fail("final.artifacts: duplicate wheel forbidden")
+        seen.add(key)
+    require_artifact_label_coverage(artifacts, EXPECTED_LABELS, "final.artifacts")
+
+    synthetic_producer = {
+        "schema_version": 1,
+        "record_type": "producer",
+        "created_at_utc": producer["created_at_utc"],
+        "job": producer["job"],
+        "source_artifact": final["source_artifact"],
+        "producer": {
+            "runner": producer["runner"],
+            "toolchain": producer["toolchain"],
+        },
+        "geos": final["geos"],
+        "artifacts": [{key: item[key] for key in CORE_KEYS} for item in artifacts],
+    }
+    validate_producer(synthetic_producer)
+
+    verifiers = final["verifiers"]
+    if not isinstance(verifiers, list) or len(verifiers) != len(EXPECTED_LABELS):
+        fail("final.verifiers: seven verifier rows required")
+    labels = set()
+    for index, verifier in enumerate(verifiers):
+        ensure_exact_keys(verifier, {"label", "sha256", "created_at_utc", "job"}, f"final.verifiers[{index}]")
+        label = require_text(verifier["label"], f"final.verifiers[{index}].label")
+        if label not in EXPECTED_LABELS or label in labels:
+            fail("final.verifiers: unique known labels required")
+        labels.add(label)
+        require_hex64(verifier["sha256"], f"final.verifiers[{index}].sha256")
+        validate_utc(verifier["created_at_utc"], f"final.verifiers[{index}].created_at_utc")
+        same_job_identity(
+            validate_job(verifier["job"], f"final.verifiers[{index}].job"),
+            producer["job"],
+            f"final.verifiers[{index}].job",
+        )
+    if labels != EXPECTED_LABELS:
+        fail("final.verifiers: incomplete label set")
+    return final
+
+
+def wheel_core(path: os.PathLike[str] | str) -> dict[str, object]:
+    wheel_path = pathlib.Path(path)
+    distribution, parsed_version, _, filename_tags = parse_wheel_filename(wheel_path.name)
+    if distribution != NAME or len(filename_tags) != 1:
+        fail(f"{wheel_path}: ambiguous or non-Shapely filename tag")
+    filename_tag = next(iter(filename_tags))
+    runtime = runtime_for_tag(filename_tag, str(wheel_path))
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        members = wheel.namelist()
+        wheel_members = [member for member in members if member.endswith(".dist-info/WHEEL")]
+        if len(wheel_members) != 1:
+            fail(f"{wheel_path}: exactly one WHEEL file required")
+        raw_tags = [
+            line[5:]
+            for line in wheel.read(wheel_members[0]).decode("utf-8").splitlines()
+            if line.startswith("Tag: ")
+        ]
+        if len(raw_tags) != 1:
+            fail(f"{wheel_path}: exactly one WHEEL Tag entry required")
+        try:
+            parsed = parse_tag(raw_tags[0])
+        except ValueError as error:
+            fail(f"{wheel_path}: malformed WHEEL tag: {error}")
+        if len(parsed) != 1:
+            fail(f"{wheel_path}: compressed/ambiguous WHEEL tag forbidden")
+        wheel_tag = next(iter(parsed))
+        if filename_tag != wheel_tag:
+            fail(f"{wheel_path}: filename/WHEEL tag-set mismatch")
+        if wheel_tag.platform != "win_arm64":
+            fail(f"{wheel_path}: non-ARM64 WHEEL tag")
+
+    core = {
+        "filename": wheel_path.name,
+        "distribution": distribution,
+        "version": str(parsed_version),
+        "sha256": sha256(wheel_path),
+        "size_bytes": wheel_path.stat().st_size,
+        "filename_tags": [str(filename_tag)],
+        "wheel_tags": [str(wheel_tag)],
+        "runtime": runtime,
+    }
+    validate_core(core, str(wheel_path))
+    return core
+
+
+def pe_machines(path: os.PathLike[str] | str) -> dict[str, str]:
+    wheel_path = pathlib.Path(path)
+    found: dict[str, str] = {}
+    with zipfile.ZipFile(wheel_path) as wheel:
+        native_members = [
+            member
+            for member in wheel.namelist()
+            if member.lower().endswith((".pyd", ".dll"))
+        ]
+        if not native_members:
+            fail(f"{wheel_path}: no native members found")
+        for member in native_members:
+            data = wheel.read(member)
+            if len(data) < 0x40 or data[:2] != b"MZ":
+                fail(f"{member}: invalid DOS header")
+            offset = struct.unpack_from("<I", data, 0x3C)[0]
+            if offset + 6 > len(data) or data[offset : offset + 4] != b"PE\0\0":
+                fail(f"{member}: invalid PE header")
+            machine = struct.unpack_from("<H", data, offset + 4)[0]
+            if machine != 0xAA64:
+                fail(f"{member}: PE machine 0x{machine:04X}, expected 0xAA64")
+            found[member] = "0xAA64"
+    return dict(sorted(found.items()))
+
+
+def wheel_licenses(path: os.PathLike[str] | str, source_root: os.PathLike[str] | str) -> dict[str, str]:
+    root = pathlib.Path(source_root)
+    expected = {
+        name: (root / "ci" / "wheelbuilder" / name).read_bytes()
+        for name in ("LICENSE_GEOS", "LICENSE_win32")
+    }
+    result: dict[str, str] = {}
+    with zipfile.ZipFile(path) as wheel:
+        names = wheel.namelist()
+        for name, content in expected.items():
+            matches = [
+                member
+                for member in names
+                if pathlib.PurePosixPath(member).name == name
+            ]
+            if len(matches) != 1:
+                fail(f"{path}: {name} missing or duplicated")
+            if wheel.read(matches[0]) != content:
+                fail(f"{path}: {name} contents differ from source")
+            result[name] = matches[0]
+    return result
+
+
+def repaired_wheel_members(path: os.PathLike[str] | str) -> tuple[bool, bool, bool]:
+    with zipfile.ZipFile(path) as wheel:
+        names = wheel.namelist()
+    has_delvewheel_marker = any(name.endswith(".dist-info/DELVEWHEEL") for name in names)
+    has_shapely_libs = any(name.startswith("shapely.libs/") for name in names)
+    has_geos_dll = any(
+        name.startswith("shapely.libs/")
+        and name.lower().endswith(".dll")
+        and "geos" in pathlib.PurePosixPath(name).name.lower()
+        for name in names
+    )
+    return has_delvewheel_marker, has_shapely_libs, has_geos_dll
+
+
+def repair_report_is_acceptable(report_text: str, wheel_path: os.PathLike[str] | str) -> bool:
+    lower = report_text.lower()
+    if "shapely.libs" in lower and "libgeos" in lower:
+        return True
+    if "already repaired this wheel" not in lower:
+        return False
+    return all(repaired_wheel_members(wheel_path))
+
+
+def require_arm64(python_exe: str, expected: dict[str, object]) -> None:
+    probe = subprocess.check_output(
+        [
+            python_exe,
+            "-c",
+            (
+                "import json, platform, sys, sysconfig; "
+                "print(json.dumps({"
+                "'machine': platform.machine().lower(), "
+                "'version': f'{sys.version_info[0]}.{sys.version_info[1]}', "
+                "'gil': bool(sysconfig.get_config_var(\"Py_GIL_DISABLED\"))"
+                "}))"
+            ),
+        ],
+        text=True,
+    )
+    state = json.loads(probe)
+    if state["machine"] not in {"arm64", "aarch64"}:
+        fail(f"wrong verifier runtime: {state}")
+    if state["version"] != expected["numeric_version"]:
+        fail(f"wrong verifier runtime: {state}")
+    if state["gil"] is not expected["free_threaded"]:
+        fail(f"wrong verifier runtime: {state}")
+
+
+def verify_one(
+    core: dict[str, object],
+    wheel_path: os.PathLike[str] | str,
+    source_root: os.PathLike[str] | str,
+    python_exe: str,
+    artifact_root: os.PathLike[str] | str,
+    report_dir: os.PathLike[str] | str,
+) -> dict[str, object]:
+    wheel_file = pathlib.Path(wheel_path)
+    if sha256(wheel_file) != core["sha256"]:
+        fail(f"{wheel_file}: wheel changed after producer")
+    if wheel_file.stat().st_size != core["size_bytes"]:
+        fail(f"{wheel_file}: wheel size changed after producer")
+    if wheel_core(wheel_file) != core:
+        fail(f"{wheel_file}: wheel metadata changed after producer")
+
+    root = pathlib.Path(artifact_root).resolve()
+    report_root = pathlib.Path(report_dir)
+    if not report_root.is_absolute():
+        report_root = root / report_root
+    report_root = report_root.resolve()
+    try:
+        relative_report_root = report_root.relative_to(root)
+    except ValueError as error:
+        fail(f"report_dir: escapes verifier artifact root ({error})")
+    report_path = report_root / f"{core['filename']}.delvewheel.txt"
+    report_member = normalize_relative_report_path(
+        (
+            pathlib.PurePosixPath(relative_report_root.as_posix())
+            / f"{core['filename']}.delvewheel.txt"
+        ).as_posix(),
+        "repair_report",
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [sys.executable, "-m", "delvewheel", "show", str(wheel_file)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    report_text = result.stdout or ""
+    report_path.write_text(report_text, encoding="utf-8", newline="\n")
+    if result.returncode != 0 or not repair_report_is_acceptable(report_text, wheel_file):
+        fail(f"{wheel_file}: per-wheel delvewheel evidence failed")
+
+    runner_temp = pathlib.Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir()))
+    with tempfile.TemporaryDirectory(dir=runner_temp) as temp_dir:
+        temp_root = pathlib.Path(temp_dir)
+        venv = temp_root / "venv"
+        clean_cwd = temp_root / "external-cwd"
+        subprocess.run([python_exe, "-m", "venv", str(venv)], check=True)
+        clean_cwd.mkdir()
+        venv_python = venv / "Scripts" / "python.exe"
+        subprocess.run(
+            [venv_python, "-m", "pip", "install", "--disable-pip-version-check", "pytest"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                venv_python,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--force-reinstall",
+                str(wheel_file),
+            ],
+            check=True,
+        )
+        subprocess.run([venv_python, "-m", "pip", "check"], check=True)
+        subprocess.run(
+            [
+                venv_python,
+                "-I",
+                "-c",
+                "from shapely import Point; assert Point(0, 0).buffer(1).area > 3",
+            ],
+            check=True,
+            cwd=clean_cwd,
+        )
+        subprocess.run(
+            [venv_python, "-I", "-m", "pytest", "--pyargs", "shapely.tests"],
+            check=True,
+            cwd=clean_cwd,
+        )
+
+    verified = {
+        **core,
+        "pe_machines": pe_machines(wheel_file),
+        "license_members": wheel_licenses(wheel_file, source_root),
+        "repair_report": report_member,
+        "repair_report_sha256": sha256(report_path),
+        "checks": {
+            "wheel_tag": 0,
+            "pe_architecture": 0,
+            "license_contents": 0,
+            "delvewheel_repair": 0,
+            "clean_external_cwd_tests": 0,
+        },
+    }
+    validate_verified_artifact(verified, wheel_file.name, core["runtime"])
+    return verified
+
+
+def producer_command(args: argparse.Namespace) -> None:
+    wheels = sorted(pathlib.Path(args.wheelhouse).glob("*.whl"))
+    if not wheels:
+        fail("producer wheelhouse is empty")
+    if platform.machine().lower() not in {"arm64", "aarch64"}:
+        fail("producer is not native ARM64")
+
+    repository = environment("GITHUB_REPOSITORY")
+    run_id = environment("GITHUB_RUN_ID")
+    job = {
+        "repository": repository,
+        "run_id": run_id,
+        "job_key": environment("GITHUB_JOB"),
+        "run_url": f"{environment('GITHUB_SERVER_URL')}/{repository}/actions/runs/{run_id}",
+        "commit_sha": environment("GITHUB_SHA").lower(),
+        "ref": environment("GITHUB_REF"),
+    }
+    geos_version = environment("GEOS_VERSION")
+    doc = {
+        "schema_version": 1,
+        "record_type": "producer",
+        "created_at_utc": now_utc(),
+        "job": job,
+        "source_artifact": SOURCE_ARTIFACT,
+        "producer": {
+            "runner": {
+                "os": "Windows",
+                "architecture": "ARM64",
+                "image_os": environment("ImageOS"),
+                "image_version": environment("ImageVersion"),
+            },
+            "toolchain": {
+                "cibuildwheel_action": "pypa/cibuildwheel@v4.2.0",
+                "msvc_toolset": "14.44",
+                "cmake": command_version("cmake", "--version"),
+                "ninja": command_version("ninja", "--version"),
+            },
+        },
+        "geos": {
+            "version": geos_version,
+            "archive_url": f"https://download.osgeo.org/geos/geos-{geos_version}.tar.bz2",
+            "sha256": environment("GEOS_SHA256").lower(),
+            "checksum_provenance_url": environment("GEOS_CHECKSUM_PROVENANCE_URL"),
+        },
+        "artifacts": [wheel_core(path) for path in wheels],
+    }
+    validate_producer(doc)
+    canonical_write(args.output, doc)
+
+
+def verify_command(args: argparse.Namespace) -> None:
+    producer = validate_producer(document(args.producer))
+    runtime = runtime_for_label(args.label)
+    require_arm64(args.python_exe, runtime)
+    wheelhouse = pathlib.Path(args.wheelhouse)
+    by_name = {path.name: path for path in wheelhouse.glob("*.whl")}
+    selected = [core for core in producer["artifacts"] if core["runtime"]["label"] == args.label]
+    if not selected:
+        fail("no retained wheel matches verifier label")
+    if any(core["filename"] not in by_name for core in selected):
+        fail("producer wheel missing from retained artifact")
+    artifact_root = pathlib.Path(args.output).resolve().parent
+    verified = [
+        verify_one(
+            core,
+            by_name[core["filename"]],
+            args.source_root,
+            args.python_exe,
+            artifact_root,
+            args.report_dir,
+        )
+        for core in selected
+    ]
+    repository = environment("GITHUB_REPOSITORY")
+    run_id = environment("GITHUB_RUN_ID")
+    doc = {
+        "schema_version": 1,
+        "record_type": "verifier",
+        "created_at_utc": now_utc(),
+        "producer_sha256": sha256(args.producer),
+        "job": {
+            "repository": repository,
+            "run_id": run_id,
+            "job_key": environment("GITHUB_JOB"),
+            "run_url": f"{environment('GITHUB_SERVER_URL')}/{repository}/actions/runs/{run_id}",
+            "commit_sha": environment("GITHUB_SHA").lower(),
+            "ref": environment("GITHUB_REF"),
+        },
+        "runtime": runtime,
+        "verifier": {
+            "runner": {
+                "os": "Windows",
+                "architecture": "ARM64",
+                "image_os": environment("ImageOS"),
+                "image_version": environment("ImageVersion"),
+            },
+            "python_executable": str(pathlib.Path(args.python_exe).resolve()),
+            "python_version": runtime["numeric_version"],
+            "free_threaded": runtime["free_threaded"],
+            "delvewheel_version": package_version("delvewheel"),
+        },
+        "artifacts": verified,
+    }
+    validate_verifier(doc)
+    canonical_write(args.output, doc)
+
+
+def resolve_report_path(base_dir: pathlib.Path, value: str) -> pathlib.Path:
+    normalized = normalize_relative_report_path(value, "repair_report")
+    root = base_dir.resolve()
+    candidate = (root / pathlib.Path(*normalized.split("/"))).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as error:
+        fail(f"repair_report: escapes verifier artifact root ({error})")
+    return candidate
+
+
+def finalize_command(args: argparse.Namespace) -> None:
+    producer_path = pathlib.Path(args.producer)
+    producer = validate_producer(document(producer_path))
+    producer_hash = sha256(producer_path)
+    require_artifact_label_coverage(producer["artifacts"], EXPECTED_LABELS, "producer.artifacts")
+    verifier_dir = pathlib.Path(args.verifier_dir)
+    verifier_paths = sorted(verifier_dir.glob("arm64-wheel-verifier-*.json"))
+    if len(verifier_paths) != len(EXPECTED_LABELS):
+        fail("missing or duplicate verifier record")
+
+    records: list[tuple[pathlib.Path, dict[str, object]]] = []
+    for path in verifier_paths:
+        verifier = validate_verifier(document(path))
+        if verifier["producer_sha256"] != producer_hash:
+            fail("verifier is for a different producer")
+        same_job_identity(verifier["job"], producer["job"], path.name)
+        records.append((path, verifier))
+
+    labels = {verifier["runtime"]["label"] for _, verifier in records}
+    if labels != EXPECTED_LABELS:
+        fail("missing or duplicate verifier label")
+
+    merged = [artifact for _, verifier in records for artifact in verifier["artifacts"]]
+    producer_set = {(artifact["filename"], artifact["sha256"]) for artifact in producer["artifacts"]}
+    merged_set = {(artifact["filename"], artifact["sha256"]) for artifact in merged}
+    if not producer_set or merged_set != producer_set or len(merged) != len(producer["artifacts"]):
+        fail("verifier/producer wheel set mismatch")
+    require_artifact_label_coverage(merged, EXPECTED_LABELS, "final.artifacts")
+
+    verifier_entries = []
+    for path, verifier in records:
+        verifier_entries.append(
+            {
+                "label": verifier["runtime"]["label"],
+                "sha256": sha256(path),
+                "created_at_utc": verifier["created_at_utc"],
+                "job": verifier["job"],
+            }
+        )
+        for artifact in verifier["artifacts"]:
+            report_path = resolve_report_path(verifier_dir, artifact["repair_report"])
+            if not report_path.exists():
+                fail("missing per-wheel repair report")
+            if sha256(report_path) != artifact["repair_report_sha256"]:
+                fail("altered per-wheel repair report")
+
+    repository = environment("GITHUB_REPOSITORY")
+    run_id = environment("GITHUB_RUN_ID")
+    finalizer_job = {
+        "repository": repository,
+        "run_id": run_id,
+        "job_key": environment("GITHUB_JOB"),
+        "run_url": f"{environment('GITHUB_SERVER_URL')}/{repository}/actions/runs/{run_id}",
+        "commit_sha": environment("GITHUB_SHA").lower(),
+        "ref": environment("GITHUB_REF"),
+    }
+    same_job_identity(finalizer_job, producer["job"], "finalizer")
+    doc = {
+        "schema_version": 1,
+        "record_type": "final",
+        "created_at_utc": now_utc(),
+        "finalizer_job": finalizer_job,
+        "producer_sha256": producer_hash,
+        "source_artifact": producer["source_artifact"],
+        "producer": producer_metadata(producer),
+        "geos": producer["geos"],
+        "verifiers": sorted(verifier_entries, key=lambda item: item["label"]),
+        "artifacts": sorted(merged, key=lambda item: item["filename"]),
+    }
+    validate_final(doc)
+    canonical_write(args.output, doc)
+
+
+def parse_distribution_filename(
+    filename: str,
+) -> tuple[str, Version, frozenset[Tag] | None]:
+    try:
+        if filename.endswith(".whl"):
+            distribution, version, _, tags = parse_wheel_filename(filename)
+            if not tags:
+                fail(f"{filename}: wheel filename has no tags")
+            return distribution, version, tags
+        distribution, version = parse_sdist_filename(filename)
+        return distribution, version, None
+    except (TypeError, ValueError) as error:
+        fail(f"{filename}: invalid distribution filename: {error}")
+
+
+def validate_release_identity(
+    release: object,
+    expected_distribution: str,
+    wanted: Version,
+) -> tuple[dict[str, object], list[object]]:
+    if not isinstance(release, dict):
+        fail("invalid PyPI release response")
+    info = release.get("info")
+    urls = release.get("urls")
+    if not isinstance(info, dict) or not isinstance(urls, list):
+        fail("invalid PyPI release response")
+    try:
+        release_name = canonicalize_name(info["name"])
+        release_version = Version(info["version"])
+    except (KeyError, TypeError, ValueError) as error:
+        fail(f"invalid PyPI release response: {error}")
+    if release_name != expected_distribution or release_version != wanted:
+        fail("wrong PyPI distribution/version")
+    return info, urls
+
+
+def pypi_release_files(
+    release: object,
+    expected_distribution: str,
+    wanted: Version,
+) -> dict[str, tuple[str, frozenset[Tag] | None]]:
+    _, urls = validate_release_identity(release, expected_distribution, wanted)
+    published: dict[str, tuple[str, frozenset[Tag] | None]] = {}
+    for item in urls:
+        if not isinstance(item, dict):
+            fail("invalid PyPI release response")
+        filename = item.get("filename")
+        if not isinstance(filename, str) or not filename:
+            fail("invalid PyPI release response")
+        if filename in published:
+            fail(f"duplicate PyPI filename: {filename}")
+        distribution, version, tags = parse_distribution_filename(filename)
+        if distribution != expected_distribution or version != wanted:
+            fail(f"wrong-version PyPI distribution: {filename}")
+        digests = item.get("digests")
+        if not isinstance(digests, dict):
+            fail("invalid PyPI release response")
+        digest = digests.get("sha256")
+        if not isinstance(digest, str) or not HEX.fullmatch(digest.lower()):
+            fail(f"invalid PyPI SHA-256: {filename}")
+        published[filename] = (digest.lower(), tags)
+    return published
+
+
+def load_pypi_release(
+    expected_distribution: str,
+    wanted: Version,
+    *,
+    allow_not_found: bool,
+) -> object | None:
+    url = f"https://pypi.org/pypi/{expected_distribution}/{wanted}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if allow_not_found and error.code == 404:
+            return None
+        raise
+
+
+def clean_staging_directory(
+    wheelhouse_path: os.PathLike[str] | str,
+    staging_path: os.PathLike[str] | str,
+) -> tuple[pathlib.Path, pathlib.Path]:
+    wheelhouse = pathlib.Path(wheelhouse_path).resolve(strict=True)
+    requested_staging = pathlib.Path(staging_path)
+    if not wheelhouse.is_dir():
+        fail(f"{wheelhouse}: wheelhouse directory required")
+    if requested_staging.is_symlink():
+        fail(f"{requested_staging}: staging directory symlink forbidden")
+    staging = requested_staging.resolve()
+    try:
+        staging.relative_to(wheelhouse)
+    except ValueError:
+        pass
+    else:
+        fail("staging directory must not overlap wheelhouse")
+    try:
+        wheelhouse.relative_to(staging)
+    except ValueError:
+        pass
+    else:
+        fail("staging directory must not overlap wheelhouse")
+    if staging.exists():
+        if not staging.is_dir():
+            fail(f"{staging}: staging path must be a directory")
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    return wheelhouse, staging
+
+
+def local_distribution_files(
+    wheelhouse: pathlib.Path,
+    expected_distribution: str,
+    wanted: Version,
+) -> dict[str, tuple[pathlib.Path, str]]:
+    local: dict[str, tuple[pathlib.Path, str]] = {}
+    for path in sorted(wheelhouse.iterdir()):
+        if path.is_symlink() or not path.is_file():
+            fail(f"{path}: wheelhouse must contain only regular distribution files")
+        resolved = path.resolve(strict=True)
+        try:
+            resolved.relative_to(wheelhouse)
+        except ValueError:
+            fail(f"{path}: distribution escapes wheelhouse")
+        distribution, version, _ = parse_distribution_filename(path.name)
+        if distribution != expected_distribution or version != wanted:
+            fail(f"{path.name}: wrong local distribution/version")
+        if path.name in local:
+            fail(f"duplicate local distribution filename: {path.name}")
+        local[path.name] = (resolved, sha256(resolved))
+    if not local:
+        fail("wheelhouse contains no distributions")
+    return local
+
+
+def write_github_outputs(path: str | None, staged_count: int) -> None:
+    if path is None:
+        return
+    with open(path, "a", encoding="utf-8", newline="\n") as output:
+        output.write(f"has_files={'true' if staged_count else 'false'}\n")
+        output.write(f"staged_count={staged_count}\n")
+
+
+def finalized_arm64_files_from_document(
+    final: dict[str, object],
+    wanted: Version,
+) -> dict[str, str]:
+    expected: dict[str, str] = {}
+    for index, artifact in enumerate(final["artifacts"]):
+        validate_verified_artifact(artifact, f"final.artifacts[{index}]")
+        filename = artifact["filename"]
+        distribution, version, tags = parse_distribution_filename(filename)
+        if (
+            distribution != NAME
+            or version != wanted
+            or tags is None
+            or not any(tag.platform == "win_arm64" for tag in tags)
+        ):
+            fail(f"wrong-version/non-ARM64 provenance wheel: {filename}")
+        if filename in expected:
+            fail(f"duplicate provenance filename: {filename}")
+        expected[filename] = artifact["sha256"]
+    if not expected:
+        fail("empty final artifact set")
+    return expected
+
+
+def finalized_arm64_files(
+    manifest_path: os.PathLike[str] | str,
+    wanted: Version,
+) -> dict[str, str]:
+    return finalized_arm64_files_from_document(
+        validate_final(document(manifest_path)),
+        wanted,
+    )
+
+
+def arm64_file_map(
+    files: dict[str, tuple[pathlib.Path, str]],
+) -> dict[str, str]:
+    arm64: dict[str, str] = {}
+    for filename, (_, digest) in files.items():
+        _, _, tags = parse_distribution_filename(filename)
+        if tags is not None and any(tag.platform == "win_arm64" for tag in tags):
+            arm64[filename] = digest
+    return arm64
+
+
+def require_exact_arm64_map(
+    actual: dict[str, str],
+    expected: dict[str, str],
+    source: str,
+) -> None:
+    if actual == expected:
+        return
+    missing = sorted(expected.keys() - actual.keys())
+    extra = sorted(actual.keys() - expected.keys())
+    mismatched = sorted(
+        filename
+        for filename in expected.keys() & actual.keys()
+        if expected[filename] != actual[filename]
+    )
+    fail(
+        f"{source} ARM64 wheel map mismatch "
+        f"(missing={missing}, extra={extra}, mismatched={mismatched})"
+    )
+
+
+def stage_pypi_command(args: argparse.Namespace) -> None:
+    expected_distribution = canonicalize_name(args.distribution)
+    if expected_distribution != NAME:
+        fail("PyPI distribution must be shapely")
+    wanted = Version(args.version)
+    if args.attempts < 1:
+        fail("PyPI metadata attempts must be positive")
+    if args.retry_delay_seconds < 0:
+        fail("PyPI metadata retry delay must be non-negative")
+
+    wheelhouse, staging = clean_staging_directory(args.wheelhouse, args.staging_dir)
+    local = local_distribution_files(wheelhouse, expected_distribution, wanted)
+    expected_arm64 = finalized_arm64_files(args.manifest, wanted)
+    require_exact_arm64_map(
+        arm64_file_map(local),
+        expected_arm64,
+        "local/finalized provenance",
+    )
+
+    for attempt in range(1, args.attempts + 1):
+        try:
+            release = load_pypi_release(
+                expected_distribution,
+                wanted,
+                allow_not_found=True,
+            )
+        except (OSError, ValueError) as error:
+            if attempt == args.attempts:
+                fail(f"PyPI metadata failed after {args.attempts} attempts: {error}")
+            print(
+                "wheel-evidence: "
+                f"PyPI metadata attempt {attempt}/{args.attempts} failed: {error}; "
+                f"retrying in {args.retry_delay_seconds:g} seconds",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(args.retry_delay_seconds)
+        else:
+            break
+
+    published = (
+        {}
+        if release is None
+        else pypi_release_files(release, expected_distribution, wanted)
+    )
+    published_arm64 = {
+        filename: digest
+        for filename, (digest, tags) in published.items()
+        if tags is not None and any(tag.platform == "win_arm64" for tag in tags)
+    }
+    unexpected = sorted(published_arm64.keys() - expected_arm64.keys())
+    mismatched = sorted(
+        filename
+        for filename in published_arm64.keys() & expected_arm64.keys()
+        if published_arm64[filename] != expected_arm64[filename]
+    )
+    if unexpected or mismatched:
+        fail(
+            "published PyPI ARM64 wheels are not a digest-matching finalized "
+            f"provenance subset (extra={unexpected}, mismatched={mismatched})"
+        )
+
+    missing: list[tuple[pathlib.Path, pathlib.Path]] = []
+    verified = 0
+    for filename, (source, digest) in local.items():
+        existing = published.get(filename)
+        if existing is None:
+            destination = staging / filename
+            if destination.parent != staging:
+                fail(f"{filename}: staging path escapes staging directory")
+            missing.append((source, destination))
+        elif existing[0] != digest:
+            fail(f"immutable PyPI file has different SHA-256: {filename}")
+        else:
+            verified += 1
+
+    try:
+        for source, destination in missing:
+            shutil.copy2(source, destination)
+            if sha256(destination) != local[source.name][1]:
+                fail(f"staged distribution digest mismatch: {source.name}")
+        write_github_outputs(args.github_output, len(missing))
+    except BaseException:
+        shutil.rmtree(staging)
+        staging.mkdir()
+        raise
+    print(
+        "wheel-evidence: "
+        f"verified {verified} existing and staged {len(missing)} missing "
+        f"distributions for {args.distribution} {wanted}"
+    )
+
+
+def pypi_check(
+    manifest_path: str,
+    expected_distribution: str,
+    expected_version: str,
+    attempts: int = 1,
+    retry_delay_seconds: float = 0,
+) -> None:
+    if canonicalize_name(expected_distribution) != NAME:
+        fail("PyPI distribution must be shapely")
+    if attempts < 1:
+        fail("PyPI verification attempts must be positive")
+    if retry_delay_seconds < 0:
+        fail("PyPI verification retry delay must be non-negative")
+    final = validate_final(document(manifest_path))
+    wanted = Version(expected_version)
+    if not final["artifacts"]:
+        fail("empty final artifact set")
+    for index, artifact in enumerate(final["artifacts"]):
+        validate_verified_artifact(artifact, f"PyPI.artifacts[{index}]")
+        if Version(artifact["version"]) != wanted:
+            fail("missing/mismatched PyPI ARM64 wheel")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            release = load_pypi_release(NAME, wanted, allow_not_found=False)
+            verify_pypi_release(final, release, wanted)
+        except (OSError, ValueError) as error:
+            if attempt == attempts:
+                fail(f"PyPI verification failed after {attempts} attempts: {error}")
+            print(
+                "wheel-evidence: "
+                f"PyPI verification attempt {attempt}/{attempts} failed: {error}; "
+                f"retrying in {retry_delay_seconds:g} seconds",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(retry_delay_seconds)
+        else:
+            print(
+                "wheel-evidence: "
+                f"verified {len(final['artifacts'])} PyPI ARM64 wheels for "
+                f"{expected_distribution} {wanted}"
+            )
+            return
+
+
+def verify_pypi_release(
+    final: dict[str, object],
+    release: object,
+    wanted: Version,
+) -> None:
+    expected = finalized_arm64_files_from_document(final, wanted)
+
+    published = pypi_release_files(release, NAME, wanted)
+    published_arm64 = {
+        filename: digest
+        for filename, (digest, tags) in published.items()
+        if tags is not None and any(tag.platform == "win_arm64" for tag in tags)
+    }
+    if published_arm64 != expected:
+        missing = sorted(expected.keys() - published_arm64.keys())
+        extra = sorted(published_arm64.keys() - expected.keys())
+        mismatched = sorted(
+            filename
+            for filename in expected.keys() & published_arm64.keys()
+            if expected[filename] != published_arm64[filename]
+        )
+        fail(
+            "PyPI ARM64 wheel map mismatch "
+            f"(missing={missing}, extra={extra}, mismatched={mismatched})"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    producer = commands.add_parser("producer")
+    producer.add_argument("--wheelhouse", required=True)
+    producer.add_argument("--output", required=True)
+
+    verify = commands.add_parser("verify")
+    for option in (
+        "--producer",
+        "--wheelhouse",
+        "--source-root",
+        "--label",
+        "--python-exe",
+        "--output",
+        "--report-dir",
+    ):
+        verify.add_argument(option, required=True)
+
+    finalize = commands.add_parser("finalize")
+    finalize.add_argument("--producer", required=True)
+    finalize.add_argument("--verifier-dir", required=True)
+    finalize.add_argument("--output", required=True)
+
+    validate = commands.add_parser("validate")
+    validate.add_argument("--kind", choices=("producer", "verifier", "final"), required=True)
+    validate.add_argument("--input", required=True)
+
+    pypi = commands.add_parser("pypi")
+    pypi.add_argument("--manifest", required=True)
+    pypi.add_argument("--distribution", required=True)
+    pypi.add_argument("--version", required=True)
+    pypi.add_argument("--attempts", type=int, default=12)
+    pypi.add_argument("--retry-delay-seconds", type=float, default=10)
+
+    stage_pypi = commands.add_parser("stage-pypi")
+    stage_pypi.add_argument("--wheelhouse", required=True)
+    stage_pypi.add_argument("--staging-dir", required=True)
+    stage_pypi.add_argument("--manifest", required=True)
+    stage_pypi.add_argument("--distribution", required=True)
+    stage_pypi.add_argument("--version", required=True)
+    stage_pypi.add_argument("--attempts", type=int, default=3)
+    stage_pypi.add_argument("--retry-delay-seconds", type=float, default=5)
+    stage_pypi.add_argument("--github-output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "producer":
+        producer_command(args)
+    elif args.command == "verify":
+        verify_command(args)
+    elif args.command == "finalize":
+        finalize_command(args)
+    elif args.command == "validate":
+        validator = {
+            "producer": validate_producer,
+            "verifier": validate_verifier,
+            "final": validate_final,
+        }[args.kind]
+        validator(document(args.input))
+    elif args.command == "pypi":
+        pypi_check(
+            args.manifest,
+            args.distribution,
+            args.version,
+            args.attempts,
+            args.retry_delay_seconds,
+        )
+    else:
+        stage_pypi_command(args)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.CalledProcessError, zipfile.BadZipFile) as error:
+        print(f"wheel-evidence: {error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary

- authenticate and SHA-256 verify GEOS before extraction or cache reuse
- acquire matching native Windows ARM64 CPython runtimes and verify repaired wheels across `cp311` through `cp315t`
- retain producer/verifier provenance and gate publication on finalized evidence
- make PyPI staging and GitHub Release publication fail-closed and safely rerunnable

## Why

Shapely already has a `windows-11-arm` build lane, but a green build alone does not prove wheel tags, native PE architecture, repaired GEOS dependencies, licenses, installed-wheel tests, or publication provenance. This change makes those checks explicit and prevents publication when native evidence is incomplete.

## Scope

This PR contains one squashed commit and only nine release/CI implementation and test files. Fork-only hackathon documentation and demo assets are intentionally excluded.

## Local validation

- `python -m py_compile ci/arm64_python_runtime.py ci/wheel_evidence.py ci/release_transaction.py`
- `python -m pytest ci/tests/test_arm64_python_runtime.py ci/tests/test_install_geos.py ci/tests/test_release_transaction.py ci/tests/test_wheel_evidence.py` — 62 passed
- workflow YAML and release-invariant checks passed
- live `cp315` and `cp315t` discovery resolved the current official `3.15.0rc1` ARM64 manifest

The local host was x64. This draft should remain unmerged until the PR workflow completes its non-publishing native `windows-11-arm` producer, all seven verifier jobs, and evidence finalization. `nightly_upload`, `publish`, Anaconda upload, PyPI upload, and GitHub Release mutation must remain skipped on the pull-request event.

## Ownership boundary

This is the pre-step repository change. Merge, tag creation, package publication, and any public ARM64 support claim remain maintainer-owned post-steps. An official support claim should follow a package-owned release that publishes verified `win_arm64` wheels.